### PR TITLE
Bump version to 0.8.1 and fix docs example links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1] - 2025-12-31
+
+### Fixed
+
+- Fixed `Usage` struct not implementing Access behaviour for telemetry metrics
+- Fixed `Task.shutdown/2` nil return case in `AgentServer` cancellation
+- Fixed tool call field access for OpenAI-compatible APIs (string vs atom keys)
+
+### Added
+
+- Vision/multimodal test suite with image fixtures (`test/nous/vision_test.exs`)
+- ContentPart test suite for image conversion utilities (`test/nous/content_part_test.exs`)
+- Multimodal message examples in conversation demo (`examples/04_conversation.exs`)
+
+### Changed
+
+- Updated docs to link examples to GitHub source files
+- Improved sidebar grouping in hexdocs
+
 ## [0.8.0] - 2025-12-31
 
 ### Added

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,16 +20,16 @@ Progressive learning path from basics to advanced features:
 
 | File | Description |
 |------|-------------|
-| [01_hello_world.exs](01_hello_world.exs) | Minimal example - create agent, run, get output |
-| [02_with_tools.exs](02_with_tools.exs) | Function-based tools and context access |
-| [03_streaming.exs](03_streaming.exs) | Real-time streaming responses |
-| [04_conversation.exs](04_conversation.exs) | Multi-turn conversations with context continuation |
-| [05_callbacks.exs](05_callbacks.exs) | Map callbacks and process messages (LiveView) |
-| [06_prompt_templates.exs](06_prompt_templates.exs) | EEx templates with variable substitution |
-| [07_module_tools.exs](07_module_tools.exs) | Tool.Behaviour pattern for module-based tools |
-| [08_tool_testing.exs](08_tool_testing.exs) | Mock tools, spy tools, and test helpers |
-| [09_agent_server.exs](09_agent_server.exs) | GenServer-based agent with PubSub |
-| [10_react_agent.exs](10_react_agent.exs) | ReAct pattern for complex reasoning |
+| [01_hello_world.exs](https://github.com/nyo16/nous/blob/master/examples/01_hello_world.exs) | Minimal example - create agent, run, get output |
+| [02_with_tools.exs](https://github.com/nyo16/nous/blob/master/examples/02_with_tools.exs) | Function-based tools and context access |
+| [03_streaming.exs](https://github.com/nyo16/nous/blob/master/examples/03_streaming.exs) | Real-time streaming responses |
+| [04_conversation.exs](https://github.com/nyo16/nous/blob/master/examples/04_conversation.exs) | Multi-turn conversations with context continuation |
+| [05_callbacks.exs](https://github.com/nyo16/nous/blob/master/examples/05_callbacks.exs) | Map callbacks and process messages (LiveView) |
+| [06_prompt_templates.exs](https://github.com/nyo16/nous/blob/master/examples/06_prompt_templates.exs) | EEx templates with variable substitution |
+| [07_module_tools.exs](https://github.com/nyo16/nous/blob/master/examples/07_module_tools.exs) | Tool.Behaviour pattern for module-based tools |
+| [08_tool_testing.exs](https://github.com/nyo16/nous/blob/master/examples/08_tool_testing.exs) | Mock tools, spy tools, and test helpers |
+| [09_agent_server.exs](https://github.com/nyo16/nous/blob/master/examples/09_agent_server.exs) | GenServer-based agent with PubSub |
+| [10_react_agent.exs](https://github.com/nyo16/nous/blob/master/examples/10_react_agent.exs) | ReAct pattern for complex reasoning |
 
 ## Provider Examples
 
@@ -37,10 +37,10 @@ Provider-specific configuration and features:
 
 | File | Description |
 |------|-------------|
-| [providers/anthropic.exs](providers/anthropic.exs) | Claude models, extended thinking, tools |
-| [providers/openai.exs](providers/openai.exs) | GPT models, function calling, settings |
-| [providers/lmstudio.exs](providers/lmstudio.exs) | Local AI with LM Studio |
-| [providers/switching_providers.exs](providers/switching_providers.exs) | Provider comparison and selection |
+| [providers/anthropic.exs](https://github.com/nyo16/nous/blob/master/examples/providers/anthropic.exs) | Claude models, extended thinking, tools |
+| [providers/openai.exs](https://github.com/nyo16/nous/blob/master/examples/providers/openai.exs) | GPT models, function calling, settings |
+| [providers/lmstudio.exs](https://github.com/nyo16/nous/blob/master/examples/providers/lmstudio.exs) | Local AI with LM Studio |
+| [providers/switching_providers.exs](https://github.com/nyo16/nous/blob/master/examples/providers/switching_providers.exs) | Provider comparison and selection |
 
 ## Advanced Examples
 
@@ -48,11 +48,11 @@ Production patterns and advanced features:
 
 | File | Description |
 |------|-------------|
-| [advanced/context_updates.exs](advanced/context_updates.exs) | Tool context updates and state management |
-| [advanced/error_handling.exs](advanced/error_handling.exs) | Retries, fallbacks, circuit breakers |
-| [advanced/telemetry.exs](advanced/telemetry.exs) | Custom metrics and cost tracking |
-| [advanced/cancellation.exs](advanced/cancellation.exs) | Task and streaming cancellation |
-| [advanced/liveview_integration.exs](advanced/liveview_integration.exs) | Phoenix LiveView integration patterns |
+| [advanced/context_updates.exs](https://github.com/nyo16/nous/blob/master/examples/advanced/context_updates.exs) | Tool context updates and state management |
+| [advanced/error_handling.exs](https://github.com/nyo16/nous/blob/master/examples/advanced/error_handling.exs) | Retries, fallbacks, circuit breakers |
+| [advanced/telemetry.exs](https://github.com/nyo16/nous/blob/master/examples/advanced/telemetry.exs) | Custom metrics and cost tracking |
+| [advanced/cancellation.exs](https://github.com/nyo16/nous/blob/master/examples/advanced/cancellation.exs) | Task and streaming cancellation |
+| [advanced/liveview_integration.exs](https://github.com/nyo16/nous/blob/master/examples/advanced/liveview_integration.exs) | Phoenix LiveView integration patterns |
 
 ## v0.8.0 Features
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
   @source_url "https://github.com/nyo16/nous"
 
   def project do
@@ -70,7 +70,7 @@ defmodule Nous.MixProject do
         # Getting Started
         {"docs/getting-started.md", filename: "getting_started", title: "Getting Started Guide"},
 
-        # Examples
+        # Examples Overview
         {"examples/README.md", filename: "examples_overview", title: "Examples Overview"},
 
         # Production Guides
@@ -85,6 +85,23 @@ defmodule Nous.MixProject do
       ],
       source_ref: "v#{@version}",
       source_url: @source_url,
+      groups_for_extras: [
+        "Getting Started": [
+          "readme.html",
+          "getting_started.html",
+          "examples_overview.html"
+        ],
+        "Production Guides": [
+          "liveview_integration.html",
+          "best_practices.html",
+          "tool_development.html",
+          "troubleshooting.html",
+          "migration_guide.html"
+        ],
+        "Design": [
+          "council_design.html"
+        ]
+      ],
       groups_for_modules: [
         "Core API": [
           Nous,


### PR DESCRIPTION
- Bump version from 0.8.0 to 0.8.1
- Update examples/README.md links to point to GitHub source files
- Add sidebar grouping for docs extras
- Update CHANGELOG with 0.8.1 fixes