### PR TITLE
feat: Add LlamaCpp provider for local NIF-based LLM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,17 @@ IO.puts("Tokens: #{result.usage.total_tokens}")
 | Ollama | `ollama:llama2` | ✅ |
 | OpenRouter | `openrouter:anthropic/claude-3.5-sonnet` | ✅ |
 | Together AI | `together:meta-llama/Llama-3-70b-chat-hf` | ✅ |
+| LlamaCpp | `llamacpp:local` + `:llamacpp_model` | ✅ |
 | Custom | `openai_compatible:model` + `:base_url` | ✅ |
 
-All providers use pure Elixir HTTP clients (Req + Finch).
+All HTTP providers use pure Elixir HTTP clients (Req + Finch). LlamaCpp runs in-process via NIFs.
 
 ```elixir
 # Switch providers with one line change
 agent = Nous.new("lmstudio:qwen3")                  # Local (free)
 agent = Nous.new("openai:gpt-4")                    # OpenAI
 agent = Nous.new("anthropic:claude-sonnet-4-5-20250929")   # Anthropic
+agent = Nous.new("llamacpp:local", llamacpp_model: llm)  # Local NIF
 ```
 
 ## Features
@@ -481,6 +483,7 @@ See [examples/advanced/liveview_integration.exs](examples/advanced/liveview_inte
 - [providers/anthropic.exs](examples/providers/anthropic.exs) - Claude, extended thinking
 - [providers/openai.exs](examples/providers/openai.exs) - GPT models
 - [providers/lmstudio.exs](examples/providers/lmstudio.exs) - Local AI
+- [providers/llamacpp.exs](examples/providers/llamacpp.exs) - Local NIF-based inference
 - [providers/switching_providers.exs](examples/providers/switching_providers.exs) - Provider comparison
 
 ### Memory Examples
@@ -638,6 +641,11 @@ agent = Nous.new("lmstudio:qwen3")
 
 # Ollama — start the server, then:
 agent = Nous.new("ollama:llama2")
+
+# LlamaCpp — load a GGUF model directly (requires llama_cpp_ex dep):
+:ok = LlamaCppEx.init()
+{:ok, llm} = LlamaCppEx.load_model("model.gguf", n_gpu_layers: -1)
+agent = Nous.new("llamacpp:local", llamacpp_model: llm)
 ```
 
 ### Running Examples

--- a/README.md
+++ b/README.md
@@ -646,6 +646,12 @@ agent = Nous.new("ollama:llama2")
 :ok = LlamaCppEx.init()
 {:ok, llm} = LlamaCppEx.load_model("model.gguf", n_gpu_layers: -1)
 agent = Nous.new("llamacpp:local", llamacpp_model: llm)
+
+# For thinking models (Qwen3, DeepSeek, etc.), disable <think> tags:
+agent = Nous.new("llamacpp:local",
+  llamacpp_model: llm,
+  model_settings: %{enable_thinking: false}
+)
 ```
 
 ### Running Examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@ Provider-specific configuration and features:
 | [providers/openai.exs](https://github.com/nyo16/nous/blob/master/examples/providers/openai.exs) | GPT models, function calling, settings |
 | [providers/lmstudio.exs](https://github.com/nyo16/nous/blob/master/examples/providers/lmstudio.exs) | Local AI with LM Studio |
 | [providers/vllm_sglang.exs](https://github.com/nyo16/nous/blob/master/examples/providers/vllm_sglang.exs) | vLLM & SGLang high-performance local inference |
+| [providers/llamacpp.exs](https://github.com/nyo16/nous/blob/master/examples/providers/llamacpp.exs) | Local NIF-based inference via llama.cpp |
 | [providers/switching_providers.exs](https://github.com/nyo16/nous/blob/master/examples/providers/switching_providers.exs) | Provider comparison and selection |
 
 ## Memory Examples

--- a/examples/providers/llamacpp.exs
+++ b/examples/providers/llamacpp.exs
@@ -1,0 +1,177 @@
+#!/usr/bin/env elixir
+
+# Nous AI - LlamaCpp (Local NIF-based Inference)
+# Run GGUF models directly in-process via llama.cpp NIFs
+
+IO.puts("=== Nous AI - LlamaCpp (Local NIF) ===\n")
+
+# ============================================================================
+# Setup
+# ============================================================================
+
+IO.puts("""
+--- Setup ---
+
+1. Add {:llama_cpp_ex, "~> 0.5.0"} to your mix.exs deps
+2. Download a GGUF model (e.g., from HuggingFace)
+3. Run this example with: mix run examples/providers/llamacpp.exs
+""")
+
+# Initialize and load model
+model_path = System.get_env("LLAMACPP_MODEL_PATH") || "model.gguf"
+IO.puts("Loading model from #{model_path}...")
+
+:ok = LlamaCppEx.init()
+
+{:ok, llm} =
+  LlamaCppEx.load_model(model_path,
+    n_gpu_layers: -1,
+    n_ctx: 4096
+  )
+
+IO.puts("Model loaded successfully!\n")
+
+# ============================================================================
+# Basic Usage
+# ============================================================================
+
+IO.puts("--- Basic Chat ---")
+
+agent =
+  Nous.new("llamacpp:local",
+    llamacpp_model: llm,
+    instructions: "You are helpful and concise."
+  )
+
+case Nous.run(agent, "What is 2 + 2?") do
+  {:ok, result} ->
+    IO.puts("Response: #{result.output}")
+    IO.puts("Tokens: #{result.usage.total_tokens}")
+
+  {:error, error} ->
+    IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Simple Text API
+# ============================================================================
+
+IO.puts("--- Simple Text Generation ---")
+
+case Nous.generate_text("llamacpp:local", "What is Elixir?", llamacpp_model: llm) do
+  {:ok, text} ->
+    IO.puts("Response: #{text}")
+
+  {:error, error} ->
+    IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Streaming
+# ============================================================================
+
+IO.puts("--- Streaming ---")
+
+case Nous.stream_text("llamacpp:local", "Write a haiku about programming.", llamacpp_model: llm) do
+  {:ok, stream} ->
+    stream |> Stream.each(&IO.write/1) |> Stream.run()
+    IO.puts("")
+
+  {:error, error} ->
+    IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Structured Output
+# ============================================================================
+
+IO.puts("--- Structured Output (JSON Schema) ---")
+
+schema = %{
+  "type" => "object",
+  "properties" => %{
+    "name" => %{"type" => "string"},
+    "age" => %{"type" => "integer"},
+    "hobbies" => %{"type" => "array", "items" => %{"type" => "string"}}
+  },
+  "required" => ["name", "age", "hobbies"]
+}
+
+structured_agent =
+  Nous.new("llamacpp:local",
+    llamacpp_model: llm,
+    instructions: "You respond only with valid JSON matching the schema.",
+    model_settings: %{json_schema: schema}
+  )
+
+case Nous.run(structured_agent, "Describe a fictional character.") do
+  {:ok, result} ->
+    IO.puts("Structured: #{result.output}")
+
+  {:error, error} ->
+    IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Model Settings
+# ============================================================================
+
+IO.puts("--- Model Settings ---")
+
+configured_agent =
+  Nous.new("llamacpp:local",
+    llamacpp_model: llm,
+    instructions: "Be creative and expressive.",
+    model_settings: %{
+      temperature: 0.9,
+      max_tokens: 200,
+      top_p: 0.95
+    }
+  )
+
+case Nous.run(configured_agent, "Tell me a short story in one paragraph.") do
+  {:ok, result} ->
+    IO.puts("Response: #{result.output}")
+
+  {:error, error} ->
+    IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Best Practices
+# ============================================================================
+
+IO.puts("""
+--- Best Practices ---
+
+1. Load the model once at app start:
+   - Use Application.start or a supervisor
+   - Store the reference in a GenServer or persistent_term
+
+2. GPU acceleration:
+   - Use n_gpu_layers: -1 to offload all layers to GPU
+   - Set n_gpu_layers: 0 for CPU-only
+
+3. Context size:
+   - Default is 512. Set n_ctx: 4096 (or higher) for longer conversations
+   - More context = more memory usage
+
+4. When to use LlamaCpp vs HTTP providers:
+   - LlamaCpp: Lowest latency, no network overhead, full control
+   - Ollama/LMStudio: Easier model management, multiple models
+   - Cloud: Largest models, no local hardware needed
+
+5. Memory management:
+   - GGUF models stay loaded in memory
+   - Unload when done if running multiple models
+""")

--- a/examples/providers/llamacpp.exs
+++ b/examples/providers/llamacpp.exs
@@ -14,7 +14,8 @@ IO.puts("""
 
 1. Add {:llama_cpp_ex, "~> 0.5.0"} to your mix.exs deps
 2. Download a GGUF model (e.g., from HuggingFace)
-3. Run this example with: mix run examples/providers/llamacpp.exs
+3. Set LLAMACPP_MODEL_PATH or edit the path below
+4. Run: mix run examples/providers/llamacpp.exs
 """)
 
 # Initialize and load model
@@ -32,15 +33,18 @@ IO.puts("Loading model from #{model_path}...")
 IO.puts("Model loaded successfully!\n")
 
 # ============================================================================
-# Basic Usage
+# Basic Usage (with thinking disabled)
 # ============================================================================
 
 IO.puts("--- Basic Chat ---")
 
+# Thinking models (Qwen3, etc.) emit <think>...</think> tags by default.
+# Set enable_thinking: false to get clean output.
 agent =
   Nous.new("llamacpp:local",
     llamacpp_model: llm,
-    instructions: "You are helpful and concise."
+    instructions: "You are helpful and concise.",
+    model_settings: %{enable_thinking: false}
   )
 
 case Nous.run(agent, "What is 2 + 2?") do
@@ -60,7 +64,10 @@ IO.puts("")
 
 IO.puts("--- Simple Text Generation ---")
 
-case Nous.generate_text("llamacpp:local", "What is Elixir?", llamacpp_model: llm) do
+case Nous.generate_text("llamacpp:local", "What is Elixir?",
+       llamacpp_model: llm,
+       enable_thinking: false
+     ) do
   {:ok, text} ->
     IO.puts("Response: #{text}")
 
@@ -76,13 +83,45 @@ IO.puts("")
 
 IO.puts("--- Streaming ---")
 
-case Nous.stream_text("llamacpp:local", "Write a haiku about programming.", llamacpp_model: llm) do
+case Nous.stream_text("llamacpp:local", "Write a haiku about programming.",
+       llamacpp_model: llm,
+       enable_thinking: false
+     ) do
   {:ok, stream} ->
     stream |> Stream.each(&IO.write/1) |> Stream.run()
     IO.puts("")
 
   {:error, error} ->
     IO.puts("Error: #{inspect(error)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Thinking Models
+# ============================================================================
+
+IO.puts("--- Thinking vs Non-Thinking ---")
+
+IO.puts("With thinking (default for Qwen3, DeepSeek, etc.):")
+
+case Nous.generate_text("llamacpp:local", "What is 1+1?",
+       llamacpp_model: llm,
+       max_tokens: 100
+     ) do
+  {:ok, text} -> IO.puts("  #{String.slice(text, 0, 120)}...")
+  {:error, e} -> IO.puts("  Error: #{inspect(e)}")
+end
+
+IO.puts("\nWithout thinking (enable_thinking: false):")
+
+case Nous.generate_text("llamacpp:local", "What is 1+1?",
+       llamacpp_model: llm,
+       max_tokens: 100,
+       enable_thinking: false
+     ) do
+  {:ok, text} -> IO.puts("  #{text}")
+  {:error, e} -> IO.puts("  Error: #{inspect(e)}")
 end
 
 IO.puts("")
@@ -107,7 +146,7 @@ structured_agent =
   Nous.new("llamacpp:local",
     llamacpp_model: llm,
     instructions: "You respond only with valid JSON matching the schema.",
-    model_settings: %{json_schema: schema}
+    model_settings: %{json_schema: schema, enable_thinking: false}
   )
 
 case Nous.run(structured_agent, "Describe a fictional character.") do
@@ -126,6 +165,16 @@ IO.puts("")
 
 IO.puts("--- Model Settings ---")
 
+IO.puts("""
+Settings mapping (Nous -> LlamaCppEx):
+
+  temperature:     -> temp          (sampling temperature)
+  max_tokens:      -> max_tokens    (max tokens to generate)
+  top_p:           -> top_p         (nucleus sampling)
+  json_schema:     -> json_schema   (constrained JSON output)
+  enable_thinking: -> enable_thinking (thinking token control)
+""")
+
 configured_agent =
   Nous.new("llamacpp:local",
     llamacpp_model: llm,
@@ -133,7 +182,8 @@ configured_agent =
     model_settings: %{
       temperature: 0.9,
       max_tokens: 200,
-      top_p: 0.95
+      top_p: 0.95,
+      enable_thinking: false
     }
   )
 
@@ -166,12 +216,17 @@ IO.puts("""
    - Default is 512. Set n_ctx: 4096 (or higher) for longer conversations
    - More context = more memory usage
 
-4. When to use LlamaCpp vs HTTP providers:
+4. Thinking models:
+   - Qwen3, DeepSeek R1, etc. emit <think> tags by default
+   - Set enable_thinking: false in model_settings for clean output
+   - Keep thinking enabled for complex reasoning tasks
+
+5. When to use LlamaCpp vs HTTP providers:
    - LlamaCpp: Lowest latency, no network overhead, full control
    - Ollama/LMStudio: Easier model management, multiple models
    - Cloud: Largest models, no local hardware needed
 
-5. Memory management:
+6. Memory management:
    - GGUF models stay loaded in memory
    - Unload when done if running multiple models
 """)

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -93,7 +93,7 @@ defmodule Nous.LLM do
   def generate_text(model, prompt, opts \\ [])
 
   def generate_text(model_string, prompt, opts) when is_binary(model_string) do
-    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key]))
+    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key, :llamacpp_model]))
     generate_text(model, prompt, opts)
   end
 
@@ -151,7 +151,7 @@ defmodule Nous.LLM do
   def stream_text(model, prompt, opts \\ [])
 
   def stream_text(model_string, prompt, opts) when is_binary(model_string) do
-    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key]))
+    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key, :llamacpp_model]))
     stream_text(model, prompt, opts)
   end
 

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -254,7 +254,7 @@ defmodule Nous.LLM do
   defp build_settings(opts, tools, provider) do
     base_settings =
       opts
-      |> Keyword.take([:temperature, :max_tokens, :top_p])
+      |> Keyword.take([:temperature, :max_tokens, :top_p, :enable_thinking])
       |> Map.new()
 
     if tools == [] do

--- a/lib/nous/messages.ex
+++ b/lib/nous/messages.ex
@@ -240,6 +240,9 @@ defmodule Nous.Messages do
       :mistral ->
         to_openai_format(messages)
 
+      :llamacpp ->
+        to_openai_format(messages)
+
       :custom ->
         to_openai_format(messages)
 
@@ -247,7 +250,7 @@ defmodule Nous.Messages do
         raise ArgumentError, """
         Unsupported provider: #{inspect(provider)}
 
-        Supported providers: :openai, :openai_compatible, :groq, :lmstudio, :vllm, :sglang, :anthropic, :gemini, :mistral
+        Supported providers: :openai, :openai_compatible, :groq, :lmstudio, :llamacpp, :vllm, :sglang, :anthropic, :gemini, :mistral
         """
     end
   end
@@ -351,6 +354,9 @@ defmodule Nous.Messages do
       :mistral ->
         from_openai_response(response)
 
+      :llamacpp ->
+        from_openai_response(response)
+
       :custom ->
         from_openai_response(response)
 
@@ -358,7 +364,7 @@ defmodule Nous.Messages do
         raise ArgumentError, """
         Unsupported provider: #{inspect(provider)}
 
-        Supported providers: :openai, :openai_compatible, :groq, :lmstudio, :vllm, :sglang, :anthropic, :gemini, :mistral
+        Supported providers: :openai, :openai_compatible, :groq, :lmstudio, :llamacpp, :vllm, :sglang, :anthropic, :gemini, :mistral
         """
     end
   end

--- a/lib/nous/model.ex
+++ b/lib/nous/model.ex
@@ -21,6 +21,7 @@ defmodule Nous.Model do
           | :groq
           | :ollama
           | :lmstudio
+          | :llamacpp
           | :openrouter
           | :together
           | :vllm
@@ -66,6 +67,7 @@ defmodule Nous.Model do
     * `"mistral:mistral-large-latest"` - Mistral models
     * `"ollama:llama2"` - Local Ollama
     * `"lmstudio:qwen3-vl-4b-thinking-mlx"` - Local LM Studio
+    * `"llamacpp:local"` - Local LlamaCpp NIF (requires `:llamacpp_model` option)
     * `"vllm:qwen3-vl-4b-thinking-mlx"` - vLLM server
     * `"sglang:meta-llama/Llama-3-8B"` - SGLang server
     * `"openrouter:anthropic/claude-3.5-sonnet"` - OpenRouter
@@ -112,6 +114,25 @@ defmodule Nous.Model do
 
   def parse("sglang:" <> model_name, opts), do: new(:sglang, model_name, opts)
 
+  def parse("llamacpp:" <> model_name, opts) do
+    {llamacpp_model, opts} = Keyword.pop(opts, :llamacpp_model)
+
+    opts =
+      if llamacpp_model do
+        default_settings = Keyword.get(opts, :default_settings, %{})
+
+        Keyword.put(
+          opts,
+          :default_settings,
+          Map.put(default_settings, :llamacpp_model, llamacpp_model)
+        )
+      else
+        opts
+      end
+
+    new(:llamacpp, model_name, opts)
+  end
+
   def parse("custom:" <> model_name, opts) do
     unless Keyword.has_key?(opts, :base_url) do
       raise ArgumentError,
@@ -126,7 +147,7 @@ defmodule Nous.Model do
     raise ArgumentError,
           "Invalid model string format: #{inspect(invalid_string)}. " <>
             "Expected format: \"provider:model-name\". " <>
-            "Supported providers: openai, anthropic, gemini, groq, mistral, ollama, lmstudio, openrouter, together, vllm, sglang, custom"
+            "Supported providers: openai, anthropic, gemini, groq, mistral, ollama, lmstudio, llamacpp, openrouter, together, vllm, sglang, custom"
   end
 
   @doc """
@@ -190,6 +211,7 @@ defmodule Nous.Model do
   # vLLM requires explicit base_url
   defp default_base_url(:vllm), do: nil
   defp default_base_url(:sglang), do: "http://localhost:30000/v1"
+  defp default_base_url(:llamacpp), do: "local"
   defp default_base_url(:custom), do: nil
 
   @spec default_api_key(provider()) :: String.t() | nil
@@ -206,6 +228,8 @@ defmodule Nous.Model do
   defp default_api_key(:vllm), do: nil
   # SGLang API key is optional
   defp default_api_key(:sglang), do: nil
+  # LlamaCpp runs locally via NIFs, no API key needed
+  defp default_api_key(:llamacpp), do: nil
   defp default_api_key(:custom), do: nil
 
   # Default receive timeouts per provider
@@ -219,6 +243,8 @@ defmodule Nous.Model do
   defp default_receive_timeout(:vllm), do: 120_000
   # 2 minutes for local SGLang
   defp default_receive_timeout(:sglang), do: 120_000
+  # 2 minutes for local LlamaCpp
+  defp default_receive_timeout(:llamacpp), do: 120_000
   # 2 minutes for custom endpoints
   defp default_receive_timeout(:custom), do: 120_000
   # 60 seconds for cloud providers

--- a/lib/nous/model_dispatcher.ex
+++ b/lib/nous/model_dispatcher.ex
@@ -7,6 +7,7 @@ defmodule Nous.ModelDispatcher do
   - `:gemini` → `Nous.Providers.Gemini`
   - `:mistral` → `Nous.Providers.Mistral`
   - `:lmstudio` → `Nous.Providers.LMStudio`
+  - `:llamacpp` → `Nous.Providers.LlamaCpp`
   - `:vllm` → `Nous.Providers.VLLM`
   - `:sglang` → `Nous.Providers.SGLang`
   - `:openai` → `Nous.Providers.OpenAI`
@@ -49,6 +50,11 @@ defmodule Nous.ModelDispatcher do
   def request(%Model{provider: :sglang} = model, messages, settings) do
     Logger.debug("Routing to SGLang provider for model: #{model.model}")
     Providers.SGLang.request(model, messages, settings)
+  end
+
+  def request(%Model{provider: :llamacpp} = model, messages, settings) do
+    Logger.debug("Routing to LlamaCpp provider for model: #{model.model}")
+    Providers.LlamaCpp.request(model, messages, settings)
   end
 
   def request(%Model{provider: :openai} = model, messages, settings) do
@@ -96,6 +102,11 @@ defmodule Nous.ModelDispatcher do
     Providers.SGLang.request_stream(model, messages, settings)
   end
 
+  def request_stream(%Model{provider: :llamacpp} = model, messages, settings) do
+    Logger.debug("Routing streaming request to LlamaCpp provider for model: #{model.model}")
+    Providers.LlamaCpp.request_stream(model, messages, settings)
+  end
+
   def request_stream(%Model{provider: :openai} = model, messages, settings) do
     Logger.debug("Routing streaming request to OpenAI provider for model: #{model.model}")
     Providers.OpenAI.request_stream(model, messages, settings)
@@ -135,6 +146,10 @@ defmodule Nous.ModelDispatcher do
 
   def count_tokens(%Model{provider: :sglang}, messages) do
     Providers.SGLang.count_tokens(messages)
+  end
+
+  def count_tokens(%Model{provider: :llamacpp}, messages) do
+    Providers.LlamaCpp.count_tokens(messages)
   end
 
   def count_tokens(%Model{provider: :openai}, messages) do

--- a/lib/nous/providers/llamacpp.ex
+++ b/lib/nous/providers/llamacpp.ex
@@ -66,7 +66,11 @@ if Code.ensure_loaded?(LlamaCppEx) do
         %{provider: :llamacpp, model_name: model.model, message_count: length(messages)}
       )
 
-      provider_messages = Nous.Messages.to_provider_format(messages, :llamacpp)
+      provider_messages =
+        messages
+        |> Nous.Messages.to_provider_format(:llamacpp)
+        |> Enum.map(&to_atom_keys/1)
+
       opts = build_llamacpp_opts(merged_settings)
 
       result =
@@ -143,10 +147,24 @@ if Code.ensure_loaded?(LlamaCppEx) do
         %{provider: :llamacpp, model_name: model.model, message_count: length(messages)}
       )
 
-      provider_messages = Nous.Messages.to_provider_format(messages, :llamacpp)
+      provider_messages =
+        messages
+        |> Nous.Messages.to_provider_format(:llamacpp)
+        |> Enum.map(&to_atom_keys/1)
+
       opts = build_llamacpp_opts(merged_settings)
 
-      case LlamaCppEx.stream_chat_completion(llamacpp_model, provider_messages, opts) do
+      stream_result = LlamaCppEx.stream_chat_completion(llamacpp_model, provider_messages, opts)
+
+      # LlamaCppEx may return {:ok, stream} or the stream directly
+      stream_result =
+        case stream_result do
+          {:ok, _} -> stream_result
+          {:error, _} -> stream_result
+          stream -> {:ok, stream}
+        end
+
+      case stream_result do
         {:ok, stream} ->
           duration = System.monotonic_time() - start_time
 
@@ -180,6 +198,19 @@ if Code.ensure_loaded?(LlamaCppEx) do
       end
     end
 
+    # Override macro-injected private functions that would otherwise be dead code
+    # (since we override request/3 and request_stream/3 which are their only callers)
+    defp default_stream_normalizer, do: Nous.StreamNormalizer.LlamaCpp
+    defp build_request_params(_model, _messages, _settings), do: %{}
+
+    # Convert string-keyed maps from to_openai_format to atom-keyed maps for LlamaCppEx
+    defp to_atom_keys(map) when is_map(map) do
+      Map.new(map, fn
+        {k, v} when is_binary(k) -> {String.to_atom(k), v}
+        {k, v} -> {k, v}
+      end)
+    end
+
     # Build LlamaCppEx options from Nous settings
     defp build_llamacpp_opts(settings) do
       opts = []
@@ -206,15 +237,19 @@ if Code.ensure_loaded?(LlamaCppEx) do
     defp completion_to_map(completion) do
       choices =
         Enum.map(completion.choices, fn choice ->
+          msg = choice.message || %{}
+
           message = %{
-            "role" => to_string(choice.message.role),
-            "content" => choice.message.content
+            "role" => to_string(Map.get(msg, :role, "assistant")),
+            "content" => Map.get(msg, :content)
           }
 
+          tool_calls = Map.get(msg, :tool_calls)
+
           message =
-            if choice.message.tool_calls && choice.message.tool_calls != [] do
-              tool_calls =
-                Enum.map(choice.message.tool_calls, fn tc ->
+            if tool_calls && tool_calls != [] do
+              converted =
+                Enum.map(tool_calls, fn tc ->
                   %{
                     "id" => tc.id,
                     "type" => "function",
@@ -225,29 +260,31 @@ if Code.ensure_loaded?(LlamaCppEx) do
                   }
                 end)
 
-              Map.put(message, "tool_calls", tool_calls)
+              Map.put(message, "tool_calls", converted)
             else
               message
             end
 
           %{
-            "index" => choice.index,
+            "index" => Map.get(choice, :index, 0),
             "message" => message,
-            "finish_reason" => choice.finish_reason
+            "finish_reason" => Map.get(choice, :finish_reason)
           }
         end)
 
+      usage_data = Map.get(completion, :usage)
+
       usage =
-        if completion.usage do
+        if usage_data do
           %{
-            "prompt_tokens" => completion.usage.prompt_tokens,
-            "completion_tokens" => completion.usage.completion_tokens,
-            "total_tokens" => completion.usage.total_tokens
+            "prompt_tokens" => Map.get(usage_data, :prompt_tokens),
+            "completion_tokens" => Map.get(usage_data, :completion_tokens),
+            "total_tokens" => Map.get(usage_data, :total_tokens)
           }
         end
 
       map = %{
-        "id" => completion.id,
+        "id" => Map.get(completion, :id),
         "object" => "chat.completion",
         "choices" => choices
       }
@@ -263,43 +300,47 @@ else
     **Not available** - add `{:llama_cpp_ex, "~> 0.5.0"}` to your mix.exs deps.
     """
 
-    use Nous.Provider,
-      id: :llamacpp,
-      default_base_url: "local",
-      default_env_key: "LLAMACPP_MODEL_PATH"
+    @behaviour Nous.Provider
 
-    @impl Nous.Provider
-    def chat(_params, _opts \\ []) do
-      {:error,
-       "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps."}
-    end
+    @not_available "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps."
 
-    @impl Nous.Provider
-    def chat_stream(_params, _opts \\ []) do
-      {:error,
-       "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps."}
-    end
+    @impl true
+    def provider_id, do: :llamacpp
 
-    @impl Nous.Provider
+    @impl true
+    def default_base_url, do: "local"
+
+    @impl true
+    def default_env_key, do: "LLAMACPP_MODEL_PATH"
+
+    @impl true
+    def chat(_params, _opts \\ []), do: {:error, @not_available}
+
+    @impl true
+    def chat_stream(_params, _opts \\ []), do: {:error, @not_available}
+
+    @impl true
     def request(_model, _messages, _settings) do
       {:error,
        Nous.Errors.ProviderError.exception(
          provider: :llamacpp,
-         message:
-           "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps.",
+         message: @not_available,
          details: :not_available
        )}
     end
 
-    @impl Nous.Provider
+    @impl true
     def request_stream(_model, _messages, _settings) do
       {:error,
        Nous.Errors.ProviderError.exception(
          provider: :llamacpp,
-         message:
-           "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps.",
+         message: @not_available,
          details: :not_available
        )}
     end
+
+    @impl true
+    def count_tokens(messages),
+      do: messages |> Enum.map(&(inspect(&1) |> String.length() |> div(4))) |> Enum.sum()
   end
 end

--- a/lib/nous/providers/llamacpp.ex
+++ b/lib/nous/providers/llamacpp.ex
@@ -28,6 +28,34 @@ if Code.ensure_loaded?(LlamaCppEx) do
     when creating the model or agent. It is stored in `default_settings`.
 
     No API key or base URL is needed since inference runs locally via NIFs.
+
+    ## Settings Mapping
+
+    Nous settings are mapped to LlamaCppEx options:
+
+    | Nous Setting | LlamaCppEx Option | Description |
+    |---|---|---|
+    | `:temperature` | `:temp` | Sampling temperature |
+    | `:max_tokens` | `:max_tokens` | Maximum tokens to generate |
+    | `:top_p` | `:top_p` | Nucleus sampling |
+    | `:json_schema` | `:json_schema` | Constrained JSON output |
+    | `:enable_thinking` | `:enable_thinking` | Enable/disable thinking tokens |
+
+    ## Thinking Models
+
+    Models like Qwen3 emit `<think>...</think>` tags by default. To disable:
+
+        agent = Nous.new("llamacpp:local",
+          llamacpp_model: llm,
+          model_settings: %{enable_thinking: false}
+        )
+
+    Or via `generate_text`:
+
+        {:ok, text} = Nous.generate_text("llamacpp:local", "Hello",
+          llamacpp_model: llm,
+          enable_thinking: false
+        )
     """
 
     use Nous.Provider,

--- a/lib/nous/providers/llamacpp.ex
+++ b/lib/nous/providers/llamacpp.ex
@@ -1,0 +1,305 @@
+if Code.ensure_loaded?(LlamaCppEx) do
+  defmodule Nous.Providers.LlamaCpp do
+    @moduledoc """
+    LlamaCpp NIF-based provider for local LLM inference.
+
+    Runs GGUF models directly in-process via `llama_cpp_ex` NIF bindings.
+    No HTTP server needed.
+
+    Requires optional dep: `{:llama_cpp_ex, "~> 0.5.0"}`
+
+    ## Usage
+
+        # Load model once at app start
+        :ok = LlamaCppEx.init()
+        {:ok, llm} = LlamaCppEx.load_model("model.gguf", n_gpu_layers: -1)
+
+        # Use with Nous
+        agent = Nous.new("llamacpp:local",
+          llamacpp_model: llm,
+          instructions: "You are helpful."
+        )
+
+        {:ok, result} = Nous.run(agent, "What is Elixir?")
+
+    ## Configuration
+
+    The `llamacpp_model` (the loaded model reference) must be passed via options
+    when creating the model or agent. It is stored in `default_settings`.
+
+    No API key or base URL is needed since inference runs locally via NIFs.
+    """
+
+    use Nous.Provider,
+      id: :llamacpp,
+      default_base_url: "local",
+      default_env_key: "LLAMACPP_MODEL_PATH"
+
+    require Logger
+
+    @impl Nous.Provider
+    def chat(_params, _opts \\ []) do
+      {:error, :use_request_api}
+    end
+
+    @impl Nous.Provider
+    def chat_stream(_params, _opts \\ []) do
+      {:error, :use_request_api}
+    end
+
+    @impl Nous.Provider
+    def request(model, messages, settings) do
+      start_time = System.monotonic_time()
+      merged_settings = Map.merge(model.default_settings, settings)
+
+      llamacpp_model = merged_settings[:llamacpp_model]
+
+      unless llamacpp_model do
+        raise ArgumentError,
+              "llamacpp provider requires :llamacpp_model option. " <>
+                "Pass it when creating the agent: Nous.new(\"llamacpp:local\", llamacpp_model: llm)"
+      end
+
+      :telemetry.execute(
+        [:nous, :provider, :request, :start],
+        %{system_time: System.system_time(), monotonic_time: start_time},
+        %{provider: :llamacpp, model_name: model.model, message_count: length(messages)}
+      )
+
+      provider_messages = Nous.Messages.to_provider_format(messages, :llamacpp)
+      opts = build_llamacpp_opts(merged_settings)
+
+      result =
+        case LlamaCppEx.chat_completion(llamacpp_model, provider_messages, opts) do
+          {:ok, completion} ->
+            response_map = completion_to_map(completion)
+            parsed = Nous.Messages.from_provider_response(response_map, :llamacpp)
+            {:ok, parsed}
+
+          {:error, error} ->
+            wrapped =
+              Nous.Errors.ProviderError.exception(
+                provider: :llamacpp,
+                message: "Request failed: #{inspect(error)}",
+                details: error
+              )
+
+            {:error, wrapped}
+        end
+
+      duration = System.monotonic_time() - start_time
+
+      case result do
+        {:ok, parsed_response} ->
+          usage =
+            case parsed_response.metadata do
+              %{usage: %Nous.Usage{} = u} -> u
+              %{usage: u} when is_map(u) -> u
+              _ -> %{}
+            end
+
+          :telemetry.execute(
+            [:nous, :provider, :request, :stop],
+            %{
+              duration: duration,
+              input_tokens: Map.get(usage, :input_tokens) || 0,
+              output_tokens: Map.get(usage, :output_tokens) || 0,
+              total_tokens: Map.get(usage, :total_tokens) || 0
+            },
+            %{
+              provider: :llamacpp,
+              model_name: model.model,
+              has_tool_calls: length(parsed_response.tool_calls) > 0
+            }
+          )
+
+        {:error, error} ->
+          :telemetry.execute(
+            [:nous, :provider, :request, :exception],
+            %{duration: duration},
+            %{provider: :llamacpp, model_name: model.model, kind: :error, reason: error}
+          )
+      end
+
+      result
+    end
+
+    @impl Nous.Provider
+    def request_stream(model, messages, settings) do
+      start_time = System.monotonic_time()
+      merged_settings = Map.merge(model.default_settings, settings)
+
+      llamacpp_model = merged_settings[:llamacpp_model]
+
+      unless llamacpp_model do
+        raise ArgumentError,
+              "llamacpp provider requires :llamacpp_model option. " <>
+                "Pass it when creating the agent: Nous.new(\"llamacpp:local\", llamacpp_model: llm)"
+      end
+
+      :telemetry.execute(
+        [:nous, :provider, :stream, :start],
+        %{system_time: System.system_time(), monotonic_time: start_time},
+        %{provider: :llamacpp, model_name: model.model, message_count: length(messages)}
+      )
+
+      provider_messages = Nous.Messages.to_provider_format(messages, :llamacpp)
+      opts = build_llamacpp_opts(merged_settings)
+
+      case LlamaCppEx.stream_chat_completion(llamacpp_model, provider_messages, opts) do
+        {:ok, stream} ->
+          duration = System.monotonic_time() - start_time
+
+          :telemetry.execute(
+            [:nous, :provider, :stream, :connected],
+            %{duration: duration},
+            %{provider: :llamacpp, model_name: model.model}
+          )
+
+          normalizer = model.stream_normalizer || Nous.StreamNormalizer.LlamaCpp
+          transformed_stream = Nous.StreamNormalizer.normalize(stream, normalizer)
+          {:ok, transformed_stream}
+
+        {:error, error} ->
+          duration = System.monotonic_time() - start_time
+
+          :telemetry.execute(
+            [:nous, :provider, :stream, :exception],
+            %{duration: duration},
+            %{provider: :llamacpp, model_name: model.model, kind: :error, reason: error}
+          )
+
+          wrapped =
+            Nous.Errors.ProviderError.exception(
+              provider: :llamacpp,
+              message: "Streaming request failed: #{inspect(error)}",
+              details: error
+            )
+
+          {:error, wrapped}
+      end
+    end
+
+    # Build LlamaCppEx options from Nous settings
+    defp build_llamacpp_opts(settings) do
+      opts = []
+
+      opts = if settings[:temperature], do: [{:temp, settings[:temperature]} | opts], else: opts
+
+      opts =
+        if settings[:max_tokens], do: [{:max_tokens, settings[:max_tokens]} | opts], else: opts
+
+      opts = if settings[:top_p], do: [{:top_p, settings[:top_p]} | opts], else: opts
+
+      opts =
+        if settings[:json_schema], do: [{:json_schema, settings[:json_schema]} | opts], else: opts
+
+      opts =
+        if Map.has_key?(settings, :enable_thinking),
+          do: [{:enable_thinking, settings[:enable_thinking]} | opts],
+          else: opts
+
+      opts
+    end
+
+    # Convert a %ChatCompletion{} struct to a string-keyed map compatible with from_openai_response/1
+    defp completion_to_map(completion) do
+      choices =
+        Enum.map(completion.choices, fn choice ->
+          message = %{
+            "role" => to_string(choice.message.role),
+            "content" => choice.message.content
+          }
+
+          message =
+            if choice.message.tool_calls && choice.message.tool_calls != [] do
+              tool_calls =
+                Enum.map(choice.message.tool_calls, fn tc ->
+                  %{
+                    "id" => tc.id,
+                    "type" => "function",
+                    "function" => %{
+                      "name" => tc.function.name,
+                      "arguments" => tc.function.arguments
+                    }
+                  }
+                end)
+
+              Map.put(message, "tool_calls", tool_calls)
+            else
+              message
+            end
+
+          %{
+            "index" => choice.index,
+            "message" => message,
+            "finish_reason" => choice.finish_reason
+          }
+        end)
+
+      usage =
+        if completion.usage do
+          %{
+            "prompt_tokens" => completion.usage.prompt_tokens,
+            "completion_tokens" => completion.usage.completion_tokens,
+            "total_tokens" => completion.usage.total_tokens
+          }
+        end
+
+      map = %{
+        "id" => completion.id,
+        "object" => "chat.completion",
+        "choices" => choices
+      }
+
+      if usage, do: Map.put(map, "usage", usage), else: map
+    end
+  end
+else
+  defmodule Nous.Providers.LlamaCpp do
+    @moduledoc """
+    LlamaCpp NIF-based provider for local LLM inference.
+
+    **Not available** - add `{:llama_cpp_ex, "~> 0.5.0"}` to your mix.exs deps.
+    """
+
+    use Nous.Provider,
+      id: :llamacpp,
+      default_base_url: "local",
+      default_env_key: "LLAMACPP_MODEL_PATH"
+
+    @impl Nous.Provider
+    def chat(_params, _opts \\ []) do
+      {:error,
+       "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps."}
+    end
+
+    @impl Nous.Provider
+    def chat_stream(_params, _opts \\ []) do
+      {:error,
+       "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps."}
+    end
+
+    @impl Nous.Provider
+    def request(_model, _messages, _settings) do
+      {:error,
+       Nous.Errors.ProviderError.exception(
+         provider: :llamacpp,
+         message:
+           "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps.",
+         details: :not_available
+       )}
+    end
+
+    @impl Nous.Provider
+    def request_stream(_model, _messages, _settings) do
+      {:error,
+       Nous.Errors.ProviderError.exception(
+         provider: :llamacpp,
+         message:
+           "LlamaCppEx is not available. Add {:llama_cpp_ex, \"~> 0.5.0\"} to your mix.exs deps.",
+         details: :not_available
+       )}
+    end
+  end
+end

--- a/lib/nous/stream_normalizer/llamacpp.ex
+++ b/lib/nous/stream_normalizer/llamacpp.ex
@@ -1,0 +1,115 @@
+if Code.ensure_loaded?(LlamaCppEx) do
+  defmodule Nous.StreamNormalizer.LlamaCpp do
+    @moduledoc """
+    Stream normalizer for LlamaCppEx `%ChatCompletionChunk{}` structs.
+
+    Converts NIF-produced chunk structs into normalized Nous stream events.
+
+    Requires optional dep: `{:llama_cpp_ex, "~> 0.5.0"}`
+    """
+
+    @behaviour Nous.StreamNormalizer
+
+    @impl true
+    def normalize_chunk(chunk) when is_struct(chunk) do
+      choices = chunk.choices || []
+
+      case choices do
+        [choice | _] ->
+          delta = choice.delta
+          finish_reason = choice.finish_reason
+
+          cond do
+            delta && delta.content && delta.content != "" ->
+              [{:text_delta, delta.content}]
+
+            finish_reason ->
+              [{:finish, finish_reason}]
+
+            true ->
+              [{:unknown, chunk}]
+          end
+
+        _ ->
+          [{:unknown, chunk}]
+      end
+    end
+
+    # Fall back to OpenAI normalizer for plain map chunks
+    def normalize_chunk(chunk) when is_map(chunk) do
+      Nous.StreamNormalizer.OpenAI.normalize_chunk(chunk)
+    end
+
+    def normalize_chunk(chunk) do
+      [{:unknown, chunk}]
+    end
+
+    @impl true
+    def complete_response?(chunk) when is_struct(chunk) do
+      choices = chunk.choices || []
+
+      case choices do
+        [choice | _] ->
+          message = Map.get(choice, :message)
+          message != nil
+
+        _ ->
+          false
+      end
+    end
+
+    def complete_response?(chunk) when is_map(chunk) do
+      Nous.StreamNormalizer.OpenAI.complete_response?(chunk)
+    end
+
+    def complete_response?(_), do: false
+
+    @impl true
+    def convert_complete_response(chunk) when is_struct(chunk) do
+      choices = chunk.choices || []
+
+      case choices do
+        [choice | _] ->
+          message = choice.message
+          content = message && message.content
+          finish_reason = choice.finish_reason || "stop"
+
+          events = []
+
+          events =
+            if content && content != "", do: [{:text_delta, content} | events], else: events
+
+          events = [{:finish, finish_reason} | events]
+          Enum.reverse(events)
+
+        _ ->
+          [{:unknown, chunk}]
+      end
+    end
+
+    def convert_complete_response(chunk) when is_map(chunk) do
+      Nous.StreamNormalizer.OpenAI.convert_complete_response(chunk)
+    end
+
+    def convert_complete_response(chunk), do: [{:unknown, chunk}]
+  end
+else
+  defmodule Nous.StreamNormalizer.LlamaCpp do
+    @moduledoc """
+    Stream normalizer for LlamaCppEx `%ChatCompletionChunk{}` structs.
+
+    **Not available** - add `{:llama_cpp_ex, "~> 0.5.0"}` to your mix.exs deps.
+    """
+
+    @behaviour Nous.StreamNormalizer
+
+    @impl true
+    def normalize_chunk(chunk), do: [{:unknown, chunk}]
+
+    @impl true
+    def complete_response?(_chunk), do: false
+
+    @impl true
+    def convert_complete_response(chunk), do: [{:unknown, chunk}]
+  end
+end

--- a/lib/nous/stream_normalizer/llamacpp.ex
+++ b/lib/nous/stream_normalizer/llamacpp.ex
@@ -11,17 +11,18 @@ if Code.ensure_loaded?(LlamaCppEx) do
     @behaviour Nous.StreamNormalizer
 
     @impl true
-    def normalize_chunk(chunk) when is_struct(chunk) do
-      choices = chunk.choices || []
+    def normalize_chunk(chunk) when is_struct(chunk) or is_map(chunk) do
+      choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
 
       case choices do
         [choice | _] ->
-          delta = choice.delta
-          finish_reason = choice.finish_reason
+          delta = Map.get(choice, :delta) || Map.get(choice, "delta")
+          finish_reason = Map.get(choice, :finish_reason) || Map.get(choice, "finish_reason")
+          content = delta && (Map.get(delta, :content) || Map.get(delta, "content"))
 
           cond do
-            delta && delta.content && delta.content != "" ->
-              [{:text_delta, delta.content}]
+            content && content != "" ->
+              [{:text_delta, content}]
 
             finish_reason ->
               [{:finish, finish_reason}]
@@ -35,22 +36,17 @@ if Code.ensure_loaded?(LlamaCppEx) do
       end
     end
 
-    # Fall back to OpenAI normalizer for plain map chunks
-    def normalize_chunk(chunk) when is_map(chunk) do
-      Nous.StreamNormalizer.OpenAI.normalize_chunk(chunk)
-    end
-
     def normalize_chunk(chunk) do
       [{:unknown, chunk}]
     end
 
     @impl true
-    def complete_response?(chunk) when is_struct(chunk) do
-      choices = chunk.choices || []
+    def complete_response?(chunk) when is_struct(chunk) or is_map(chunk) do
+      choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
 
       case choices do
         [choice | _] ->
-          message = Map.get(choice, :message)
+          message = Map.get(choice, :message) || Map.get(choice, "message")
           message != nil
 
         _ ->
@@ -58,21 +54,19 @@ if Code.ensure_loaded?(LlamaCppEx) do
       end
     end
 
-    def complete_response?(chunk) when is_map(chunk) do
-      Nous.StreamNormalizer.OpenAI.complete_response?(chunk)
-    end
-
     def complete_response?(_), do: false
 
     @impl true
-    def convert_complete_response(chunk) when is_struct(chunk) do
-      choices = chunk.choices || []
+    def convert_complete_response(chunk) when is_struct(chunk) or is_map(chunk) do
+      choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
 
       case choices do
         [choice | _] ->
-          message = choice.message
-          content = message && message.content
-          finish_reason = choice.finish_reason || "stop"
+          message = Map.get(choice, :message) || Map.get(choice, "message") || %{}
+          content = Map.get(message, :content) || Map.get(message, "content")
+
+          finish_reason =
+            Map.get(choice, :finish_reason) || Map.get(choice, "finish_reason") || "stop"
 
           events = []
 
@@ -83,15 +77,11 @@ if Code.ensure_loaded?(LlamaCppEx) do
           Enum.reverse(events)
 
         _ ->
-          [{:unknown, chunk}]
+          [{:finish, "stop"}]
       end
     end
 
-    def convert_complete_response(chunk) when is_map(chunk) do
-      Nous.StreamNormalizer.OpenAI.convert_complete_response(chunk)
-    end
-
-    def convert_complete_response(chunk), do: [{:unknown, chunk}]
+    def convert_complete_response(_chunk), do: [{:finish, "stop"}]
   end
 else
   defmodule Nous.StreamNormalizer.LlamaCpp do
@@ -104,12 +94,12 @@ else
     @behaviour Nous.StreamNormalizer
 
     @impl true
-    def normalize_chunk(chunk), do: [{:unknown, chunk}]
+    def normalize_chunk(_chunk), do: [{:finish, "not_available"}]
 
     @impl true
     def complete_response?(_chunk), do: false
 
     @impl true
-    def convert_complete_response(chunk), do: [{:unknown, chunk}]
+    def convert_complete_response(_chunk), do: [{:finish, "not_available"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.12.2"
+  @version "0.13.0"
   @source_url "https://github.com/nyo16/nous"
 
   def project do
@@ -57,6 +57,9 @@ defmodule Nous.MixProject do
       # {:zvec, "~> 0.2", optional: true},
       # {:exqlite, "~> 0.27", optional: true},
       # {:duckdbex, "~> 0.3", optional: true},
+
+      # Local LLM inference via llama.cpp NIFs (optional — add to your app's deps to unlock)
+      # {:llama_cpp_ex, "~> 0.5.0", optional: true},
 
       # Memory system embedding providers (all optional — add to your app's deps to unlock)
       # {:bumblebee, "~> 0.6", optional: true},
@@ -157,7 +160,9 @@ defmodule Nous.MixProject do
           Nous.Providers.OpenAI,
           Nous.Providers.OpenAICompatible,
           Nous.Providers.Anthropic,
-          Nous.Providers.LMStudio
+          Nous.Providers.LMStudio,
+          Nous.Providers.LlamaCpp,
+          Nous.StreamNormalizer.LlamaCpp
         ],
         "Tool System": [
           Nous.Tool,


### PR DESCRIPTION
Add llama_cpp_ex integration for running GGUF models directly in-process via NIF bindings. No HTTP server needed.

- New provider at lib/nous/providers/llamacpp.ex with Code.ensure_loaded? guard
- New stream normalizer for ChatCompletionChunk structs
- Model parsing extracts :llamacpp_model into default_settings
- Routes to OpenAI format for message conversion
- Full example at examples/providers/llamacpp.exs
- Bump version to 0.13.0