### PR TITLE
Fix documentation warnings in mix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ spawn_link(fn ->
 end)
 ```
 
-See [liveview_streaming_example.ex](examples/liveview_streaming_example.ex) for real-time streaming or [LIVEVIEW_INTEGRATION.md](examples/LIVEVIEW_INTEGRATION.md) for patterns
+See [liveview_streaming_example.ex](examples/liveview_streaming_example.ex) for real-time streaming or [LiveView Integration Guide](docs/guides/liveview-integration.md) for patterns
 
 ## Logging & Telemetry
 
@@ -269,7 +269,7 @@ Events: `[:nous, :agent, :run, :*]`, `[:nous, :model, :request, :*]`, `[:nous, :
 
 ## Examples
 
-**🚀 [Get Started in 5 Minutes](examples/GETTING_STARTED.md)** - Quick setup guide with local or cloud options.
+**🚀 [Get Started in 5 Minutes](docs/getting-started.md)** - Quick setup guide with local or cloud options.
 
 **📚 [Full Examples Collection](examples/README.md)** - Comprehensive learning path from beginner to production.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,19 +107,19 @@ end)
 ## Next Steps
 
 ### Immediate Next Steps (15 minutes)
-1. **Try examples** → [quickstart examples](../examples/quickstart/)
-2. **Follow tutorials** → [structured learning](../examples/tutorials/)
-3. **Browse by feature** → [reference guides](../examples/reference/)
+1. **Try examples** → [quickstart examples](../examples/quickstart/README.md)
+2. **Follow tutorials** → [structured learning](../examples/tutorials/README.md)
+3. **Browse by feature** → [reference guides](../examples/reference/README.md)
 
 ### Learning Path
-- **Beginner** (15 min) → [01-basics](../examples/tutorials/01-basics/)
-- **Intermediate** (1 hour) → [02-patterns](../examples/tutorials/02-patterns/)
-- **Advanced** (deep dive) → [03-production](../examples/tutorials/03-production/)
-- **Complete projects** → [04-projects](../examples/tutorials/04-projects/)
+- **Beginner** (15 min) → [01-basics](../examples/tutorials/01-basics/README.md)
+- **Intermediate** (1 hour) → [02-patterns](../examples/tutorials/02-patterns/README.md)
+- **Advanced** (deep dive) → [03-production](../examples/tutorials/03-production/README.md)
+- **Complete projects** → [04-projects](../examples/tutorials/04-projects/README.md)
 
 ### Production Setup
-- **[Best Practices Guide](guides/best-practices.md)** - Production deployment
-- **[Tool Development Guide](guides/tool-development.md)** - Custom tools
+- **[Best Practices Guide](guides/best_practices.md)** - Production deployment
+- **[Tool Development Guide](guides/tool_development.md)** - Custom tools
 - **[Troubleshooting Guide](guides/troubleshooting.md)** - Common issues
 
 ## Provider Configuration
@@ -237,7 +237,7 @@ For more help, see the **[Troubleshooting Guide](guides/troubleshooting.md)**.
 
 ## What's Next?
 
-- **Hands-on learning** → [Examples](../examples/)
-- **Specific features** → [Reference guides](../examples/reference/)
-- **Production deployment** → [Best practices](guides/best-practices.md)
-- **Custom tools** → [Tool development](guides/tool-development.md)
+- **Hands-on learning** → [Examples](../examples/README.md)
+- **Specific features** → [Reference guides](../examples/reference/README.md)
+- **Production deployment** → [Best practices](guides/best_practices.md)
+- **Custom tools** → [Tool development](guides/tool_development.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,21 +3,21 @@
 Working examples demonstrating all features, from simple Q&A to production-ready multi-agent systems.
 
 ## 🚀 5-Minute Start
-→ **[quickstart/](quickstart/)** - Get running immediately
+→ **[quickstart](quickstart/README.md)** - Get running immediately
 
 Perfect if you're new to Nous or want to test your setup quickly.
 
 ## 📚 Learn Nous AI
-→ **[tutorials/](tutorials/)** - Structured learning path
+→ **[tutorials](tutorials/README.md)** - Structured learning path
 
 Follow the complete progression from beginner to expert:
-- **[01-basics/](tutorials/01-basics/)** (15 min) - Hello world, tools, providers
-- **[02-patterns/](tutorials/02-patterns/)** (1 hour) - Streaming, conversation, ReAct
-- **[03-production/](tutorials/03-production/)** (advanced) - GenServer, LiveView, distributed
-- **[04-projects/](tutorials/04-projects/)** (complete apps) - Council, Trading Desk, Code Editor
+- **[01-basics](tutorials/01-basics/README.md)** (15 min) - Hello world, tools, providers
+- **[02-patterns](tutorials/02-patterns/README.md)** (1 hour) - Streaming, conversation, ReAct
+- **[03-production](tutorials/03-production/README.md)** (advanced) - GenServer, LiveView, distributed
+- **[04-projects](tutorials/04-projects/README.md)** (complete apps) - Council, Trading Desk, Code Editor
 
 ## 🔍 Find Examples
-→ **[reference/](reference/)** - Browse by feature/topic
+→ **[reference](reference/README.md)** - Browse by feature/topic
 
 Need something specific? Find examples by capability:
 - **[Tools](reference/tools.md)** - Function calling and custom tools
@@ -26,7 +26,7 @@ Need something specific? Find examples by capability:
 - **[Patterns](reference/patterns.md)** - ReAct, GenServer, distributed systems
 
 ## 📋 Templates
-→ **[templates/](templates/)** - Copy-paste starters
+→ **[templates](templates/README.md)** - Copy-paste starters
 
 Ready-to-use templates for common patterns.
 
@@ -54,16 +54,16 @@ mix run tutorials/01-basics/05-calculator.exs
 ## Navigation Guide
 
 **New to AI agents?**
-→ Start with [quickstart/](quickstart/) then follow [tutorials/01-basics/](tutorials/01-basics/)
+→ Start with [quickstart](quickstart/README.md) then follow [tutorials/01-basics](tutorials/01-basics/README.md)
 
 **Looking for specific features?**
-→ Browse [reference/](reference/) by capability
+→ Browse [reference](reference/README.md) by capability
 
 **Want to build something?**
-→ Use [templates/](templates/) as starting points
+→ Use [templates](templates/README.md) as starting points
 
 **Need production patterns?**
-→ Study [tutorials/04-projects/](tutorials/04-projects/) for complete applications
+→ Study [tutorials/04-projects](tutorials/04-projects/README.md) for complete applications
 
 ---
 
@@ -105,8 +105,8 @@ Every example in this directory is:
 
 ---
 
-**Get started now:** [quickstart/](quickstart/)
-**Learn systematically:** [tutorials/](tutorials/)
-**Find specific features:** [reference/](reference/)
+**Get started now:** [quickstart](quickstart/README.md)
+**Learn systematically:** [tutorials](tutorials/README.md)
+**Find specific features:** [reference](reference/README.md)
 
-Need help? Check the [troubleshooting guide](../docs/guides/troubleshooting.md) or [main documentation](../docs/).
+Need help? Check the [troubleshooting guide](../docs/guides/troubleshooting.md) or [main documentation](../docs/README.md).

--- a/examples/reference/README.md
+++ b/examples/reference/README.md
@@ -24,8 +24,8 @@ Advanced reasoning patterns and architectural examples.
 | Get real-time responses | [streaming.md](streaming.md) |
 | Use specific AI provider | [providers.md](providers.md) |
 | Build production systems | [patterns.md](patterns.md) |
-| Learn step by step | [../tutorials/](../tutorials/) |
-| Get started quickly | [../quickstart/](../quickstart/) |
+| Learn step by step | [tutorials](../tutorials/README.md) |
+| Get started quickly | [quickstart](../quickstart/README.md) |
 
 ---
 
@@ -57,4 +57,4 @@ Advanced reasoning patterns and architectural examples.
 
 ---
 
-*Looking for a guided learning experience? Check out [tutorials/](../tutorials/) for structured progression from beginner to advanced.*
+*Looking for a guided learning experience? Check out [tutorials](../tutorials/README.md) for structured progression from beginner to advanced.*

--- a/examples/reference/patterns.md
+++ b/examples/reference/patterns.md
@@ -6,7 +6,7 @@ Advanced reasoning patterns and production architecture examples.
 New to advanced patterns? Follow this progression:
 1. **[ReAct Agent](../tutorials/02-patterns/04-react-agent.exs)** - Reasoning and acting
 2. **[GenServer Integration](../tutorials/03-production/01-genserver.ex)** - Elixir processes
-3. **[Complete Projects](../tutorials/04-projects/)** - Production systems
+3. **[Complete Projects](../tutorials/04-projects/README.md)** - Production systems
 
 ## Reasoning Patterns
 
@@ -110,17 +110,17 @@ end
 ## Multi-Agent Systems
 
 ### Agent Council
-- **[council/](../tutorials/04-projects/council/)** - Multi-LLM deliberation
+- **[Council](../tutorials/04-projects/council/README.md)** - Multi-LLM deliberation
 - Multiple AI models vote on best responses
 - 3-stage voting system for consensus
 
 ### Trading Desk
-- **[trading_desk/](../tutorials/04-projects/trading_desk/)** - Enterprise coordination
+- **[Trading Desk](../tutorials/04-projects/trading_desk/README.md)** - Enterprise coordination
 - 4 specialized agents: Market, Risk, Trading, Research
 - Supervisor coordination with 18 tools
 
 ### AI Code Editor
-- **[coderex/](../tutorials/04-projects/coderex/)** - Code generation system
+- **[Coderex](../tutorials/04-projects/coderex/README.md)** - Code generation system
 - Complete code editing agent
 - SEARCH/REPLACE format with file operations
 
@@ -304,4 +304,4 @@ end
 **Next Steps:**
 - Start with [04-react-agent.exs](../tutorials/02-patterns/04-react-agent.exs)
 - Try [GenServer integration](../tutorials/03-production/01-genserver.ex) for stateful agents
-- Explore complete [project examples](../tutorials/04-projects/) for production patterns
+- Explore complete [project examples](../tutorials/04-projects/README.md) for production patterns

--- a/examples/reference/streaming.md
+++ b/examples/reference/streaming.md
@@ -39,8 +39,8 @@ end)
 - **[liveview_chat_example.ex](../liveview_chat_example.ex)** - Complete chat interface
 
 ### LiveView Chat Patterns
-- **[LiveView Chat Guide](../LIVEVIEW_CHAT_GUIDE.md)** - Complete chat implementation
-- **[LiveView Integration Guide](../LIVEVIEW_INTEGRATION.md)** - General integration patterns
+- **[LiveView Chat Example](../liveview_chat_example.ex)** - Complete chat implementation
+- **[LiveView Integration Guide](../../docs/guides/liveview-integration.md)** - General integration patterns
 
 ## Advanced Streaming
 
@@ -173,4 +173,4 @@ end)
 **Next Steps:**
 - Start with [01-streaming.exs](../tutorials/02-patterns/01-streaming.exs)
 - Try [LiveView streaming](../tutorials/03-production/02-liveview-streaming.ex) for web apps
-- Read the [LiveView Integration Guide](../LIVEVIEW_INTEGRATION.md)
+- Read the [LiveView Integration Guide](../../docs/guides/liveview-integration.md)

--- a/examples/reference/tools.md
+++ b/examples/reference/tools.md
@@ -42,7 +42,7 @@ New to tools? Follow this progression:
 
 ### Custom Tool Development
 - **[custom_tools_guide.exs](../custom_tools_guide.exs)** - Building your own tools
-- **Tool Development Guide**: [../docs/guides/tool-development.md](../docs/guides/tool-development.md)
+- **Tool Development Guide**: [Tool Development](../../docs/guides/tool_development.md)
 
 ### Provider-Specific Tool Examples
 - **[anthropic_with_tools.exs](../anthropic_with_tools.exs)** - Claude tool calling
@@ -103,5 +103,5 @@ IO.inspect(result.usage, label: "Usage")  # Shows tool_calls count
 
 **Next Steps:**
 - Start with [03-tool-calling.exs](../tutorials/01-basics/03-tool-calling.exs)
-- Read the [Tool Development Guide](../docs/guides/tool-development.md)
+- Read the [Tool Development Guide](../../docs/guides/tool_development.md)
 - Try building your own custom tools

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -4,7 +4,7 @@ Learn Nous AI systematically with hands-on tutorials progressing from beginner t
 
 ## Learning Path Overview
 
-### [01-basics/](01-basics/) (15 minutes total)
+### [01-basics](01-basics/README.md) (15 minutes total)
 **Perfect for**: First-time users, getting started
 
 **What you'll learn**:
@@ -17,7 +17,7 @@ Learn Nous AI systematically with hands-on tutorials progressing from beginner t
 
 ---
 
-### [02-patterns/](02-patterns/) (1 hour total)
+### [02-patterns](02-patterns/README.md) (1 hour total)
 **Perfect for**: Users comfortable with basics
 
 **What you'll learn**:
@@ -30,7 +30,7 @@ Learn Nous AI systematically with hands-on tutorials progressing from beginner t
 
 ---
 
-### [03-production/](03-production/) (Advanced level)
+### [03-production](03-production/README.md) (Advanced level)
 **Perfect for**: Building production systems
 
 **What you'll learn**:
@@ -43,7 +43,7 @@ Learn Nous AI systematically with hands-on tutorials progressing from beginner t
 
 ---
 
-### [04-projects/](04-projects/) (Complete applications)
+### [04-projects](04-projects/README.md) (Complete applications)
 **Perfect for**: Understanding real-world architectures
 
 **What you'll explore**:
@@ -61,13 +61,13 @@ Learn Nous AI systematically with hands-on tutorials progressing from beginner t
 → Begin with [01-basics/01-hello-world.exs](01-basics/01-hello-world.exs)
 
 **Want specific capabilities?**
-→ Browse [../reference/](../reference/) by feature
+→ Browse [reference](../reference/README.md) by feature
 
 **Need templates?**
-→ Check [../templates/](../templates/) for starter code
+→ Check [templates](../templates/README.md) for starter code
 
 **Production deployment?**
-→ See [../docs/guides/best-practices.md](../docs/guides/best-practices.md)
+→ See [Best Practices Guide](../../docs/guides/best_practices.md)
 
 ---
 

--- a/lib/nous/messages.ex
+++ b/lib/nous/messages.ex
@@ -146,12 +146,12 @@ defmodule Nous.Messages do
       iex> conversation = [Message.system("Be helpful"), Message.user("Hello")]
       iex> Messages.to_openai_format(conversation)
       [
-        %OpenaiEx.ChatMessage{role: "system", content: "Be helpful"},
-        %OpenaiEx.ChatMessage{role: "user", content: "Hello"}
+        %{role: "system", content: "Be helpful"},
+        %{role: "user", content: "Hello"}
       ]
 
   """
-  @spec to_openai_format([Message.t()]) :: [OpenaiEx.ChatMessage.t()]
+  @spec to_openai_format([Message.t()]) :: [map()]
   def to_openai_format(messages) when is_list(messages) do
     Enum.map(messages, &message_to_openai/1)
   end


### PR DESCRIPTION
- Fix undefined type reference OpenaiEx.ChatMessage.t() in messages.ex
- Fix broken file references in markdown documentation:
  - Update directory links to point to README.md files
  - Correct file paths with underscores (best_practices, tool_development)
  - Fix references to non-existent LIVEVIEW_INTEGRATION.md and GETTING_STARTED.md