### PR TITLE
fix: Add pluggable stream parser for Gemini JSON array streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.2] - 2026-03-04
+
+### Fixed
+
+- **Gemini streaming**: Fixed streaming responses returning 0 events. The Gemini `streamGenerateContent` endpoint returns a JSON array (`application/json`) by default, not Server-Sent Events. Instead of forcing SSE via `alt=sse` query parameter, added a pluggable stream parser to `Nous.Providers.HTTP`.
+
+### Added
+
+- `Nous.Providers.HTTP.JSONArrayParser` — stream buffer parser for JSON array responses. Extracts complete JSON objects from a streaming `[{...},{...},...]` response by tracking `{}` nesting depth while respecting string literals and escape sequences.
+- `:stream_parser` option on `HTTP.stream/4` — accepts any module implementing `parse_buffer/1` with the same `{events, remaining_buffer}` contract as SSE parsing. Defaults to the existing SSE parser. Enables any provider with a non-SSE streaming format to plug in a custom parser.
+
 ## [0.12.0] - 2026-02-28
 
 ### Added

--- a/lib/nous/providers/gemini.ex
+++ b/lib/nous/providers/gemini.ex
@@ -110,7 +110,11 @@ defmodule Nous.Providers.Gemini do
     # Remove model from params (it's in the URL)
     body = params |> Map.delete("model") |> Map.delete(:model)
 
-    HTTP.stream(url, body, headers, timeout: timeout, finch_name: finch_name)
+    HTTP.stream(url, body, headers,
+      timeout: timeout,
+      finch_name: finch_name,
+      stream_parser: Nous.Providers.HTTP.JSONArrayParser
+    )
   end
 
   # Build URL with model and API key in query params

--- a/lib/nous/providers/http.ex
+++ b/lib/nous/providers/http.ex
@@ -95,6 +95,9 @@ defmodule Nous.Providers.HTTP do
   ## Options
     * `:timeout` - Request timeout in ms (default: 60_000)
     * `:finch_name` - Finch pool name (default: Nous.Finch)
+    * `:stream_parser` - Module for parsing the stream buffer (default: SSE parsing).
+      Must implement `parse_buffer/1` returning `{events, remaining_buffer}`.
+      See `Nous.Providers.HTTP.JSONArrayParser` for an example.
 
   ## Error Handling
   The stream will emit `{:stream_error, reason}` on errors and then halt.
@@ -106,6 +109,7 @@ defmodule Nous.Providers.HTTP do
       when is_binary(url) and is_map(body) and is_list(headers) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
+    stream_parser = Keyword.get(opts, :stream_parser)
 
     case Jason.encode(body) do
       {:ok, json_body} ->
@@ -114,7 +118,9 @@ defmodule Nous.Providers.HTTP do
 
         stream =
           Stream.resource(
-            fn -> start_streaming(url, headers, json_body, finch_name, timeout) end,
+            fn ->
+              start_streaming(url, headers, json_body, finch_name, timeout, stream_parser)
+            end,
             &next_chunk/1,
             &cleanup/1
           )
@@ -356,7 +362,7 @@ defmodule Nous.Providers.HTTP do
   end
 
   # Start streaming - spawn a process to handle Finch.stream
-  defp start_streaming(url, headers, body, finch_name, timeout) do
+  defp start_streaming(url, headers, body, finch_name, timeout, stream_parser) do
     parent = self()
 
     pid =
@@ -408,7 +414,8 @@ defmodule Nous.Providers.HTTP do
       done: false,
       status: nil,
       timeout: timeout,
-      error: nil
+      error: nil,
+      stream_parser: stream_parser
     }
   end
 
@@ -482,7 +489,7 @@ defmodule Nous.Providers.HTTP do
           Logger.error("SSE buffer overflow, terminating stream")
           {[{:stream_error, %{reason: :buffer_overflow}}], %{state | done: true}}
         else
-          {events, remaining_buffer} = parse_sse_buffer(new_buffer)
+          {events, remaining_buffer} = parse_stream_buffer(new_buffer, state.stream_parser)
 
           # Filter out parse errors if we want to be lenient
           {valid_events, errors} =
@@ -505,7 +512,7 @@ defmodule Nous.Providers.HTTP do
 
       {:sse, :done, :ok} ->
         # Flush any remaining buffer
-        {events, _} = parse_sse_buffer(state.buffer <> "\n\n")
+        {events, _} = flush_stream_buffer(state.buffer, state.stream_parser)
 
         final_events =
           Enum.reject(events, fn
@@ -529,6 +536,16 @@ defmodule Nous.Providers.HTTP do
         {[{:stream_error, %{reason: :timeout, timeout_ms: timeout}}], %{state | done: true}}
     end
   end
+
+  # Parse stream buffer using the configured parser (default: SSE)
+  defp parse_stream_buffer(buffer, nil), do: parse_sse_buffer(buffer)
+  defp parse_stream_buffer(buffer, parser_mod), do: parser_mod.parse_buffer(buffer)
+
+  # Flush remaining buffer at end of stream
+  # SSE needs a trailing \n\n to force the last event through;
+  # custom parsers just re-parse the remaining buffer as-is.
+  defp flush_stream_buffer(buffer, nil), do: parse_sse_buffer(buffer <> "\n\n")
+  defp flush_stream_buffer(buffer, parser_mod), do: parser_mod.parse_buffer(buffer)
 
   # Cleanup when stream is done
   defp cleanup(state) do

--- a/lib/nous/providers/http/json_array_parser.ex
+++ b/lib/nous/providers/http/json_array_parser.ex
@@ -1,0 +1,126 @@
+defmodule Nous.Providers.HTTP.JSONArrayParser do
+  @moduledoc """
+  Stream parser for JSON array responses.
+
+  Parses streaming HTTP responses where the body is a JSON array of objects:
+
+      [{"candidates":[...]},{"candidates":[...]},...]
+
+  Used by providers (like Gemini) that stream responses as a JSON array
+  rather than Server-Sent Events. Has the same interface as
+  `Nous.Providers.HTTP.parse_sse_buffer/1` so it can be used as a
+  drop-in `:stream_parser` for `HTTP.stream/4`.
+
+  ## How it works
+
+  Chunks arrive at arbitrary byte boundaries. The parser accumulates them
+  in a buffer, skips array-level syntax (`[`, `]`, `,`, whitespace), and
+  extracts complete top-level JSON objects by tracking `{}` nesting depth
+  while respecting string literals and escape sequences.
+  """
+
+  require Logger
+
+  @doc """
+  Parse a buffer containing chunks of a JSON array into individual events.
+
+  Returns `{events, remaining_buffer}` where events is a list of parsed
+  JSON maps (same contract as `HTTP.parse_sse_buffer/1`).
+
+  ## Examples
+
+      iex> parse_buffer(~s|[{"text":"hi"},{"text":"there"}]|)
+      {[%{"text" => "hi"}, %{"text" => "there"}], ""}
+
+      iex> parse_buffer(~s|[{"text":"hi"},{"tex|)
+      {[%{"text" => "hi"}], ~s|{"tex|}
+
+      iex> parse_buffer("")
+      {[], ""}
+  """
+  @spec parse_buffer(String.t()) :: {list(), String.t()}
+  def parse_buffer(buffer) when is_binary(buffer) do
+    extract_objects(buffer, [])
+  end
+
+  def parse_buffer(_), do: {[], ""}
+
+  # Recursively extract complete JSON objects from the buffer
+  defp extract_objects(buffer, acc) do
+    trimmed = skip_array_syntax(buffer)
+
+    case extract_next_object(trimmed) do
+      {:ok, json_str, rest} ->
+        case Jason.decode(json_str) do
+          {:ok, parsed} ->
+            extract_objects(rest, [parsed | acc])
+
+          {:error, error} ->
+            Logger.debug("JSON array parser: failed to decode object: #{inspect(error)}")
+            # Don't consume more — the buffer might just need more data
+            {Enum.reverse(acc), trimmed}
+        end
+
+      :incomplete ->
+        {Enum.reverse(acc), trimmed}
+    end
+  end
+
+  # Skip array-level syntax: [ ] , and whitespace between objects
+  defp skip_array_syntax(<<c, rest::binary>>) when c in ~c|[,] \t\n\r|,
+    do: skip_array_syntax(rest)
+
+  defp skip_array_syntax(buffer), do: buffer
+
+  # Extract the next complete top-level JSON object from the buffer.
+  # Only starts extraction when buffer begins with `{`.
+  defp extract_next_object(<<"{", _::binary>> = buffer) do
+    case find_object_end(buffer, 0, 0, false) do
+      {:ok, end_pos} ->
+        <<json::binary-size(^end_pos), rest::binary>> = buffer
+        {:ok, json, rest}
+
+      :incomplete ->
+        :incomplete
+    end
+  end
+
+  defp extract_next_object(_), do: :incomplete
+
+  # Walk the buffer character by character tracking {} depth.
+  # Respects JSON string boundaries and escape sequences.
+  #
+  # Returns {:ok, end_position} when a complete object is found,
+  # or :incomplete if the buffer ends mid-object.
+
+  # Buffer exhausted before object closed
+  defp find_object_end(<<>>, _pos, _depth, _in_string), do: :incomplete
+
+  # Escaped character inside a string — skip both bytes
+  defp find_object_end(<<"\\", _, rest::binary>>, pos, depth, true) do
+    find_object_end(rest, pos + 2, depth, true)
+  end
+
+  # Quote toggles string state
+  defp find_object_end(<<"\"", rest::binary>>, pos, depth, in_string) do
+    find_object_end(rest, pos + 1, depth, not in_string)
+  end
+
+  # Open brace outside string — increase depth
+  defp find_object_end(<<"{", rest::binary>>, pos, depth, false) do
+    find_object_end(rest, pos + 1, depth + 1, false)
+  end
+
+  # Close brace outside string — decrease depth, check if object complete
+  defp find_object_end(<<"}", rest::binary>>, pos, depth, false) do
+    case depth - 1 do
+      0 -> {:ok, pos + 1}
+      new_depth -> find_object_end(rest, pos + 1, new_depth, false)
+    end
+  end
+
+  # Any other character — advance position
+  defp find_object_end(<<_, rest::binary>>, pos, depth, in_string) do
+    find_object_end(rest, pos + 1, depth, in_string)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.12.1"
+  @version "0.12.2"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/providers/http/json_array_parser_test.exs
+++ b/test/nous/providers/http/json_array_parser_test.exs
@@ -1,0 +1,173 @@
+defmodule Nous.Providers.HTTP.JSONArrayParserTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.Providers.HTTP.JSONArrayParser
+
+  describe "parse_buffer/1" do
+    test "parses a complete JSON array" do
+      buffer = ~s|[{"text":"hello"},{"text":"world"}]|
+      {events, remaining} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"text" => "hello"}, %{"text" => "world"}]
+      assert remaining == ""
+    end
+
+    test "parses a single complete object in array" do
+      buffer = ~s|[{"id":1}]|
+      {events, remaining} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"id" => 1}]
+      assert remaining == ""
+    end
+
+    test "handles incomplete object at end" do
+      buffer = ~s|[{"id":1},{"id":2},{"id|
+      {events, remaining} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"id" => 1}, %{"id" => 2}]
+      assert remaining == ~s|{"id|
+    end
+
+    test "handles no complete objects yet" do
+      buffer = ~s|[{"partial|
+      {events, remaining} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == []
+      assert remaining == ~s|{"partial|
+    end
+
+    test "handles empty buffer" do
+      {events, remaining} = JSONArrayParser.parse_buffer("")
+      assert events == []
+      assert remaining == ""
+    end
+
+    test "handles nil buffer" do
+      {events, remaining} = JSONArrayParser.parse_buffer(nil)
+      assert events == []
+      assert remaining == ""
+    end
+
+    test "handles just the opening bracket" do
+      {events, remaining} = JSONArrayParser.parse_buffer("[")
+      assert events == []
+      assert remaining == ""
+    end
+
+    test "handles whitespace between objects" do
+      buffer = ~s|[ {"a":1} , {"b":2} , {"c":3} ]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"a" => 1}, %{"b" => 2}, %{"c" => 3}]
+    end
+
+    test "handles newlines between objects (typical streaming)" do
+      buffer = "[{\"a\":1}\n,{\"b\":2}\n,{\"c\":3}\n]"
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"a" => 1}, %{"b" => 2}, %{"c" => 3}]
+    end
+
+    test "handles nested objects" do
+      buffer = ~s|[{"outer":{"inner":"value"}}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"outer" => %{"inner" => "value"}}]
+    end
+
+    test "handles nested arrays in objects" do
+      buffer = ~s|[{"items":[1,2,{"nested":true}]}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"items" => [1, 2, %{"nested" => true}]}]
+    end
+
+    test "handles braces inside strings" do
+      buffer = ~s|[{"text":"a {curly} thing"}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"text" => "a {curly} thing"}]
+    end
+
+    test "handles escaped quotes inside strings" do
+      buffer = ~s|[{"text":"say \\"hello\\""}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"text" => ~s|say "hello"|}]
+    end
+
+    test "handles escaped backslash before quote" do
+      buffer = ~s|[{"path":"C:\\\\Users\\\\test"}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"path" => "C:\\Users\\test"}]
+    end
+
+    test "handles unicode content" do
+      buffer = ~s|[{"emoji":"🎉","jp":"日本語"}]|
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert events == [%{"emoji" => "🎉", "jp" => "日本語"}]
+    end
+
+    test "simulates chunked delivery" do
+      # Chunk 1: opening bracket + first partial object
+      chunk1 = ~s|[{"candi|
+      {events1, buf1} = JSONArrayParser.parse_buffer(chunk1)
+      assert events1 == []
+      assert buf1 == ~s|{"candi|
+
+      # Chunk 2: completes first object, starts second
+      chunk2 = ~s|dates":[{"text":"hi"}]}\n,{"candi|
+      {events2, buf2} = JSONArrayParser.parse_buffer(buf1 <> chunk2)
+      assert events2 == [%{"candidates" => [%{"text" => "hi"}]}]
+      assert buf2 == ~s|{"candi|
+
+      # Chunk 3: completes second object + closing bracket
+      chunk3 = ~s|dates":[{"text":"bye"}]}\n]|
+      {events3, buf3} = JSONArrayParser.parse_buffer(buf2 <> chunk3)
+      assert events3 == [%{"candidates" => [%{"text" => "bye"}]}]
+      assert buf3 == ""
+    end
+
+    test "parses real Gemini streaming response shape" do
+      buffer = """
+      [{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}
+      ,{"candidates":[{"content":{"parts":[{"text":" there!"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash"}
+      ]
+      """
+
+      {events, _} = JSONArrayParser.parse_buffer(buffer)
+
+      assert length(events) == 2
+
+      [first, second] = events
+
+      assert get_in(first, ["candidates", Access.at(0), "content", "parts", Access.at(0), "text"]) ==
+               "Hello"
+
+      assert get_in(second, [
+               "candidates",
+               Access.at(0),
+               "content",
+               "parts",
+               Access.at(0),
+               "text"
+             ]) == " there!"
+
+      assert get_in(second, ["candidates", Access.at(0), "finishReason"]) == "STOP"
+    end
+
+    test "handles many objects efficiently" do
+      objects = Enum.map(1..200, fn i -> ~s|{"seq":#{i}}| end) |> Enum.join(",")
+      buffer = "[" <> objects <> "]"
+
+      {events, remaining} = JSONArrayParser.parse_buffer(buffer)
+
+      assert length(events) == 200
+      assert hd(events) == %{"seq" => 1}
+      assert List.last(events) == %{"seq" => 200}
+      assert remaining == ""
+    end
+  end
+end


### PR DESCRIPTION
Gemini's streamGenerateContent endpoint returns a JSON array by default, not SSE. Instead of forcing SSE with alt=sse, this adds a proper JSON array stream parser and makes HTTP.stream's buffer parser pluggable.

- Add Nous.Providers.HTTP.JSONArrayParser for JSON array responses
- Add :stream_parser option to HTTP.stream/4 (defaults to SSE)
- Gemini provider uses JSONArrayParser for native format support
- 18 new tests for the JSON array parser

Bumps version to 0.12.2.