### PR TITLE
Merge ParallelSubAgent into SubAgent, accept Agent structs as templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.1] - 2026-02-14
+
+### Changed
+
+- **Sub-Agent plugin unified**: Merged `ParallelSubAgent` into `Nous.Plugins.SubAgent`
+  - Single plugin now provides both `delegate_task` (single) and `spawn_agents` (parallel) tools
+  - `system_prompt/2` callback injects orchestration guidance including available templates
+  - Templates accept `%Nous.Agent{}` structs (recommended) or config maps (legacy)
+  - Parallel execution via `Task.Supervisor.async_stream_nolink`
+  - Configurable concurrency (`parallel_max_concurrency`, default: 5) and timeout (`parallel_timeout`, default: 120s)
+  - Graceful partial failure: crashed/timed-out sub-agents don't block others
+
+- **New Example**: `examples/13_sub_agents.exs`
+  - Template-based sub-agents using `Agent.new/2` structs
+  - Parallel execution with inline model config
+  - Direct programmatic invocation bypassing the LLM
+
 ## [0.10.0] - 2026-02-14
 
 ### Added

--- a/examples/13_sub_agents.exs
+++ b/examples/13_sub_agents.exs
@@ -1,0 +1,198 @@
+#!/usr/bin/env elixir
+
+# Nous AI - Sub-Agents
+# Delegate work to specialized sub-agents: one at a time or in parallel
+#
+# The SubAgent plugin provides two tools:
+#   - `delegate_task`  — single sub-agent for focused work
+#   - `spawn_agents`   — multiple sub-agents running concurrently
+#
+# The parent agent decides when and how to delegate via tool calls.
+# Each sub-agent runs in its own isolated context.
+
+IO.puts("=== Nous AI - Sub-Agents Demo ===\n")
+
+# ============================================================================
+# Example 1: Parallel research with template-based agents
+# ============================================================================
+#
+# Define specialized agent templates as Agent structs. The parent agent
+# picks which template to use for each task.
+
+IO.puts("--- Example 1: Parallel research with templates ---")
+
+templates = %{
+  "researcher" =>
+    Nous.Agent.new("lmstudio:qwen3",
+      instructions: """
+      You are a focused research specialist. When given a research question:
+      1. Provide a clear, factual answer with specific technical details
+      2. Include concrete examples (code snippets, configuration, API calls)
+      3. Note any important caveats or limitations
+      4. Keep your response under 200 words — be dense with information, not verbose
+
+      Do NOT ask follow-up questions. Answer directly with what you know.
+      """
+    ),
+  "analyst" =>
+    Nous.Agent.new("lmstudio:qwen3",
+      instructions: """
+      You are a technical analyst who evaluates trade-offs. When given a topic:
+      1. List 2-3 concrete pros with specific scenarios where they matter
+      2. List 2-3 concrete cons with specific scenarios where they hurt
+      3. Give a one-sentence recommendation for when to use this approach
+      4. Keep your response under 200 words
+
+      Be opinionated. Do NOT hedge with "it depends" — commit to a clear stance.
+      """
+    )
+}
+
+parent =
+  Nous.Agent.new("lmstudio:qwen3",
+    instructions: """
+    You are a senior technical lead who coordinates research across specialists.
+
+    When a user asks you to compare or research multiple things:
+    1. Identify the independent sub-tasks (one per topic/angle)
+    2. For each sub-task, write a SELF-CONTAINED prompt — the sub-agent has NO
+       context from this conversation, so include all necessary background
+    3. Call `spawn_agents` with all tasks at once using the appropriate template
+    4. When results come back, synthesize them into a structured comparison
+       with a clear recommendation at the end
+
+    You have two templates available:
+    - "researcher": factual deep-dives on specific topics
+    - "analyst": trade-off analysis with pros/cons and recommendations
+
+    IMPORTANT: Do NOT answer the question yourself. Always delegate to sub-agents
+    first, then synthesize their findings.
+    """,
+    plugins: [Nous.Plugins.SubAgent],
+    deps: %{sub_agent_templates: templates}
+  )
+
+{:ok, result} =
+  Nous.Agent.run(
+    parent,
+    "Compare Elixir GenServer vs Agent vs ETS for caching. Research each option in parallel.",
+    max_iterations: 15
+  )
+
+IO.puts("Parent's synthesized answer:")
+IO.puts(result.output)
+IO.puts("\nTotal tokens: #{result.usage.total_tokens}")
+IO.puts("")
+
+# ============================================================================
+# Example 2: Inline models (no templates needed)
+# ============================================================================
+
+IO.puts("--- Example 2: Inline parallel agents ---")
+
+parent2 =
+  Nous.Agent.new("lmstudio:qwen3",
+    instructions: """
+    You are a content coordinator who produces documents by delegating sections
+    to parallel writers.
+
+    When asked to produce a multi-section document:
+    1. Break the document into independent sections
+    2. For each section, use `spawn_agents` with inline config:
+       - Set "model" to "lmstudio:qwen3"
+       - Set "instructions" to a writing style guide for that section
+       - Set "task" to the specific content to write, including any context
+         the writer needs (they have NO knowledge of the overall document)
+    3. When all sections come back, assemble them into a cohesive document
+       with transitions between sections and a brief introduction
+
+    IMPORTANT: Each sub-agent writes ONE section independently. They cannot
+    see each other's work. You handle stitching them together.
+    """,
+    plugins: [Nous.Plugins.SubAgent],
+    deps: %{
+      parallel_max_concurrency: 3,
+      parallel_timeout: 60_000
+    }
+  )
+
+{:ok, result2} =
+  Nous.Agent.run(
+    parent2,
+    """
+    Create an "Elixir Highlights" document with three sections:
+    1. The Actor model and how processes work in Elixir/OTP
+    2. Pattern matching and how it shapes Elixir code
+    3. The pipe operator and functional composition
+
+    Each section should be one focused paragraph. Write all three in parallel,
+    then combine them with a short intro.
+    """,
+    max_iterations: 15
+  )
+
+IO.puts("Combined result:")
+IO.puts(result2.output)
+IO.puts("\nTotal tokens: #{result2.usage.total_tokens}")
+IO.puts("")
+
+# ============================================================================
+# Example 3: Direct tool invocation (without LLM deciding)
+# ============================================================================
+
+IO.puts("--- Example 3: Direct parallel execution ---")
+
+alias Nous.Agent.Context
+
+ctx =
+  Context.new(
+    deps: %{
+      sub_agent_templates: %{
+        "writer" =>
+          Nous.Agent.new("lmstudio:qwen3",
+            instructions: """
+            You are a concise technical writer for an Elixir glossary.
+            Answer the question in exactly 2-3 sentences.
+            Use plain language — assume the reader knows programming but not Elixir.
+            Do NOT use bullet points or headers. Just prose.
+            """
+          )
+      }
+    }
+  )
+
+result3 =
+  Nous.Plugins.SubAgent.spawn_agents(ctx, %{
+    "tasks" => [
+      %{
+        "task" =>
+          "Define OTP in Elixir. Explain what it stands for and why it matters for building reliable systems.",
+        "template" => "writer"
+      },
+      %{
+        "task" =>
+          "Define a supervision tree in Elixir. Explain how it helps applications recover from crashes automatically.",
+        "template" => "writer"
+      },
+      %{
+        "task" =>
+          "Define GenServer in Elixir. Explain what problem it solves and give one concrete use case.",
+        "template" => "writer"
+      }
+    ]
+  })
+
+IO.puts("Parallel results: #{result3.succeeded}/#{result3.total} succeeded\n")
+
+for {r, i} <- Enum.with_index(result3.results) do
+  IO.puts("  Task #{i + 1}: #{r.task}")
+
+  if r.success do
+    IO.puts("  Answer: #{String.slice(r.output, 0, 120)}...")
+    IO.puts("  Tokens: #{r.tokens_used}\n")
+  else
+    IO.puts("  Error: #{r.error}\n")
+  end
+end
+
+IO.puts("Done!")

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ Progressive learning path from basics to advanced features:
 | [10_react_agent.exs](https://github.com/nyo16/nous/blob/master/examples/10_react_agent.exs) | ReAct pattern for complex reasoning |
 | [11_human_in_the_loop.exs](https://github.com/nyo16/nous/blob/master/examples/11_human_in_the_loop.exs) | HITL approval workflows (sync + async PubSub) |
 | [12_pubsub_agent.exs](https://github.com/nyo16/nous/blob/master/examples/12_pubsub_agent.exs) | PubSub agent lifecycle, registry, persistence |
+| [13_sub_agents.exs](https://github.com/nyo16/nous/blob/master/examples/13_sub_agents.exs) | Sub-agents (single + parallel) with fan-out/fan-in |
 
 ## Provider Examples
 

--- a/lib/nous/plugins/sub_agent.ex
+++ b/lib/nous/plugins/sub_agent.ex
@@ -1,9 +1,11 @@
 defmodule Nous.Plugins.SubAgent do
   @moduledoc """
-  Plugin that enables agents to delegate tasks to specialized child agents.
+  Plugin that enables agents to delegate tasks to specialized sub-agents.
 
-  Provides a `delegate_task` tool that spawns a child agent with its own
-  isolated context, runs it to completion, and returns the result.
+  Provides two tools:
+
+    - `delegate_task` — run a single sub-agent for one task (sequential)
+    - `spawn_agents` — run multiple sub-agents in parallel via `Task.Supervisor`
 
   ## Usage
 
@@ -11,15 +13,12 @@ defmodule Nous.Plugins.SubAgent do
         plugins: [Nous.Plugins.SubAgent],
         deps: %{
           sub_agent_templates: %{
-            "researcher" => %{
-              model: "openai:gpt-4o-mini",
-              instructions: "You are a research specialist. Find accurate information.",
-              tools: [&MyTools.web_search/2]
-            },
-            "coder" => %{
-              model: "openai:gpt-4",
+            "researcher" => Agent.new("openai:gpt-4o-mini",
+              instructions: "You are a research specialist. Find accurate information."
+            ),
+            "coder" => Agent.new("openai:gpt-4",
               instructions: "You are a coding specialist. Write clean Elixir code."
-            }
+            )
           }
         }
       )
@@ -27,18 +26,40 @@ defmodule Nous.Plugins.SubAgent do
   ## Templates
 
   Pre-configured agent templates can be provided via `deps[:sub_agent_templates]`.
-  The `delegate_task` tool can reference a template by name or provide inline config.
+  Templates can be either `%Nous.Agent{}` structs or config maps:
+
+      # Using Agent structs (recommended)
+      "researcher" => Agent.new("openai:gpt-4o-mini", instructions: "Research specialist")
+
+      # Using config maps (legacy)
+      "researcher" => %{model: "openai:gpt-4o-mini", instructions: "Research specialist"}
+
+  Both `delegate_task` and `spawn_agents` can reference templates by name or
+  provide inline model/instructions for ad-hoc sub-agents.
+
+  ## Parallel Configuration
+
+  Configure concurrency and timeout for `spawn_agents` via `deps`:
+
+    - `:parallel_max_concurrency` — max concurrent sub-agents (default: 5)
+    - `:parallel_timeout` — per-task timeout in ms (default: 120_000)
   """
 
   @behaviour Nous.Plugin
 
-  alias Nous.Tool
+  alias Nous.{Agent, Tool}
 
   require Logger
 
+  @default_max_concurrency 5
+  @default_timeout 120_000
+
+  # ===========================================================================
+  # Plugin callbacks
+  # ===========================================================================
+
   @impl true
   def init(_agent, ctx) do
-    # Ensure sub-agent tracking exists
     templates = ctx.deps[:sub_agent_templates] || %{}
 
     deps =
@@ -52,8 +73,54 @@ defmodule Nous.Plugins.SubAgent do
 
   @impl true
   def tools(_agent, _ctx) do
-    [delegate_task_tool()]
+    [delegate_task_tool(), spawn_agents_tool()]
   end
+
+  @impl true
+  def system_prompt(_agent, ctx) do
+    templates = ctx.deps[:sub_agent_templates] || %{}
+
+    template_list =
+      case Map.keys(templates) do
+        [] -> "No templates configured. Use inline model and instructions for each task."
+        names -> "Available templates: #{Enum.join(names, ", ")}"
+      end
+
+    """
+    ## Sub-Agents
+
+    You have two tools for delegating work to sub-agents:
+
+    - `delegate_task` — run a single sub-agent for a focused task
+    - `spawn_agents` — run multiple sub-agents in parallel
+
+    #{template_list}
+
+    ### When to use `delegate_task`
+    - A single task that needs specialized handling
+    - Sequential delegation where one result informs the next
+
+    ### When to use `spawn_agents`
+    - Researching multiple topics simultaneously
+    - Analyzing different parts of a codebase in parallel
+    - Generating content for separate sections at once
+    - Any set of tasks where one result doesn't depend on another
+
+    ### When NOT to use sub-agents
+    - A single focused question you can answer directly
+    - Tasks that share state or need to coordinate with each other
+
+    ### Writing good sub-agent prompts
+    Each sub-agent starts fresh with zero context. Include everything it needs:
+    - What specifically to do
+    - Any constraints (length, format, focus area)
+    - Relevant background the sub-agent won't have
+    """
+  end
+
+  # ===========================================================================
+  # Tool definitions
+  # ===========================================================================
 
   defp delegate_task_tool do
     %Tool{
@@ -93,23 +160,141 @@ defmodule Nous.Plugins.SubAgent do
     }
   end
 
+  defp spawn_agents_tool do
+    %Tool{
+      name: "spawn_agents",
+      description: """
+      Spawn multiple sub-agents to work on tasks in parallel. Each sub-agent \
+      runs independently with its own context and returns a result. Use this \
+      when you have multiple independent tasks that can be worked on simultaneously, \
+      such as researching different topics, analyzing separate modules, or \
+      generating content for different sections.
+
+      Each task in the array runs as a separate agent concurrently. Results are \
+      collected and returned together once all tasks complete.
+      """,
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "tasks" => %{
+            "type" => "array",
+            "description" =>
+              "List of tasks to run in parallel. Each task spawns a separate sub-agent.",
+            "items" => %{
+              "type" => "object",
+              "properties" => %{
+                "task" => %{
+                  "type" => "string",
+                  "description" => "The task description/prompt for this sub-agent"
+                },
+                "template" => %{
+                  "type" => "string",
+                  "description" =>
+                    "Name of a pre-configured agent template (e.g., 'researcher', 'coder')"
+                },
+                "model" => %{
+                  "type" => "string",
+                  "description" =>
+                    "Model for inline config (e.g., 'openai:gpt-4o-mini'). Used when no template."
+                },
+                "instructions" => %{
+                  "type" => "string",
+                  "description" =>
+                    "Instructions for inline config. Used when no template is specified."
+                }
+              },
+              "required" => ["task"]
+            }
+          }
+        },
+        "required" => ["tasks"]
+      },
+      function: &__MODULE__.spawn_agents/2,
+      takes_ctx: true
+    }
+  end
+
+  # ===========================================================================
+  # delegate_task — single sub-agent
+  # ===========================================================================
+
   @doc false
   def delegate_task(ctx, args) do
     task = Map.fetch!(args, "task")
     template_name = Map.get(args, "template")
 
-    config = resolve_agent_config(ctx, template_name, args)
+    case resolve_agent(ctx, template_name, args) do
+      {:ok, agent} ->
+        case run_sub_agent(agent, task, ctx) do
+          {:ok, result} ->
+            %{
+              success: true,
+              result: result.output,
+              tokens_used: result.tokens_used,
+              iterations: result.iterations
+            }
 
-    case config do
-      {:ok, agent_config} ->
-        run_sub_agent(agent_config, task, ctx)
+          {:error, error_msg} ->
+            %{success: false, error: error_msg}
+        end
 
       {:error, reason} ->
         %{success: false, error: reason}
     end
   end
 
-  defp resolve_agent_config(ctx, template_name, _args) when is_binary(template_name) do
+  # ===========================================================================
+  # spawn_agents — parallel sub-agents
+  # ===========================================================================
+
+  @doc false
+  def spawn_agents(ctx, %{"tasks" => tasks}) when is_list(tasks) do
+    max_concurrency = ctx.deps[:parallel_max_concurrency] || @default_max_concurrency
+    timeout = ctx.deps[:parallel_timeout] || @default_timeout
+    task_count = length(tasks)
+
+    Logger.info(
+      "Spawning #{task_count} parallel sub-agents (max_concurrency: #{max_concurrency})"
+    )
+
+    results =
+      Nous.TaskSupervisor
+      |> Task.Supervisor.async_stream_nolink(
+        Enum.with_index(tasks),
+        fn {task_spec, index} ->
+          run_parallel_task(ctx, task_spec, index)
+        end,
+        max_concurrency: max_concurrency,
+        timeout: timeout,
+        on_timeout: :kill_task
+      )
+      |> Enum.zip(tasks)
+      |> Enum.map(fn {stream_result, task_spec} ->
+        format_parallel_result(stream_result, task_spec)
+      end)
+
+    succeeded = Enum.count(results, & &1.success)
+    failed = task_count - succeeded
+
+    Logger.info("Parallel sub-agents complete: #{succeeded} succeeded, #{failed} failed")
+
+    %{
+      total: task_count,
+      succeeded: succeeded,
+      failed: failed,
+      results: results
+    }
+  end
+
+  def spawn_agents(_ctx, _args) do
+    %{success: false, error: "Missing required 'tasks' array"}
+  end
+
+  # ===========================================================================
+  # Shared internals
+  # ===========================================================================
+
+  defp resolve_agent(ctx, template_name, _args) when is_binary(template_name) do
     templates = ctx.deps[:sub_agent_templates] || %{}
 
     case Map.get(templates, template_name) do
@@ -117,79 +302,125 @@ defmodule Nous.Plugins.SubAgent do
         available = Map.keys(templates) |> Enum.join(", ")
         {:error, "Template '#{template_name}' not found. Available: #{available}"}
 
-      template ->
-        {:ok, template}
+      %Agent{} = agent ->
+        {:ok, agent}
+
+      %{} = config ->
+        {:ok, agent_from_config(config)}
     end
   end
 
-  defp resolve_agent_config(_ctx, nil, args) do
+  defp resolve_agent(_ctx, nil, args) do
     model = Map.get(args, "model")
 
     if model do
       {:ok,
-       %{
-         model: model,
-         instructions: Map.get(args, "instructions", "Complete the given task thoroughly."),
-         tools: []
-       }}
+       Agent.new(model,
+         instructions: Map.get(args, "instructions", "Complete the given task thoroughly.")
+       )}
     else
-      {:error, "Either 'template' or 'model' must be provided for sub-agent delegation."}
+      {:error, "Either 'template' or 'model' must be provided."}
     end
   end
 
-  defp run_sub_agent(config, task, parent_ctx) do
+  defp agent_from_config(config) do
     model = Map.get(config, :model) || Map.get(config, "model")
     instructions = Map.get(config, :instructions) || Map.get(config, "instructions", "")
     tools = Map.get(config, :tools) || Map.get(config, "tools", [])
+    model_settings = Map.get(config, :model_settings) || Map.get(config, "model_settings", %{})
 
-    Logger.info("Spawning sub-agent with model #{model} for task: #{String.slice(task, 0, 80)}")
+    Agent.new(model,
+      instructions: instructions,
+      tools: tools,
+      model_settings: model_settings
+    )
+  end
 
-    try do
-      agent =
-        Nous.Agent.new(model,
-          instructions: instructions,
-          tools: tools,
-          model_settings: Map.get(config, :model_settings, %{})
-        )
+  defp run_sub_agent(agent, task, parent_ctx, index \\ nil) do
+    label = if index, do: "[sub-agent #{index}]", else: "[sub-agent]"
+    Logger.info("#{label} Starting: #{String.slice(task, 0, 80)}")
 
-      # Run with isolated deps (only pass through explicitly shared keys)
-      shared_keys = Map.get(config, :shared_deps, [])
-      sub_deps = Map.take(parent_ctx.deps, shared_keys)
+    # Isolated deps — only pass through explicitly shared keys
+    shared_keys = []
+    sub_deps = Map.take(parent_ctx.deps, shared_keys)
 
-      # Propagate PubSub from parent with :sub suffix on topic
-      parent_pubsub = parent_ctx.deps[:__sub_agent_pubsub__]
-      parent_topic = parent_ctx.deps[:__sub_agent_pubsub_topic__]
+    # Propagate PubSub with scoped topic
+    parent_pubsub = parent_ctx.deps[:__sub_agent_pubsub__]
+    parent_topic = parent_ctx.deps[:__sub_agent_pubsub_topic__]
 
-      sub_topic =
-        if parent_topic, do: "#{parent_topic}:sub", else: nil
+    sub_suffix = if index, do: "parallel:#{index}", else: "sub"
+    sub_topic = if parent_topic, do: "#{parent_topic}:#{sub_suffix}", else: nil
 
-      run_opts = [
-        deps: sub_deps,
-        max_iterations: 10,
-        pubsub: parent_pubsub,
-        pubsub_topic: sub_topic
-      ]
+    run_opts = [
+      deps: sub_deps,
+      max_iterations: 10,
+      pubsub: parent_pubsub,
+      pubsub_topic: sub_topic
+    ]
 
-      case Nous.Agent.run(agent, task, run_opts) do
-        {:ok, result} ->
-          Logger.info("Sub-agent completed successfully")
+    case Agent.run(agent, task, run_opts) do
+      {:ok, result} ->
+        Logger.info("#{label} Completed successfully")
 
-          %{
-            success: true,
-            result: result.output,
-            tokens_used: result.usage.total_tokens,
-            iterations: result.iterations
-          }
+        {:ok,
+         %{
+           output: result.output,
+           tokens_used: result.usage.total_tokens,
+           iterations: result.iterations
+         }}
 
-        {:error, error} ->
-          error_msg = if is_exception(error), do: Exception.message(error), else: inspect(error)
-          Logger.warning("Sub-agent failed: #{error_msg}")
-          %{success: false, error: error_msg}
-      end
-    rescue
-      e ->
-        Logger.error("Sub-agent crashed: #{Exception.message(e)}")
-        %{success: false, error: "Sub-agent execution failed: #{Exception.message(e)}"}
+      {:error, error} ->
+        error_msg = if is_exception(error), do: Exception.message(error), else: inspect(error)
+        Logger.warning("#{label} Failed: #{error_msg}")
+        {:error, error_msg}
     end
+  rescue
+    e ->
+      label = if index, do: "[sub-agent #{index}]", else: "[sub-agent]"
+      Logger.error("#{label} Crashed: #{Exception.message(e)}")
+      {:error, "Sub-agent execution failed: #{Exception.message(e)}"}
+  end
+
+  # ===========================================================================
+  # Parallel-specific helpers
+  # ===========================================================================
+
+  defp run_parallel_task(ctx, task_spec, index) do
+    task_prompt = Map.fetch!(task_spec, "task")
+    template_name = Map.get(task_spec, "template")
+
+    case resolve_agent(ctx, template_name, task_spec) do
+      {:ok, agent} ->
+        run_sub_agent(agent, task_prompt, ctx, index)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp format_parallel_result({:ok, {:ok, result}}, task_spec) do
+    %{
+      task: Map.get(task_spec, "task"),
+      success: true,
+      output: result.output,
+      tokens_used: result.tokens_used,
+      iterations: result.iterations
+    }
+  end
+
+  defp format_parallel_result({:ok, {:error, reason}}, task_spec) do
+    %{
+      task: Map.get(task_spec, "task"),
+      success: false,
+      error: reason
+    }
+  end
+
+  defp format_parallel_result({:exit, reason}, task_spec) do
+    %{
+      task: Map.get(task_spec, "task"),
+      success: false,
+      error: "Sub-agent crashed: #{inspect(reason)}"
+    }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/plugins/sub_agent_test.exs
+++ b/test/nous/plugins/sub_agent_test.exs
@@ -1,0 +1,631 @@
+defmodule Nous.Plugins.SubAgentTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.{Agent, Message, Usage}
+  alias Nous.Agent.Context
+  alias Nous.Plugins.SubAgent
+
+  # ---------------------------------------------------------------------------
+  # Mock dispatchers
+  # ---------------------------------------------------------------------------
+
+  defmodule MockDispatcher do
+    @moduledoc false
+
+    def request(_model, messages, _settings) do
+      user_content =
+        messages
+        |> Enum.find_value(fn
+          %Message{role: :user, content: content} when is_binary(content) -> content
+          _ -> nil
+        end)
+
+      text = "Mock response for: #{user_content || "unknown"}"
+
+      legacy = %{
+        parts: [{:text, text}],
+        usage: %Usage{
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          tool_calls: 0,
+          requests: 1
+        },
+        model_name: "test-model",
+        timestamp: DateTime.utc_now()
+      }
+
+      {:ok, Message.from_legacy(legacy)}
+    end
+
+    def request_stream(_model, _messages, _settings), do: {:ok, []}
+    def count_tokens(_messages), do: 50
+  end
+
+  defmodule FailingDispatcher do
+    @moduledoc false
+
+    def request(_model, _messages, _settings) do
+      {:error, %Nous.Errors.ModelError{message: "LLM unavailable", provider: :test}}
+    end
+
+    def request_stream(_model, _messages, _settings), do: {:error, "unavailable"}
+    def count_tokens(_messages), do: 50
+  end
+
+  defmodule SlowDispatcher do
+    @moduledoc false
+
+    def request(_model, _messages, _settings) do
+      Process.sleep(:infinity)
+    end
+
+    def request_stream(_model, _messages, _settings), do: {:ok, []}
+    def count_tokens(_messages), do: 50
+  end
+
+  setup do
+    original = Application.get_env(:nous, :model_dispatcher)
+    Application.put_env(:nous, :model_dispatcher, MockDispatcher)
+
+    on_exit(fn ->
+      if original,
+        do: Application.put_env(:nous, :model_dispatcher, original),
+        else: Application.delete_env(:nous, :model_dispatcher)
+    end)
+
+    templates = %{
+      "researcher" =>
+        Agent.new("openai:test-model",
+          instructions: "You are a research specialist."
+        ),
+      "writer" =>
+        Agent.new("openai:test-model",
+          instructions: "You are a writer."
+        )
+    }
+
+    agent = Agent.new("openai:test-model", instructions: "Coordinator")
+    ctx = Context.new(deps: %{sub_agent_templates: templates})
+
+    %{agent: agent, ctx: ctx, templates: templates}
+  end
+
+  # ===========================================================================
+  # Plugin callback tests
+  # ===========================================================================
+
+  describe "init/2" do
+    test "preserves existing templates in deps", %{agent: agent, ctx: ctx} do
+      result = SubAgent.init(agent, ctx)
+
+      assert result.deps[:sub_agent_templates] == ctx.deps[:sub_agent_templates]
+    end
+
+    test "sets default empty templates when none provided", %{agent: agent} do
+      ctx = Context.new(deps: %{})
+      result = SubAgent.init(agent, ctx)
+
+      assert result.deps[:sub_agent_templates] == %{}
+    end
+
+    test "stores pubsub config from context", %{agent: agent} do
+      ctx = Context.new(deps: %{}, pubsub: MyPubSub, pubsub_topic: "test:topic")
+      result = SubAgent.init(agent, ctx)
+
+      assert result.deps[:__sub_agent_pubsub__] == MyPubSub
+      assert result.deps[:__sub_agent_pubsub_topic__] == "test:topic"
+    end
+  end
+
+  describe "tools/2" do
+    test "returns both delegate_task and spawn_agents tools", %{agent: agent, ctx: ctx} do
+      tools = SubAgent.tools(agent, ctx)
+
+      assert length(tools) == 2
+      names = Enum.map(tools, & &1.name) |> Enum.sort()
+      assert names == ["delegate_task", "spawn_agents"]
+    end
+
+    test "both tools take context", %{agent: agent, ctx: ctx} do
+      tools = SubAgent.tools(agent, ctx)
+
+      for tool <- tools do
+        assert tool.takes_ctx == true
+      end
+    end
+
+    test "delegate_task has required 'task' parameter", %{agent: agent, ctx: ctx} do
+      tools = SubAgent.tools(agent, ctx)
+      tool = Enum.find(tools, &(&1.name == "delegate_task"))
+
+      assert tool.parameters["required"] == ["task"]
+    end
+
+    test "spawn_agents has required 'tasks' parameter", %{agent: agent, ctx: ctx} do
+      tools = SubAgent.tools(agent, ctx)
+      tool = Enum.find(tools, &(&1.name == "spawn_agents"))
+
+      assert tool.parameters["required"] == ["tasks"]
+      assert tool.parameters["properties"]["tasks"]["type"] == "array"
+    end
+  end
+
+  describe "system_prompt/2" do
+    test "includes available template names", %{agent: agent, ctx: ctx} do
+      ctx = SubAgent.init(agent, ctx)
+      prompt = SubAgent.system_prompt(agent, ctx)
+
+      assert prompt =~ "researcher"
+      assert prompt =~ "writer"
+    end
+
+    test "mentions no templates when none configured", %{agent: agent} do
+      ctx = Context.new(deps: %{})
+      ctx = SubAgent.init(agent, ctx)
+      prompt = SubAgent.system_prompt(agent, ctx)
+
+      assert prompt =~ "No templates configured"
+    end
+
+    test "includes guidance on both tools", %{agent: agent, ctx: ctx} do
+      ctx = SubAgent.init(agent, ctx)
+      prompt = SubAgent.system_prompt(agent, ctx)
+
+      assert prompt =~ "delegate_task"
+      assert prompt =~ "spawn_agents"
+      assert prompt =~ "Writing good sub-agent prompts"
+    end
+  end
+
+  # ===========================================================================
+  # delegate_task — single sub-agent
+  # ===========================================================================
+
+  describe "delegate_task/2 success" do
+    test "runs a single sub-agent from template", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.delegate_task(ctx, %{
+          "task" => "Research topic A",
+          "template" => "researcher"
+        })
+
+      assert result.success == true
+      assert is_binary(result.result)
+      assert result.result =~ "Mock response for:"
+      assert is_integer(result.tokens_used)
+      assert result.tokens_used > 0
+    end
+
+    test "runs a single sub-agent with inline model", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.delegate_task(ctx, %{
+          "task" => "Do something",
+          "model" => "openai:test-model",
+          "instructions" => "Be helpful"
+        })
+
+      assert result.success == true
+      assert result.result =~ "Mock response for:"
+    end
+  end
+
+  describe "delegate_task/2 errors" do
+    test "returns error when template not found", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.delegate_task(ctx, %{
+          "task" => "Do stuff",
+          "template" => "nonexistent"
+        })
+
+      assert result.success == false
+      assert result.error =~ "Template 'nonexistent' not found"
+    end
+
+    test "returns error when neither template nor model provided", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result = SubAgent.delegate_task(ctx, %{"task" => "Do stuff"})
+
+      assert result.success == false
+      assert result.error =~ "Either 'template' or 'model' must be provided"
+    end
+
+    test "handles LLM errors gracefully", %{ctx: ctx} do
+      Application.put_env(:nous, :model_dispatcher, FailingDispatcher)
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.delegate_task(ctx, %{
+          "task" => "Will fail",
+          "template" => "researcher"
+        })
+
+      assert result.success == false
+      assert is_binary(result.error)
+    end
+  end
+
+  # ===========================================================================
+  # spawn_agents — parallel sub-agents
+  # ===========================================================================
+
+  describe "spawn_agents/2 success" do
+    test "runs multiple tasks in parallel and returns results", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{"task" => "Research topic A", "template" => "researcher"},
+            %{"task" => "Research topic B", "template" => "researcher"}
+          ]
+        })
+
+      assert result.total == 2
+      assert result.succeeded == 2
+      assert result.failed == 0
+      assert length(result.results) == 2
+
+      for r <- result.results do
+        assert r.success == true
+        assert is_binary(r.output)
+        assert r.output =~ "Mock response for:"
+        assert is_integer(r.tokens_used)
+        assert r.tokens_used > 0
+      end
+    end
+
+    test "each result includes the original task prompt", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{"task" => "First task", "template" => "researcher"},
+            %{"task" => "Second task", "template" => "writer"}
+          ]
+        })
+
+      tasks = Enum.map(result.results, & &1.task)
+      assert "First task" in tasks
+      assert "Second task" in tasks
+    end
+
+    test "works with inline model config (no template)", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{
+              "task" => "Do something",
+              "model" => "openai:test-model",
+              "instructions" => "Be helpful"
+            }
+          ]
+        })
+
+      assert result.total == 1
+      assert result.succeeded == 1
+      assert hd(result.results).success == true
+    end
+
+    test "handles single task", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Solo task", "template" => "researcher"}]
+        })
+
+      assert result.total == 1
+      assert result.succeeded == 1
+    end
+
+    test "handles empty task list", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{"tasks" => []})
+
+      assert result.total == 0
+      assert result.succeeded == 0
+      assert result.failed == 0
+      assert result.results == []
+    end
+  end
+
+  describe "spawn_agents/2 errors" do
+    test "returns error when template not found", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{"task" => "Do stuff", "template" => "nonexistent"}
+          ]
+        })
+
+      assert result.total == 1
+      assert result.failed == 1
+
+      [r] = result.results
+      assert r.success == false
+      assert r.error =~ "Template 'nonexistent' not found"
+    end
+
+    test "returns error when neither template nor model provided", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Do stuff"}]
+        })
+
+      assert result.total == 1
+      assert result.failed == 1
+
+      [r] = result.results
+      assert r.success == false
+      assert r.error =~ "Either 'template' or 'model' must be provided"
+    end
+
+    test "returns error for missing tasks key" do
+      ctx = Context.new()
+
+      result = SubAgent.spawn_agents(ctx, %{"not_tasks" => []})
+
+      assert result == %{success: false, error: "Missing required 'tasks' array"}
+    end
+
+    test "handles LLM errors gracefully without crashing other tasks", %{ctx: ctx} do
+      Application.put_env(:nous, :model_dispatcher, FailingDispatcher)
+
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{"task" => "Will fail", "template" => "researcher"},
+            %{"task" => "Also will fail", "template" => "researcher"}
+          ]
+        })
+
+      assert result.total == 2
+      assert result.failed == 2
+
+      for r <- result.results do
+        assert r.success == false
+        assert is_binary(r.error)
+      end
+    end
+
+    test "partial failure: some tasks succeed, some fail", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [
+            %{"task" => "Good task", "template" => "researcher"},
+            %{"task" => "Bad task", "template" => "nonexistent"}
+          ]
+        })
+
+      assert result.total == 2
+      assert result.succeeded == 1
+      assert result.failed == 1
+
+      success = Enum.find(result.results, & &1.success)
+      failure = Enum.find(result.results, &(!&1.success))
+
+      assert success.task == "Good task"
+      assert failure.task == "Bad task"
+    end
+  end
+
+  # ===========================================================================
+  # spawn_agents — concurrency and timeout
+  # ===========================================================================
+
+  describe "spawn_agents/2 concurrency" do
+    test "respects parallel_max_concurrency config" do
+      counter = :atomics.new(1, signed: true)
+      max_seen = :atomics.new(1, signed: true)
+
+      defmodule ConcurrencyTracker do
+        @moduledoc false
+
+        def request(_model, _messages, _settings) do
+          {counter, max_seen} = :persistent_term.get({__MODULE__, :counters})
+
+          current = :atomics.add_get(counter, 1, 1)
+          loop_max(max_seen, current)
+
+          Process.sleep(50)
+
+          :atomics.sub(counter, 1, 1)
+
+          legacy = %{
+            parts: [{:text, "done"}],
+            usage: %Usage{
+              input_tokens: 1,
+              output_tokens: 1,
+              total_tokens: 2,
+              tool_calls: 0,
+              requests: 1
+            },
+            model_name: "test",
+            timestamp: DateTime.utc_now()
+          }
+
+          {:ok, Message.from_legacy(legacy)}
+        end
+
+        defp loop_max(atomic, value) do
+          current_max = :atomics.get(atomic, 1)
+          if value > current_max, do: :atomics.put(atomic, 1, value)
+        end
+
+        def request_stream(_model, _messages, _settings), do: {:ok, []}
+        def count_tokens(_messages), do: 50
+      end
+
+      :persistent_term.put({ConcurrencyTracker, :counters}, {counter, max_seen})
+      Application.put_env(:nous, :model_dispatcher, ConcurrencyTracker)
+
+      ctx =
+        Context.new(
+          deps: %{
+            sub_agent_templates: %{
+              "worker" => Agent.new("openai:test", instructions: "Work")
+            },
+            parallel_max_concurrency: 2
+          }
+        )
+
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" =>
+            Enum.map(1..6, fn i ->
+              %{"task" => "Task #{i}", "template" => "worker"}
+            end)
+        })
+
+      assert result.total == 6
+      assert result.succeeded == 6
+
+      observed_max = :atomics.get(max_seen, 1)
+      assert observed_max <= 2
+
+      :persistent_term.erase({ConcurrencyTracker, :counters})
+    end
+
+    test "handles task timeout gracefully" do
+      Application.put_env(:nous, :model_dispatcher, SlowDispatcher)
+
+      ctx =
+        Context.new(
+          deps: %{
+            sub_agent_templates: %{
+              "slow" => Agent.new("openai:test", instructions: "Be slow")
+            },
+            parallel_timeout: 200
+          }
+        )
+
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "This will timeout", "template" => "slow"}]
+        })
+
+      assert result.total == 1
+      assert result.failed == 1
+
+      [r] = result.results
+      assert r.success == false
+      assert r.error =~ "crashed"
+    end
+  end
+
+  # ===========================================================================
+  # Template resolution — Agent structs and config maps
+  # ===========================================================================
+
+  describe "template resolution" do
+    test "works with Agent struct templates", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Test", "template" => "researcher"}]
+        })
+
+      assert result.succeeded == 1
+    end
+
+    test "works with legacy config map templates" do
+      ctx =
+        Context.new(
+          deps: %{
+            sub_agent_templates: %{
+              "legacy" => %{
+                model: "openai:test-model",
+                instructions: "Legacy config map"
+              }
+            }
+          }
+        )
+
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Test legacy", "template" => "legacy"}]
+        })
+
+      assert result.succeeded == 1
+    end
+
+    test "inline config uses default instructions when not provided", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Test", "model" => "openai:test-model"}]
+        })
+
+      assert result.succeeded == 1
+    end
+
+    test "lists available templates in error message", %{ctx: ctx} do
+      ctx = SubAgent.init(%Agent{model: nil}, ctx)
+
+      result =
+        SubAgent.spawn_agents(ctx, %{
+          "tasks" => [%{"task" => "Test", "template" => "nope"}]
+        })
+
+      [r] = result.results
+      assert r.error =~ "researcher"
+      assert r.error =~ "writer"
+    end
+  end
+
+  # ===========================================================================
+  # Integration with Plugin system
+  # ===========================================================================
+
+  describe "Plugin behaviour integration" do
+    test "works with Plugin.run_init/3", %{agent: agent, ctx: ctx} do
+      result = Nous.Plugin.run_init([SubAgent], agent, ctx)
+
+      assert result.deps[:sub_agent_templates] == ctx.deps[:sub_agent_templates]
+    end
+
+    test "works with Plugin.collect_tools/3", %{agent: agent, ctx: ctx} do
+      tools = Nous.Plugin.collect_tools([SubAgent], agent, ctx)
+
+      assert length(tools) == 2
+      names = Enum.map(tools, & &1.name) |> Enum.sort()
+      assert names == ["delegate_task", "spawn_agents"]
+    end
+
+    test "works with Plugin.collect_system_prompts/3", %{agent: agent, ctx: ctx} do
+      prompt = Nous.Plugin.collect_system_prompts([SubAgent], agent, ctx)
+
+      assert is_binary(prompt)
+      assert prompt =~ "Sub-Agents"
+    end
+  end
+end


### PR DESCRIPTION
Unified the two sub-agent plugins into a single Nous.Plugins.SubAgent that provides both delegate_task (single) and spawn_agents (parallel) tools. Templates now accept %Nous.Agent{} structs instead of config maps (with backward compat). Version set to 0.10.1.