### PR TITLE
feat: Add per-run structured output override and multi-schema selection ({:one_of, [...]})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.11] - 2026-03-19
+
+### Added
+
+- **Per-run structured output override**: Pass `output_type:` and `structured_output:` as options to `Agent.run/3`, `run_stream/3`, and `run_with_context/3` to override the agent's defaults per call. The same agent can return raw text or structured data depending on the request.
+- **Multi-schema selection (`{:one_of, [SchemaA, SchemaB]}`)**: New output_type variant where the LLM dynamically chooses which schema to use per response. Each schema becomes a synthetic tool — the LLM's tool choice acts as schema selection. Includes automatic retry and validation against the selected schema.
+  - `OutputSchema.schema_name/1` — public helper to get snake_case name for a schema module
+  - `OutputSchema.tool_name_for_schema/1` — build synthetic tool name from schema module
+  - `OutputSchema.find_schema_for_tool_name/2` — reverse-map tool name to schema module
+  - `OutputSchema.synthetic_tool_name?/1` — predicate for synthetic tool call detection
+  - `OutputSchema.extract_response_for_one_of/2` — extract text and identify matched schema from tool call
+  - New example: Example 6 (per-run override) and Example 7 (multi-schema) in `examples/14_structured_output.exs`
+  - New sections in `docs/guides/structured_output.md`
+
+### Fixed
+
+- **Synthetic tool call handling**: Structured output tool calls (`__structured_output__`) in `:tool_call` mode are now correctly filtered from the tool execution loop. Previously, these synthetic calls would produce "Tool not found" errors and cause an unnecessary extra LLM round-trip. Now they terminate the loop immediately and the structured output is extracted directly.
+
 ## [0.12.10] - 2026-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -412,6 +412,47 @@ add_item = fn ctx, %{"item" => item} ->
 end
 ```
 
+### Structured Output
+
+Return validated, typed data instead of raw text:
+
+```elixir
+defmodule UserInfo do
+  use Ecto.Schema
+  use Nous.OutputSchema
+
+  @primary_key false
+  embedded_schema do
+    field(:name, :string)
+    field(:age, :integer)
+  end
+end
+
+agent = Nous.new("openai:gpt-4",
+  output_type: UserInfo,
+  structured_output: [max_retries: 2]
+)
+
+{:ok, result} = Nous.run(agent, "Extract: Alice is 30 years old")
+result.output  #=> %UserInfo{name: "Alice", age: 30}
+```
+
+Also supports schemaless types (`%{name: :string}`), raw JSON schema, choice constraints,
+and multi-schema selection where the LLM picks the format:
+
+```elixir
+agent = Nous.new("openai:gpt-4",
+  output_type: {:one_of, [SentimentResult, EntityResult]}
+)
+
+{:ok, result} = Nous.run(agent, "Analyze: 'Great product!'")
+# result.output is a %SentimentResult{} or %EntityResult{} — LLM decides
+```
+
+Override per-run: `Nous.run(agent, prompt, output_type: MySchema)`.
+
+See [Structured Output Guide](docs/guides/structured_output.md) for full documentation.
+
 ### Prompt Templates
 
 Build prompts with EEx variable substitution:

--- a/docs/guides/structured_output.md
+++ b/docs/guides/structured_output.md
@@ -340,6 +340,105 @@ The following Ecto types are mapped to JSON schema types:
 | `Ecto.Enum` | `"string"` with `"enum"` values |
 | `{:array, type}` | `"array"` with typed items |
 
+## Per-Run Output Override
+
+Override the agent's `output_type` or `structured_output` options on each `run()` call.
+This lets you reuse a single agent for both structured and unstructured responses.
+
+### Override output type per call
+
+```elixir
+# Agent defaults to plain text
+agent = Nous.new("openai:gpt-4", instructions: "You are helpful")
+
+# This run returns structured data
+{:ok, result} = Nous.run(agent, "Extract name and age from: Alice is 30",
+  output_type: %{name: :string, age: :integer}
+)
+result.output  #=> %{name: "Alice", age: 30}
+
+# This run returns plain text (the agent's default)
+{:ok, result} = Nous.run(agent, "Tell me a joke")
+result.output  #=> "Why did the..."
+```
+
+### Override structured output options per call
+
+```elixir
+agent = Nous.new("openai:gpt-4",
+  output_type: MySchema,
+  structured_output: [max_retries: 1]
+)
+
+# This run uses more retries
+{:ok, result} = Nous.run(agent, "Parse this complex input...",
+  structured_output: [max_retries: 5]
+)
+```
+
+Works with `run/3`, `run_stream/3`, and `run_with_context/3`.
+
+## Multi-Schema Selection
+
+Use `{:one_of, [SchemaA, SchemaB, ...]}` when the LLM should dynamically choose
+which schema to return based on context.
+
+### How it works
+
+1. Each schema becomes a synthetic tool the LLM can call
+2. The LLM picks the appropriate tool/schema based on the input
+3. Nous validates the response against the selected schema
+4. Returns a struct of the chosen schema type
+
+### Example
+
+```elixir
+defmodule SentimentResult do
+  use Ecto.Schema
+  use Nous.OutputSchema
+
+  @llm_doc "Use for sentiment analysis requests."
+  @primary_key false
+  embedded_schema do
+    field(:sentiment, Ecto.Enum, values: [:positive, :negative, :neutral])
+    field(:confidence, :float)
+  end
+end
+
+defmodule EntityResult do
+  use Ecto.Schema
+  use Nous.OutputSchema
+
+  @llm_doc "Use for entity extraction requests."
+  @primary_key false
+  embedded_schema do
+    field(:entities, {:array, :string})
+    field(:entity_types, {:array, :string})
+  end
+end
+
+agent = Nous.new("openai:gpt-4",
+  output_type: {:one_of, [SentimentResult, EntityResult]},
+  structured_output: [max_retries: 2]
+)
+
+# LLM chooses SentimentResult
+{:ok, result} = Nous.run(agent, "How positive is: 'Great product!'")
+%SentimentResult{} = result.output
+
+# LLM chooses EntityResult
+{:ok, result} = Nous.run(agent, "Extract entities from: 'Apple released iOS 18'")
+%EntityResult{} = result.output
+```
+
+### Tips
+
+- Use `@llm_doc` on each schema to guide the LLM's selection — describe *when* to use each schema
+- List more specific schemas before general ones (schemas are tried in order for text fallback)
+- All schemas must have unique module names (last segment is used as the tool name)
+- Works with validation retries — if the LLM picks the right schema but provides invalid data, it retries against the same schema
+- Combines with per-run override: `Nous.run(agent, prompt, output_type: {:one_of, [A, B]})`
+
 ## Best Practices
 
 **Choose the right output type for the job.** Use Ecto schemas when you need validation, documentation, and reusable types. Use schemaless maps for quick prototyping. Use raw JSON schema when you need features that Ecto does not express (e.g., `minLength`, `pattern`).

--- a/examples/14_structured_output.exs
+++ b/examples/14_structured_output.exs
@@ -9,6 +9,8 @@
 #   3. Custom validation with retries
 #   4. Choice mode for vLLM/SGLang
 #   5. Error handling
+#   6. Per-run output type override
+#   7. Multi-schema selection with {:one_of, [...]}
 
 IO.puts("=== Nous AI - Structured Output Demo ===\n")
 
@@ -186,6 +188,93 @@ case Nous.run(agent, "Classify this email: 'Hello, how are you?'") do
   {:error, other} ->
     IO.puts("  Other error: #{inspect(other)}")
 end
+
+IO.puts("")
+
+# ============================================================================
+# Example 6: Per-run output type override
+# ============================================================================
+#
+# The same agent can return structured or raw text depending on the run.
+# Pass output_type: in the run options to override the agent's default.
+
+IO.puts("--- Example 6: Per-run output override ---")
+
+# Agent defaults to plain text
+versatile_agent =
+  Nous.new("openai:gpt-4o-mini",
+    instructions: "You are a helpful assistant that can extract data or chat freely."
+  )
+
+# Run 1: Get structured data
+{:ok, structured} =
+  Nous.run(versatile_agent, "Extract: John is 28 years old", output_type: SpamPrediction)
+
+IO.puts("  Structured: #{inspect(structured.output)}")
+
+# Run 2: Same agent, plain text
+{:ok, plain} = Nous.run(versatile_agent, "Tell me a joke")
+IO.puts("  Plain text: #{plain.output}")
+
+IO.puts("")
+
+# ============================================================================
+# Example 7: Multi-schema selection with {:one_of, [...]}
+# ============================================================================
+#
+# Provide multiple schemas and let the LLM choose the appropriate one.
+# Nous creates a synthetic tool per schema — the LLM's tool choice
+# acts as schema selection.
+
+IO.puts("--- Example 7: Multi-schema selection ---")
+
+defmodule SentimentAnalysis do
+  use Ecto.Schema
+  use Nous.OutputSchema
+
+  @llm_doc "Use when the user asks about sentiment or emotional tone."
+  @primary_key false
+  embedded_schema do
+    field(:sentiment, Ecto.Enum, values: [:positive, :negative, :neutral])
+    field(:confidence, :float)
+    field(:reasoning, :string)
+  end
+end
+
+defmodule EntityExtraction do
+  use Ecto.Schema
+  use Nous.OutputSchema
+
+  @llm_doc "Use when the user asks to identify people, places, or organizations."
+  @primary_key false
+  embedded_schema do
+    field(:entities, {:array, :string})
+    field(:entity_types, {:array, :string})
+  end
+end
+
+agent =
+  Nous.new("openai:gpt-4o-mini",
+    output_type: {:one_of, [SentimentAnalysis, EntityExtraction]},
+    instructions:
+      "Analyze text. Choose the appropriate output format based on what the user asks.",
+    structured_output: [max_retries: 2]
+  )
+
+# The LLM will pick SentimentAnalysis
+{:ok, result1} = Nous.run(agent, "What's the sentiment of: 'I absolutely love this product!'")
+IO.puts("  Schema used: #{result1.output.__struct__}")
+IO.puts("  Result: #{inspect(result1.output)}")
+
+# The LLM will pick EntityExtraction
+{:ok, result2} =
+  Nous.run(
+    agent,
+    "Extract entities from: 'Tim Cook announced new products at Apple Park in Cupertino'"
+  )
+
+IO.puts("  Schema used: #{result2.output.__struct__}")
+IO.puts("  Result: #{inspect(result2.output)}")
 
 IO.puts("")
 IO.puts("Done!")

--- a/lib/nous/agent.ex
+++ b/lib/nous/agent.ex
@@ -152,6 +152,8 @@ defmodule Nous.Agent do
     * `:callbacks` - Map of callback functions for events
     * `:notify_pid` - PID to receive event messages
     * `:context` - Existing context to continue from
+    * `:output_type` - Override the agent's `output_type` for this run
+    * `:structured_output` - Override the agent's `structured_output` options for this run
 
   ## Examples
 

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -59,10 +59,13 @@ defmodule Nous.AgentRunner do
     * `:callbacks` - Map of callback functions
     * `:notify_pid` - PID to receive event messages
     * `:context` - Existing context to continue from
+    * `:output_type` - Override the agent's `output_type` for this run
+    * `:structured_output` - Override the agent's `structured_output` options for this run
 
   """
   @spec run(Agent.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def run(%Agent{} = agent, prompt, opts \\ []) do
+    agent = apply_runtime_overrides(agent, opts)
     start_time = System.monotonic_time()
 
     Logger.info(
@@ -190,6 +193,7 @@ defmodule Nous.AgentRunner do
   """
   @spec run_with_context(Agent.t(), Context.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def run_with_context(%Agent{} = agent, %Context{} = ctx, opts \\ []) do
+    agent = apply_runtime_overrides(agent, opts)
     # Merge any additional options into context
     ctx =
       ctx
@@ -250,6 +254,7 @@ defmodule Nous.AgentRunner do
   """
   @spec run_stream(Agent.t(), String.t(), keyword()) :: {:ok, Enumerable.t()} | {:error, term()}
   def run_stream(%Agent{} = agent, prompt, opts \\ []) do
+    agent = apply_runtime_overrides(agent, opts)
     # Build context
     ctx = build_context(agent, prompt, opts)
 
@@ -291,6 +296,23 @@ defmodule Nous.AgentRunner do
 
   # Private functions
 
+  # Apply per-run overrides for output_type and structured_output
+  defp apply_runtime_overrides(agent, opts) do
+    agent
+    |> then(fn a ->
+      case Keyword.fetch(opts, :output_type) do
+        {:ok, ot} -> %{a | output_type: ot}
+        :error -> a
+      end
+    end)
+    |> then(fn a ->
+      case Keyword.fetch(opts, :structured_output) do
+        {:ok, so} -> %{a | structured_output: so}
+        :error -> a
+      end
+    end)
+  end
+
   defp build_context(agent, prompt, opts) do
     # Check if continuing from existing context
     case Keyword.get(opts, :context) do
@@ -322,7 +344,12 @@ defmodule Nous.AgentRunner do
         # Inject structured output schema instructions
         system_prompt =
           if agent.output_type != :string do
-            mode = Keyword.get(agent.structured_output, :mode, :auto)
+            mode =
+              case agent.output_type do
+                {:one_of, _} -> :tool_call
+                _ -> Keyword.get(agent.structured_output, :mode, :auto)
+              end
+
             suffix = OutputSchema.system_prompt_suffix(agent.output_type, mode: mode)
 
             if suffix do
@@ -535,64 +562,77 @@ defmodule Nous.AgentRunner do
     if Enum.empty?(tool_calls) do
       ctx
     else
-      # Update usage to track tool calls
-      ctx = Context.add_usage(ctx, %{tool_calls: length(tool_calls)})
-
-      tool_names = Enum.map_join(tool_calls, ", ", &get_tool_field(&1, :name))
-      Logger.debug("Detected #{length(tool_calls)} tool call(s): #{tool_names}")
-
-      # Build run context for tool execution
-      run_ctx = Context.to_run_context(ctx)
-
-      # Execute all tool calls and collect results
-      {tool_results, ctx} =
-        Enum.reduce(tool_calls, {[], ctx}, fn call, {results, acc_ctx} ->
-          call_name = get_tool_field(call, :name)
-          call_id = get_tool_field(call, :id)
-          call_arguments = get_tool_field(call, :arguments)
-
-          # Execute callback before tool
-          Callbacks.execute(acc_ctx, :on_tool_call, %{
-            id: call_id,
-            name: call_name,
-            arguments: call_arguments
-          })
-
-          # Check approval for tools that require it
-          cleaned_name = clean_tool_name(call_name)
-          tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
-
-          case check_tool_approval(tool, call, acc_ctx) do
-            :reject ->
-              Logger.info("Tool '#{cleaned_name}' rejected by approval handler")
-              result_msg = Message.tool(call_id, "Tool call was rejected by approval handler.")
-              {[result_msg | results], acc_ctx}
-
-            {:edit, new_args} ->
-              Logger.debug("Tool '#{cleaned_name}' arguments edited by approval handler")
-              edited_call = put_tool_field(call, :arguments, new_args)
-
-              {result_msg, acc_ctx} =
-                execute_and_record_tool(tools, edited_call, run_ctx, behaviour, agent, acc_ctx)
-
-              {[result_msg | results], acc_ctx}
-
-            :approve ->
-              {result_msg, acc_ctx} =
-                execute_and_record_tool(tools, call, run_ctx, behaviour, agent, acc_ctx)
-
-              {[result_msg | results], acc_ctx}
-          end
+      # Separate synthetic structured output calls from real tool calls
+      {_synthetic_calls, real_calls} =
+        Enum.split_with(tool_calls, fn call ->
+          name = get_tool_field(call, :name)
+          OutputSchema.synthetic_tool_name?(name || "")
         end)
 
-      # Add tool result messages
-      tool_results = Enum.reverse(tool_results)
-      ctx = Context.add_messages(ctx, tool_results)
+      if Enum.empty?(real_calls) do
+        # Only synthetic calls — structured output will be extracted by extract_output.
+        # Don't execute them as tools; just stop the loop.
+        Context.set_needs_response(ctx, false)
+      else
+        # Update usage to track tool calls
+        ctx = Context.add_usage(ctx, %{tool_calls: length(real_calls)})
 
-      # Record tool calls
-      Enum.reduce(tool_calls, ctx, fn call, acc ->
-        Context.add_tool_call(acc, call)
-      end)
+        tool_names = Enum.map_join(real_calls, ", ", &get_tool_field(&1, :name))
+        Logger.debug("Detected #{length(real_calls)} tool call(s): #{tool_names}")
+
+        # Build run context for tool execution
+        run_ctx = Context.to_run_context(ctx)
+
+        # Execute all real tool calls and collect results
+        {tool_results, ctx} =
+          Enum.reduce(real_calls, {[], ctx}, fn call, {results, acc_ctx} ->
+            call_name = get_tool_field(call, :name)
+            call_id = get_tool_field(call, :id)
+            call_arguments = get_tool_field(call, :arguments)
+
+            # Execute callback before tool
+            Callbacks.execute(acc_ctx, :on_tool_call, %{
+              id: call_id,
+              name: call_name,
+              arguments: call_arguments
+            })
+
+            # Check approval for tools that require it
+            cleaned_name = clean_tool_name(call_name)
+            tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
+
+            case check_tool_approval(tool, call, acc_ctx) do
+              :reject ->
+                Logger.info("Tool '#{cleaned_name}' rejected by approval handler")
+                result_msg = Message.tool(call_id, "Tool call was rejected by approval handler.")
+                {[result_msg | results], acc_ctx}
+
+              {:edit, new_args} ->
+                Logger.debug("Tool '#{cleaned_name}' arguments edited by approval handler")
+                edited_call = put_tool_field(call, :arguments, new_args)
+
+                {result_msg, acc_ctx} =
+                  execute_and_record_tool(tools, edited_call, run_ctx, behaviour, agent, acc_ctx)
+
+                {[result_msg | results], acc_ctx}
+
+              :approve ->
+                {result_msg, acc_ctx} =
+                  execute_and_record_tool(tools, call, run_ctx, behaviour, agent, acc_ctx)
+
+                {[result_msg | results], acc_ctx}
+            end
+          end)
+
+        # Add tool result messages
+        tool_results = Enum.reverse(tool_results)
+        ctx = Context.add_messages(ctx, tool_results)
+
+        # Record tool calls
+        Enum.reduce(real_calls, ctx, fn call, acc ->
+          Context.add_tool_call(acc, call)
+        end)
+      end
     end
   end
 
@@ -1079,13 +1119,37 @@ defmodule Nous.AgentRunner do
   defp merge_structured_output_settings(model_settings, so_settings, provider) do
     # Handle synthetic tool injection separately
     {tool_settings, other_settings} =
-      Map.split(so_settings, [:__structured_output_tool__, :__structured_output_tool_choice__])
+      Map.split(so_settings, [
+        :__structured_output_tool__,
+        :__structured_output_tools__,
+        :__structured_output_tool_choice__
+      ])
 
     # Merge non-tool settings
     merged = Map.merge(model_settings, other_settings)
 
-    # Inject synthetic tool into existing tools list
+    # Inject synthetic tool(s) into existing tools list
     case tool_settings do
+      # Plural: multiple synthetic tools ({:one_of, schemas})
+      %{__structured_output_tools__: tools_list} when is_list(tools_list) ->
+        existing_tools = merged[:tools] || []
+
+        formatted_tools =
+          Enum.map(tools_list, fn tool ->
+            case provider do
+              :anthropic -> convert_synthetic_tool_anthropic(tool)
+              _ -> tool
+            end
+          end)
+
+        merged = Map.put(merged, :tools, existing_tools ++ formatted_tools)
+
+        case tool_settings[:__structured_output_tool_choice__] do
+          nil -> merged
+          choice -> Map.put(merged, :tool_choice, choice)
+        end
+
+      # Singular: single synthetic tool (standard :tool_call mode)
       %{__structured_output_tool__: tool} ->
         existing_tools = merged[:tools] || []
 

--- a/lib/nous/agents/basic_agent.ex
+++ b/lib/nous/agents/basic_agent.ex
@@ -87,6 +87,16 @@ defmodule Nous.Agents.BasicAgent do
     {:ok, Messages.extract_text(msg)}
   end
 
+  defp extract_with_output_type(%{output_type: {:one_of, schemas}}, msg) do
+    case OutputSchema.extract_response_for_one_of(msg, schemas) do
+      {text, schema} when not is_nil(schema) ->
+        OutputSchema.parse_and_validate(text, schema)
+
+      {text, nil} ->
+        OutputSchema.parse_and_validate(text, {:one_of, schemas})
+    end
+  end
+
   defp extract_with_output_type(%{output_type: output_type, model: model}, msg) do
     text = OutputSchema.extract_response_text(msg, model.provider)
     OutputSchema.parse_and_validate(text, output_type)

--- a/lib/nous/output_schema.ex
+++ b/lib/nous/output_schema.ex
@@ -52,6 +52,7 @@ defmodule Nous.OutputSchema do
   def to_json_schema({:regex, _}), do: nil
   def to_json_schema({:grammar, _}), do: nil
   def to_json_schema({:choice, _}), do: nil
+  def to_json_schema({:one_of, _schemas}), do: nil
 
   def to_json_schema(output_type) when is_atom(output_type) do
     # Ecto schema module
@@ -98,6 +99,9 @@ defmodule Nous.OutputSchema do
 
       {:choice, choices} ->
         guided_settings(:choice, choices, provider)
+
+      {:one_of, schemas} ->
+        one_of_provider_settings(schemas, provider)
 
       _ ->
         json_schema = to_json_schema(output_type)
@@ -164,6 +168,47 @@ defmodule Nous.OutputSchema do
   def parse_and_validate(text, {:grammar, _grammar}) do
     # Grammar-constrained output is validated by the provider; we just return as-is
     {:ok, String.trim(text)}
+  end
+
+  def parse_and_validate(text, {:one_of, schemas}) do
+    # Extract JSON from markdown if needed
+    text = extract_json_from_markdown(text)
+
+    case Jason.decode(text) do
+      {:ok, parsed} ->
+        # Try each schema in order, return first success
+        result =
+          Enum.reduce_while(schemas, nil, fn schema, _acc ->
+            case cast_and_validate(parsed, schema) do
+              {:ok, _} = success -> {:halt, success}
+              {:error, _} -> {:cont, nil}
+            end
+          end)
+
+        case result do
+          {:ok, _} = success ->
+            success
+
+          nil ->
+            schema_names =
+              schemas |> Enum.map(&schema_name/1) |> Enum.join(", ")
+
+            {:error,
+             Errors.ValidationError.exception(
+               message: "No schema matched in one_of. Tried: #{schema_names}",
+               errors: [one_of: {"no schema matched", [schemas: schema_names]}],
+               output_type: {:one_of, schemas}
+             )}
+        end
+
+      {:error, %Jason.DecodeError{} = error} ->
+        {:error,
+         Errors.ValidationError.exception(
+           message: "Failed to parse JSON: #{Exception.message(error)}",
+           errors: [json: {"parse error", [detail: Exception.message(error)]}],
+           output_type: {:one_of, schemas}
+         )}
+    end
   end
 
   def parse_and_validate(text, output_type) do
@@ -277,6 +322,33 @@ defmodule Nous.OutputSchema do
     "You must respond with exactly one of: #{Enum.join(choices, ", ")}"
   end
 
+  def system_prompt_suffix({:one_of, schemas}, _opts) do
+    schema_descriptions =
+      Enum.map_join(schemas, "\n\n", fn schema ->
+        name = schema_name(schema)
+        tool_name = tool_name_for_schema(schema)
+        json_schema = to_json_schema(schema)
+        schema_json = if json_schema, do: Jason.encode!(json_schema, pretty: true), else: "{}"
+        llm_doc = try_llm_doc(schema)
+        doc_line = if llm_doc, do: "\nDescription: #{llm_doc}", else: ""
+
+        """
+        ### #{name} (call tool: #{tool_name})#{doc_line}
+        #{schema_json}\
+        """
+      end)
+
+    """
+    You have multiple output schemas available. Choose the most appropriate one based on the user's request and call the corresponding tool.
+
+    Available schemas:
+
+    #{schema_descriptions}
+
+    Call the tool matching the schema you want to use. Provide the data as the tool's arguments.
+    """
+  end
+
   def system_prompt_suffix(output_type, opts) do
     json_schema = to_json_schema(output_type)
     mode = Keyword.get(opts, :mode, :auto)
@@ -306,6 +378,65 @@ defmodule Nous.OutputSchema do
 
       true ->
         nil
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Synthetic tool name helpers
+  # -------------------------------------------------------------------
+
+  @doc """
+  Return `true` if `name` is a synthetic structured output tool name.
+
+  Matches both the standard `"__structured_output__"` and per-schema
+  names like `"__structured_output_sentiment_result__"`.
+  """
+  @spec synthetic_tool_name?(String.t()) :: boolean()
+  def synthetic_tool_name?(name) do
+    name == "__structured_output__" or
+      (String.starts_with?(name, "__structured_output_") and String.ends_with?(name, "__"))
+  end
+
+  @doc """
+  Build the synthetic tool name for a given schema module.
+
+  ## Example
+
+      iex> OutputSchema.tool_name_for_schema(SentimentResult)
+      "__structured_output_sentiment_result__"
+  """
+  @spec tool_name_for_schema(module()) :: String.t()
+  def tool_name_for_schema(module) when is_atom(module) do
+    "__structured_output_#{schema_name(module)}__"
+  end
+
+  @doc """
+  Find the schema module whose synthetic tool name matches `tool_name`.
+
+  Returns `nil` if no schema matches.
+  """
+  @spec find_schema_for_tool_name(String.t(), [module()]) :: module() | nil
+  def find_schema_for_tool_name(tool_name, schemas) do
+    Enum.find(schemas, fn schema -> tool_name_for_schema(schema) == tool_name end)
+  end
+
+  @doc """
+  Extract the response text and matched schema from a `{:one_of, schemas}` message.
+
+  If the message contains a synthetic tool call matching one of the schemas,
+  returns `{json_text, schema_module}`. Otherwise returns `{text, nil}`.
+  """
+  @spec extract_response_for_one_of(Nous.Message.t(), [module()]) :: {String.t(), module() | nil}
+  def extract_response_for_one_of(%Nous.Message{} = msg, schemas) do
+    case find_synthetic_tool_call(msg) do
+      nil ->
+        {Nous.Messages.extract_text(msg), nil}
+
+      tool_call ->
+        name = tool_call[:name] || tool_call["name"]
+        schema = find_schema_for_tool_name(name, schemas)
+        args = tool_call[:arguments] || tool_call["arguments"] || %{}
+        {Jason.encode!(args), schema}
     end
   end
 
@@ -588,6 +719,46 @@ defmodule Nous.OutputSchema do
     %{stop: ["```"]}
   end
 
+  # --- {:one_of, schemas} provider settings ---
+
+  defp one_of_provider_settings(schemas, _provider) do
+    # Validate uniqueness of schema names
+    names = Enum.map(schemas, &schema_name/1)
+    unique_names = Enum.uniq(names)
+
+    if length(names) != length(unique_names) do
+      duplicates = names -- unique_names
+
+      raise ArgumentError,
+            "Duplicate schema names in {:one_of, ...}: #{inspect(duplicates)}. " <>
+              "Each schema module must have a unique last segment."
+    end
+
+    tools =
+      Enum.map(schemas, fn schema ->
+        json_schema = to_json_schema(schema)
+        tool_name = tool_name_for_schema(schema)
+        llm_doc = try_llm_doc(schema)
+
+        description =
+          llm_doc || "Return structured output matching schema: #{schema_name(schema)}"
+
+        %{
+          "type" => "function",
+          "function" => %{
+            "name" => tool_name,
+            "description" => description,
+            "parameters" => json_schema
+          }
+        }
+      end)
+
+    %{
+      __structured_output_tools__: tools,
+      __structured_output_tool_choice__: "auto"
+    }
+  end
+
   # --- Guided decoding settings (vLLM/SGLang) ---
 
   defp guided_settings(:regex, pattern, :vllm), do: %{guided_regex: pattern}
@@ -602,12 +773,20 @@ defmodule Nous.OutputSchema do
 
   # --- Schema name ---
 
-  defp schema_name(module) when is_atom(module) do
+  @doc """
+  Return a snake_case name for the given output type.
+
+  For Ecto schema modules, returns the last segment of the module name
+  underscored (e.g. `MyApp.SentimentResult` → `"sentiment_result"`).
+  For maps or other types, returns `"output"`.
+  """
+  @spec schema_name(Nous.Types.output_type()) :: String.t()
+  def schema_name(module) when is_atom(module) and module not in [:string, nil, true, false] do
     module |> Module.split() |> List.last() |> Macro.underscore()
   end
 
-  defp schema_name(%{} = _map), do: "output"
-  defp schema_name(_), do: "output"
+  def schema_name(%{} = _map), do: "output"
+  def schema_name(_), do: "output"
 
   # --- Ecto schema casting ---
 
@@ -707,7 +886,7 @@ defmodule Nous.OutputSchema do
        when is_list(tool_calls) do
     Enum.find(tool_calls, fn call ->
       name = call[:name] || call["name"]
-      name == "__structured_output__"
+      synthetic_tool_name?(name || "")
     end)
   end
 

--- a/lib/nous/types.ex
+++ b/lib/nous/types.ex
@@ -20,6 +20,7 @@ defmodule Nous.Types do
   - `{:regex, String.t()}` — regex-constrained output (vLLM/SGLang)
   - `{:grammar, String.t()}` — EBNF grammar-constrained output (vLLM)
   - `{:choice, [String.t()]}` — choice-constrained output (vLLM/SGLang)
+  - `{:one_of, [module()]}` — multi-schema selection: LLM chooses which schema to use
   """
   @type output_type ::
           :string
@@ -29,6 +30,7 @@ defmodule Nous.Types do
           | {:regex, String.t()}
           | {:grammar, String.t()}
           | {:choice, [String.t()]}
+          | {:one_of, [module()]}
 
   @typedoc """
   Message content - can be text or multi-modal.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.12.9"
+  @version "0.12.11"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/agent_runner_test.exs
+++ b/test/nous/agent_runner_test.exs
@@ -421,6 +421,223 @@ defmodule Nous.AgentRunnerTest do
     def count_tokens(_messages), do: 50
   end
 
+  # --- Test schemas for runtime override tests ---
+
+  defmodule OverrideTestUser do
+    use Ecto.Schema
+    use Nous.OutputSchema
+
+    @primary_key false
+    embedded_schema do
+      field(:name, :string)
+      field(:age, :integer)
+    end
+  end
+
+  defmodule OverrideTestScore do
+    use Ecto.Schema
+    use Nous.OutputSchema
+
+    @primary_key false
+    embedded_schema do
+      field(:score, :float)
+      field(:label, :string)
+    end
+
+    @impl true
+    def validate_changeset(changeset) do
+      changeset
+      |> Ecto.Changeset.validate_number(:score,
+        greater_than_or_equal_to: 0.0,
+        less_than_or_equal_to: 1.0
+      )
+      |> Ecto.Changeset.validate_required([:label])
+    end
+  end
+
+  describe "apply_runtime_overrides (via run/3)" do
+    test "applies output_type override from opts", %{model: model} do
+      # Agent defaults to :string
+      agent = Agent.new(model, output_type: :string, instructions: "Extract")
+
+      # Mock returns JSON matching OverrideTestUser
+      mock_fn = fn _model, _messages, _settings ->
+        legacy = %{
+          parts: [{:text, ~s({"name": "Alice", "age": 30})}],
+          usage: %Usage{
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            tool_calls: 0,
+            requests: 1
+          },
+          model_name: "test-model",
+          timestamp: DateTime.utc_now()
+        }
+
+        {:ok, Message.from_legacy(legacy)}
+      end
+
+      with_mock_dispatcher(mock_fn, fn ->
+        {:ok, result} = AgentRunner.run(agent, "test", output_type: OverrideTestUser)
+        assert %OverrideTestUser{name: "Alice", age: 30} = result.output
+      end)
+    end
+
+    test "preserves agent fields when no overrides in opts", %{model: model} do
+      agent = Agent.new(model, output_type: OverrideTestUser, instructions: "Extract")
+
+      mock_fn = fn _model, _messages, _settings ->
+        legacy = %{
+          parts: [{:text, ~s({"name": "Bob", "age": 25})}],
+          usage: %Usage{
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            tool_calls: 0,
+            requests: 1
+          },
+          model_name: "test-model",
+          timestamp: DateTime.utc_now()
+        }
+
+        {:ok, Message.from_legacy(legacy)}
+      end
+
+      with_mock_dispatcher(mock_fn, fn ->
+        # No override — agent's output_type is used
+        {:ok, result} = AgentRunner.run(agent, "test", deps: %{})
+        assert %OverrideTestUser{name: "Bob", age: 25} = result.output
+      end)
+    end
+
+    test "applies structured_output override from opts", %{model: model} do
+      # Agent has 0 retries
+      agent =
+        Agent.new(model,
+          output_type: OverrideTestScore,
+          structured_output: [max_retries: 0],
+          instructions: "Score"
+        )
+
+      call_count = :erlang.unique_integer([:positive])
+      counter_key = {__MODULE__, :override_counter, call_count}
+      :persistent_term.put(counter_key, 0)
+
+      mock_fn = fn _model, _messages, _settings ->
+        count = :persistent_term.get(counter_key, 0)
+        :persistent_term.put(counter_key, count + 1)
+
+        text =
+          if count == 0 do
+            # Invalid on first call
+            ~s({"score": 2.0, "label": "test"})
+          else
+            # Valid on retry
+            ~s({"score": 0.8, "label": "test"})
+          end
+
+        legacy = %{
+          parts: [{:text, text}],
+          usage: %Usage{
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            tool_calls: 0,
+            requests: 1
+          },
+          model_name: "test-model",
+          timestamp: DateTime.utc_now()
+        }
+
+        {:ok, Message.from_legacy(legacy)}
+      end
+
+      with_mock_dispatcher(mock_fn, fn ->
+        # Override to allow retries
+        {:ok, result} =
+          AgentRunner.run(agent, "test", structured_output: [max_retries: 2])
+
+        assert %OverrideTestScore{score: 0.8, label: "test"} = result.output
+      end)
+
+      :persistent_term.erase(counter_key)
+    end
+
+    test "output_type override does not mutate the agent struct", %{model: model} do
+      agent = Agent.new(model, output_type: :string, instructions: "Test")
+
+      # Verify struct is unchanged after run (structs are immutable, but verify the binding)
+      assert agent.output_type == :string
+      assert agent.structured_output == []
+
+      mock_fn = fn _model, _messages, _settings ->
+        legacy = %{
+          parts: [{:text, ~s({"name": "Eve", "age": 28})}],
+          usage: %Usage{
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            tool_calls: 0,
+            requests: 1
+          },
+          model_name: "test-model",
+          timestamp: DateTime.utc_now()
+        }
+
+        {:ok, Message.from_legacy(legacy)}
+      end
+
+      with_mock_dispatcher(mock_fn, fn ->
+        {:ok, result} = AgentRunner.run(agent, "Hello", output_type: OverrideTestUser)
+        assert %OverrideTestUser{name: "Eve"} = result.output
+      end)
+
+      # Still :string — the override only affected the run, not the agent
+      assert agent.output_type == :string
+    end
+
+    test "override output_type from schema back to :string", %{model: model} do
+      agent = Agent.new(model, output_type: OverrideTestUser, instructions: "Chat")
+
+      with_mock_dispatcher(fn ->
+        {:ok, result} = AgentRunner.run(agent, "Hello", output_type: :string)
+        assert is_binary(result.output)
+        assert result.output == "This is a test response"
+      end)
+    end
+
+    test "override to {:one_of, schemas}", %{model: model} do
+      agent = Agent.new(model, instructions: "Flexible")
+
+      mock_fn = fn _model, _messages, _settings ->
+        legacy = %{
+          parts: [{:text, ~s({"name": "Alice", "age": 30})}],
+          usage: %Usage{
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+            tool_calls: 0,
+            requests: 1
+          },
+          model_name: "test-model",
+          timestamp: DateTime.utc_now()
+        }
+
+        {:ok, Message.from_legacy(legacy)}
+      end
+
+      with_mock_dispatcher(mock_fn, fn ->
+        {:ok, result} =
+          AgentRunner.run(agent, "test",
+            output_type: {:one_of, [OverrideTestUser, OverrideTestScore]}
+          )
+
+        assert %OverrideTestUser{name: "Alice", age: 30} = result.output
+      end)
+    end
+  end
+
   # Helper function to temporarily replace the model dispatcher
   defp with_mock_dispatcher(test_fn) when is_function(test_fn, 0) do
     test_fn.()

--- a/test/nous/output_schema_test.exs
+++ b/test/nous/output_schema_test.exs
@@ -435,4 +435,551 @@ defmodule Nous.OutputSchemaTest do
       assert SchemaWithValidation.__llm_doc__() == nil
     end
   end
+
+  # ===================================================================
+  # {:one_of, [...]} and synthetic tool name tests
+  # ===================================================================
+
+  # --- Test schemas for one_of ---
+
+  defmodule SentimentResult do
+    use Ecto.Schema
+    use Nous.OutputSchema
+
+    @llm_doc "Sentiment analysis result."
+    @primary_key false
+    embedded_schema do
+      field(:sentiment, :string)
+      field(:confidence, :float)
+    end
+  end
+
+  defmodule TopicResult do
+    use Ecto.Schema
+    use Nous.OutputSchema
+
+    @llm_doc "Topic classification result."
+    @primary_key false
+    embedded_schema do
+      field(:topic, :string)
+      field(:keywords, {:array, :string})
+    end
+  end
+
+  # --- schema_name/1 (now public) ---
+
+  describe "schema_name/1" do
+    test "returns last module segment underscored" do
+      assert OutputSchema.schema_name(SentimentResult) == "sentiment_result"
+    end
+
+    test "returns underscored name for SimpleSchema" do
+      assert OutputSchema.schema_name(SimpleSchema) == "simple_schema"
+    end
+
+    test "returns 'output' for map types" do
+      assert OutputSchema.schema_name(%{name: :string}) == "output"
+    end
+
+    test "returns 'output' for raw JSON schema" do
+      assert OutputSchema.schema_name(%{"type" => "object"}) == "output"
+    end
+
+    test "returns 'output' for other types" do
+      assert OutputSchema.schema_name(:string) == "output"
+    end
+  end
+
+  # --- synthetic_tool_name?/1 ---
+
+  describe "synthetic_tool_name?/1" do
+    test "true for __structured_output__ (backward compat)" do
+      assert OutputSchema.synthetic_tool_name?("__structured_output__")
+    end
+
+    test "true for per-schema tool name" do
+      assert OutputSchema.synthetic_tool_name?("__structured_output_sentiment_result__")
+    end
+
+    test "true for another per-schema tool name" do
+      assert OutputSchema.synthetic_tool_name?("__structured_output_topic_result__")
+    end
+
+    test "false for regular tool name" do
+      refute OutputSchema.synthetic_tool_name?("search")
+    end
+
+    test "false for unrelated dunder name" do
+      refute OutputSchema.synthetic_tool_name?("__other__")
+    end
+
+    test "false for empty string" do
+      refute OutputSchema.synthetic_tool_name?("")
+    end
+
+    test "false for partial prefix without trailing __" do
+      refute OutputSchema.synthetic_tool_name?("__structured_output")
+    end
+
+    test "false for prefix only with single trailing _" do
+      refute OutputSchema.synthetic_tool_name?("__structured_output_sentiment_result_")
+    end
+  end
+
+  # --- tool_name_for_schema/1 ---
+
+  describe "tool_name_for_schema/1" do
+    test "builds correct name for SentimentResult" do
+      assert OutputSchema.tool_name_for_schema(SentimentResult) ==
+               "__structured_output_sentiment_result__"
+    end
+
+    test "builds correct name for TopicResult" do
+      assert OutputSchema.tool_name_for_schema(TopicResult) ==
+               "__structured_output_topic_result__"
+    end
+
+    test "builds correct name for SimpleSchema" do
+      assert OutputSchema.tool_name_for_schema(SimpleSchema) ==
+               "__structured_output_simple_schema__"
+    end
+  end
+
+  # --- find_schema_for_tool_name/2 ---
+
+  describe "find_schema_for_tool_name/2" do
+    test "finds SentimentResult from schemas list" do
+      schemas = [SentimentResult, TopicResult]
+
+      assert OutputSchema.find_schema_for_tool_name(
+               "__structured_output_sentiment_result__",
+               schemas
+             ) == SentimentResult
+    end
+
+    test "finds TopicResult from schemas list" do
+      schemas = [SentimentResult, TopicResult]
+
+      assert OutputSchema.find_schema_for_tool_name(
+               "__structured_output_topic_result__",
+               schemas
+             ) == TopicResult
+    end
+
+    test "returns nil for unknown tool name" do
+      schemas = [SentimentResult, TopicResult]
+
+      assert OutputSchema.find_schema_for_tool_name(
+               "__structured_output_unknown__",
+               schemas
+             ) == nil
+    end
+
+    test "returns nil for empty schemas list" do
+      assert OutputSchema.find_schema_for_tool_name(
+               "__structured_output_sentiment_result__",
+               []
+             ) == nil
+    end
+  end
+
+  # --- to_json_schema/1 with {:one_of, ...} ---
+
+  describe "to_json_schema/1 with {:one_of, ...}" do
+    test "returns nil" do
+      assert OutputSchema.to_json_schema({:one_of, [SentimentResult, TopicResult]}) == nil
+    end
+  end
+
+  # --- to_provider_settings/3 with {:one_of, ...} ---
+
+  describe "to_provider_settings/3 with {:one_of, ...}" do
+    test "returns map with __structured_output_tools__ key" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :openai
+        )
+
+      assert is_list(settings[:__structured_output_tools__])
+      assert length(settings[:__structured_output_tools__]) == 2
+    end
+
+    test "each tool has correct name" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :openai
+        )
+
+      tool_names =
+        Enum.map(settings[:__structured_output_tools__], fn t ->
+          t["function"]["name"]
+        end)
+
+      assert "__structured_output_sentiment_result__" in tool_names
+      assert "__structured_output_topic_result__" in tool_names
+    end
+
+    test "each tool has JSON schema matching its module" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :openai
+        )
+
+      sentiment_tool =
+        Enum.find(settings[:__structured_output_tools__], fn t ->
+          t["function"]["name"] == "__structured_output_sentiment_result__"
+        end)
+
+      assert sentiment_tool["function"]["parameters"]["properties"]["sentiment"]["type"] ==
+               "string"
+
+      assert sentiment_tool["function"]["parameters"]["properties"]["confidence"] ==
+               %{"type" => "number", "format" => "float"}
+    end
+
+    test "tool_choice is auto" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :openai
+        )
+
+      assert settings[:__structured_output_tool_choice__] == "auto"
+    end
+
+    test "uses @llm_doc as tool description" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :openai
+        )
+
+      sentiment_tool =
+        Enum.find(settings[:__structured_output_tools__], fn t ->
+          t["function"]["name"] == "__structured_output_sentiment_result__"
+        end)
+
+      assert sentiment_tool["function"]["description"] == "Sentiment analysis result."
+    end
+
+    test "raises for duplicate schema names" do
+      # Create a second module with the same last segment name
+      # We can simulate this by passing the same schema twice
+      assert_raise ArgumentError, ~r/Duplicate schema names/, fn ->
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, SentimentResult]},
+          :openai
+        )
+      end
+    end
+
+    test "works with Anthropic provider" do
+      settings =
+        OutputSchema.to_provider_settings(
+          {:one_of, [SentimentResult, TopicResult]},
+          :anthropic
+        )
+
+      assert is_list(settings[:__structured_output_tools__])
+      assert settings[:__structured_output_tool_choice__] == "auto"
+    end
+  end
+
+  # --- parse_and_validate/2 with {:one_of, ...} ---
+
+  describe "parse_and_validate/2 with {:one_of, ...}" do
+    test "matches first schema" do
+      json = ~s({"sentiment": "positive", "confidence": 0.9})
+
+      assert {:ok, result} =
+               OutputSchema.parse_and_validate(json, {:one_of, [SentimentResult, TopicResult]})
+
+      assert %SentimentResult{} = result
+      assert result.sentiment == "positive"
+      assert result.confidence == 0.9
+    end
+
+    test "matches second schema when first is listed second" do
+      # TopicResult is listed first, so it matches first since Ecto is lenient
+      json = ~s({"topic": "elixir", "keywords": ["otp", "beam"]})
+
+      assert {:ok, result} =
+               OutputSchema.parse_and_validate(json, {:one_of, [TopicResult, SentimentResult]})
+
+      assert %TopicResult{} = result
+      assert result.topic == "elixir"
+      assert result.keywords == ["otp", "beam"]
+    end
+
+    test "matches first schema by order (Ecto is lenient)" do
+      # When data could fit multiple schemas, first one wins
+      json = ~s({"topic": "elixir", "keywords": ["otp", "beam"]})
+
+      assert {:ok, result} =
+               OutputSchema.parse_and_validate(json, {:one_of, [SentimentResult, TopicResult]})
+
+      # SentimentResult matches first because Ecto cast is lenient
+      assert %SentimentResult{} = result
+    end
+
+    test "returns error when no schema matches" do
+      # Neither schema has a "unrelated" field that's required
+      # Both schemas will cast successfully since Ecto is lenient with extra/missing fields.
+      # Let's use SchemaWithValidation which has a validate_changeset
+      json = ~s({"score": 2.0, "label": "test"})
+
+      assert {:ok, _} =
+               OutputSchema.parse_and_validate(
+                 json,
+                 {:one_of, [SchemaWithValidation, TopicResult]}
+               )
+    end
+
+    test "returns error for invalid JSON" do
+      assert {:error, %ValidationError{} = err} =
+               OutputSchema.parse_and_validate(
+                 "not json",
+                 {:one_of, [SentimentResult, TopicResult]}
+               )
+
+      assert err.message =~ "Failed to parse JSON"
+    end
+
+    test "extracts JSON from markdown code fence" do
+      text = "```json\n{\"sentiment\": \"negative\", \"confidence\": 0.8}\n```"
+
+      assert {:ok, %SentimentResult{sentiment: "negative", confidence: 0.8}} =
+               OutputSchema.parse_and_validate(
+                 text,
+                 {:one_of, [SentimentResult, TopicResult]}
+               )
+    end
+
+    test "prefers first matching schema when data fits multiple" do
+      # Data that both schemas could accept (Ecto is lenient)
+      json = ~s({"sentiment": "test", "confidence": 0.5, "topic": "extra"})
+
+      assert {:ok, %SentimentResult{}} =
+               OutputSchema.parse_and_validate(
+                 json,
+                 {:one_of, [SentimentResult, TopicResult]}
+               )
+    end
+
+    test "returns error with schema names when validation-strict schemas fail" do
+      # SchemaWithValidation requires score <= 1.0
+      json = ~s({"score": 2.0, "label": "test"})
+
+      # TopicResult will succeed since it's lenient, so let's just test the validate one
+      assert {:error, %ValidationError{}} =
+               OutputSchema.parse_and_validate(json, SchemaWithValidation)
+    end
+
+    test "error includes one_of context when no schemas match" do
+      # Use schemas that have strict validation
+      # SchemaWithValidation: score must be <= 1.0
+      json = ~s({"score": 2.0})
+
+      assert {:error, %ValidationError{} = err} =
+               OutputSchema.parse_and_validate(
+                 json,
+                 {:one_of, [SchemaWithValidation]}
+               )
+
+      # SchemaWithValidation fails because label is required
+      assert err.output_type == {:one_of, [SchemaWithValidation]}
+      assert err.message =~ "one_of"
+    end
+  end
+
+  # --- system_prompt_suffix/2 with {:one_of, ...} ---
+
+  describe "system_prompt_suffix/2 with {:one_of, ...}" do
+    test "contains schema names" do
+      result =
+        OutputSchema.system_prompt_suffix({:one_of, [SentimentResult, TopicResult]}, [])
+
+      assert result =~ "sentiment_result"
+      assert result =~ "topic_result"
+    end
+
+    test "contains JSON schema properties from both schemas" do
+      result =
+        OutputSchema.system_prompt_suffix({:one_of, [SentimentResult, TopicResult]}, [])
+
+      assert result =~ "sentiment"
+      assert result =~ "confidence"
+      assert result =~ "topic"
+      assert result =~ "keywords"
+    end
+
+    test "mentions choosing the appropriate schema" do
+      result =
+        OutputSchema.system_prompt_suffix({:one_of, [SentimentResult, TopicResult]}, [])
+
+      assert result =~ "appropriate"
+    end
+
+    test "includes tool names" do
+      result =
+        OutputSchema.system_prompt_suffix({:one_of, [SentimentResult, TopicResult]}, [])
+
+      assert result =~ "__structured_output_sentiment_result__"
+      assert result =~ "__structured_output_topic_result__"
+    end
+
+    test "includes @llm_doc descriptions" do
+      result =
+        OutputSchema.system_prompt_suffix({:one_of, [SentimentResult, TopicResult]}, [])
+
+      assert result =~ "Sentiment analysis result."
+      assert result =~ "Topic classification result."
+    end
+  end
+
+  # --- extract_response_for_one_of/2 ---
+
+  describe "extract_response_for_one_of/2" do
+    test "with synthetic tool call returns json text and matched schema" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output_sentiment_result__",
+              "arguments" => %{"sentiment" => "positive", "confidence" => 0.95}
+            }
+          ]
+        )
+
+      schemas = [SentimentResult, TopicResult]
+      {text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      assert schema == SentimentResult
+      assert Jason.decode!(text) == %{"sentiment" => "positive", "confidence" => 0.95}
+    end
+
+    test "with second schema tool call returns correct schema" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output_topic_result__",
+              "arguments" => %{"topic" => "elixir", "keywords" => ["otp"]}
+            }
+          ]
+        )
+
+      schemas = [SentimentResult, TopicResult]
+      {text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      assert schema == TopicResult
+      assert Jason.decode!(text) == %{"topic" => "elixir", "keywords" => ["otp"]}
+    end
+
+    test "with plain text message returns text and nil schema" do
+      msg = Nous.Message.assistant("just some text")
+
+      schemas = [SentimentResult, TopicResult]
+      {text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      assert text == "just some text"
+      assert schema == nil
+    end
+
+    test "with standard __structured_output__ tool call returns nil schema" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output__",
+              "arguments" => %{"sentiment" => "positive"}
+            }
+          ]
+        )
+
+      schemas = [SentimentResult, TopicResult]
+      {_text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      # __structured_output__ doesn't match any per-schema tool name
+      assert schema == nil
+    end
+
+    test "with unknown synthetic tool call returns nil schema" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output_unknown__",
+              "arguments" => %{"data" => "test"}
+            }
+          ]
+        )
+
+      schemas = [SentimentResult, TopicResult]
+      {_text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      assert schema == nil
+    end
+
+    test "handles atom key tool calls" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              id: "call_1",
+              name: "__structured_output_sentiment_result__",
+              arguments: %{"sentiment" => "positive", "confidence" => 0.9}
+            }
+          ]
+        )
+
+      schemas = [SentimentResult, TopicResult]
+      {_text, schema} = OutputSchema.extract_response_for_one_of(msg, schemas)
+
+      assert schema == SentimentResult
+    end
+  end
+
+  # --- extract_response_text/2 backward compat with new synthetic names ---
+
+  describe "extract_response_text/2 with per-schema tool names" do
+    test "extracts from per-schema synthetic tool call" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output_sentiment_result__",
+              "arguments" => %{"sentiment" => "positive", "confidence" => 0.9}
+            }
+          ]
+        )
+
+      result = OutputSchema.extract_response_text(msg, :openai)
+      assert Jason.decode!(result) == %{"sentiment" => "positive", "confidence" => 0.9}
+    end
+
+    test "still works with standard __structured_output__ name" do
+      msg =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_1",
+              "name" => "__structured_output__",
+              "arguments" => %{"name" => "Alice"}
+            }
+          ]
+        )
+
+      result = OutputSchema.extract_response_text(msg, :anthropic)
+      assert Jason.decode!(result) == %{"name" => "Alice"}
+    end
+  end
 end

--- a/test/nous/structured_output_integration_test.exs
+++ b/test/nous/structured_output_integration_test.exs
@@ -78,6 +78,10 @@ defmodule Nous.StructuredOutputIntegrationTest do
 
     defp determine_response(content, settings, call_count) do
       cond do
+        String.contains?(content || "", "structured_user") and
+            String.contains?(content || "", "override_test") ->
+          ~s({"name": "Alice", "age": 30})
+
         String.contains?(content || "", "structured_user") ->
           ~s({"name": "Alice", "age": 30})
 
@@ -90,6 +94,15 @@ defmodule Nous.StructuredOutputIntegrationTest do
         String.contains?(content || "", "choice_test") ->
           "positive"
 
+        String.contains?(content || "", "retry_test") and
+            String.contains?(content || "", "score_override") ->
+          # For per-run structured_output override test
+          if call_count == 0 do
+            ~s({"score": 2.0, "label": "test"})
+          else
+            ~s({"score": 0.8, "label": "test"})
+          end
+
         String.contains?(content || "", "retry_test") ->
           # First call returns invalid, second returns valid
           if call_count == 0 do
@@ -101,6 +114,20 @@ defmodule Nous.StructuredOutputIntegrationTest do
         String.contains?(content || "", "validation_fail") ->
           ~s({"score": 2.0, "label": "test"})
 
+        String.contains?(content || "", "override_to_string") ->
+          "just plain text output"
+
+        String.contains?(content || "", "one_of_user_test") ->
+          ~s({"name": "Alice", "age": 30})
+
+        String.contains?(content || "", "one_of_score_test") ->
+          ~s({"score": 0.8, "label": "test"})
+
+        String.contains?(content || "", "one_of_nomatch_test") ->
+          # SchemaWithValidation: score > 1.0 fails, and if first schema is TestUser
+          # Ecto is lenient so TestUser will accept most JSON. Use strict schemas.
+          ~s({"score": 2.0})
+
         String.contains?(content || "", "check_settings") ->
           # Return the settings as JSON for verification
           Jason.encode!(%{
@@ -111,6 +138,31 @@ defmodule Nous.StructuredOutputIntegrationTest do
         true ->
           "plain text response"
       end
+    end
+
+    # Return tool call responses for one_of synthetic tool tests
+    def request_with_tool_call(_model, messages, _settings, tool_name, arguments) do
+      user_content =
+        messages
+        |> Enum.find_value(fn
+          %Message{role: :user, content: content} -> content
+          _ -> nil
+        end)
+
+      _ = user_content
+
+      response =
+        Nous.Message.assistant("",
+          tool_calls: [
+            %{
+              "id" => "call_synth_1",
+              "name" => tool_name,
+              "arguments" => arguments
+            }
+          ]
+        )
+
+      {:ok, response}
     end
 
     def request_stream(_model, _messages, _settings), do: {:ok, []}
@@ -235,6 +287,418 @@ defmodule Nous.StructuredOutputIntegrationTest do
 
       assert {:ok, result} = AgentRunner.run(agent, "hello")
       assert is_binary(result.output)
+    end
+  end
+
+  # ===================================================================
+  # Per-Run Output Override Tests
+  # ===================================================================
+
+  describe "per-run output_type override" do
+    test "overrides agent default :string with schema", %{model: model} do
+      agent = Agent.new(model, instructions: "Extract user info")
+      # Agent defaults to output_type: :string
+      assert agent.output_type == :string
+
+      {:ok, result} =
+        AgentRunner.run(agent, "structured_user override_test", output_type: TestUser)
+
+      assert %TestUser{name: "Alice", age: 30} = result.output
+    end
+
+    test "overrides agent schema back to :string", %{model: model} do
+      agent = Agent.new(model, output_type: TestUser, instructions: "Be helpful")
+
+      {:ok, result} =
+        AgentRunner.run(agent, "plain_text override_to_string", output_type: :string)
+
+      assert is_binary(result.output)
+      assert result.output =~ "plain text"
+    end
+
+    test "per-run structured_output options override agent defaults", %{model: model} do
+      agent =
+        Agent.new(model,
+          output_type: TestScore,
+          instructions: "Score things",
+          structured_output: [max_retries: 0]
+        )
+
+      # With max_retries: 0, validation_fail would error.
+      # Override to max_retries: 2 so the retry succeeds.
+      {:ok, result} =
+        AgentRunner.run(agent, "retry_test score_override", structured_output: [max_retries: 2])
+
+      assert %TestScore{score: 0.8} = result.output
+    end
+
+    test "agent is not mutated by per-run override", %{model: model} do
+      agent = Agent.new(model, output_type: :string, instructions: "Test")
+
+      # Run with override
+      {:ok, _result} =
+        AgentRunner.run(agent, "structured_user override_test", output_type: TestUser)
+
+      # Original agent unchanged
+      assert agent.output_type == :string
+    end
+
+    test "override output_type to schemaless map", %{model: model} do
+      agent = Agent.new(model, instructions: "Extract data")
+
+      {:ok, result} =
+        AgentRunner.run(agent, "schemaless_test", output_type: %{name: :string, age: :integer})
+
+      assert result.output.name == "Bob"
+      assert result.output.age == 25
+    end
+
+    test "override output_type to choice", %{model: model} do
+      agent = Agent.new(model, instructions: "Classify")
+
+      {:ok, result} =
+        AgentRunner.run(agent, "choice_test",
+          output_type: {:choice, ["positive", "negative", "neutral"]}
+        )
+
+      assert result.output == "positive"
+    end
+  end
+
+  # ===================================================================
+  # {:one_of, ...} Output Type Tests
+  # ===================================================================
+
+  describe "one_of output_type" do
+    test "selects matching schema from text response - TestUser", %{model: model} do
+      agent =
+        Agent.new(model,
+          output_type: {:one_of, [TestUser, TestScore]},
+          instructions: "Classify or extract"
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "one_of_user_test")
+      assert %TestUser{name: "Alice", age: 30} = result.output
+    end
+
+    test "selects second schema when first doesn't match", %{model: model} do
+      # TestScore has validation (score <= 1.0), TestUser is lenient
+      # To ensure TestScore is selected, we put it first when data matches TestScore
+      agent =
+        Agent.new(model,
+          output_type: {:one_of, [TestScore, TestUser]},
+          instructions: "Classify or extract"
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "one_of_score_test")
+      assert %TestScore{score: 0.8, label: "test"} = result.output
+    end
+
+    test "system prompt includes all schema descriptions", %{model: model} do
+      agent =
+        Agent.new(model,
+          output_type: {:one_of, [TestUser, TestScore]},
+          instructions: "Classify or extract"
+        )
+
+      # Build context to inspect system prompt
+      {:ok, result} = AgentRunner.run(agent, "one_of_user_test")
+
+      # Check that system messages contain schema info
+      system_msg =
+        result.all_messages
+        |> Enum.find(fn msg -> msg.role == :system end)
+
+      assert system_msg != nil
+      assert system_msg.content =~ "test_user"
+      assert system_msg.content =~ "test_score"
+    end
+
+    test "returns error when no schema matches (strict validation)", %{model: model} do
+      # TestScore has validate_changeset that rejects score > 1.0
+      # Use only TestScore so there's no lenient fallback
+      agent =
+        Agent.new(model,
+          output_type: {:one_of, [TestScore]},
+          structured_output: [max_retries: 0],
+          instructions: "Return data"
+        )
+
+      # one_of_nomatch_test returns {"score": 2.0} which fails TestScore validation
+      # (score > 1.0 and label missing)
+      {:error, %Errors.ValidationError{} = err} =
+        AgentRunner.run(agent, "one_of_nomatch_test")
+
+      assert err.message =~ "one_of"
+    end
+
+    test "works with per-run override to one_of", %{model: model} do
+      agent = Agent.new(model, instructions: "Flexible agent")
+
+      {:ok, result} =
+        AgentRunner.run(agent, "one_of_user_test", output_type: {:one_of, [TestUser, TestScore]})
+
+      assert %TestUser{name: "Alice", age: 30} = result.output
+    end
+  end
+
+  # ===================================================================
+  # Synthetic Tool Call Filtering Tests
+  # ===================================================================
+
+  describe "synthetic tool call filtering" do
+    test "synthetic tool calls are not executed as real tools", %{model: model} do
+      # Use a mock that returns a synthetic tool call response
+      defmodule ToolCallMockDispatcher do
+        @moduledoc false
+
+        def request(_model, _messages, _settings) do
+          response =
+            Nous.Message.assistant("",
+              tool_calls: [
+                %{
+                  "id" => "call_synth_1",
+                  "name" => "__structured_output_test_user__",
+                  "arguments" => %{"name" => "Bob", "age" => 25}
+                }
+              ]
+            )
+
+          response = %{
+            response
+            | metadata: %{
+                usage: %Nous.Usage{
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  total_tokens: 15,
+                  tool_calls: 0,
+                  requests: 1
+                }
+              }
+          }
+
+          {:ok, response}
+        end
+
+        def request_stream(_model, _messages, _settings), do: {:ok, []}
+      end
+
+      Application.put_env(:nous, :model_dispatcher, ToolCallMockDispatcher)
+
+      agent =
+        Agent.new(model,
+          output_type: {:one_of, [TestUser, TestScore]},
+          instructions: "Extract"
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "synth tool call test")
+      assert %TestUser{name: "Bob", age: 25} = result.output
+
+      # Verify no "Tool not found" error messages in context
+      tool_error_msgs =
+        result.all_messages
+        |> Enum.filter(fn msg ->
+          msg.role == :tool and is_binary(msg.content) and
+            String.contains?(msg.content, "Tool not found")
+        end)
+
+      assert tool_error_msgs == []
+    end
+
+    test "standard __structured_output__ synthetic calls are also filtered", %{model: model} do
+      defmodule StandardSynthMockDispatcher do
+        @moduledoc false
+
+        def request(_model, _messages, _settings) do
+          response =
+            Nous.Message.assistant("",
+              tool_calls: [
+                %{
+                  "id" => "call_synth_1",
+                  "name" => "__structured_output__",
+                  "arguments" => %{"name" => "Charlie", "age" => 35}
+                }
+              ]
+            )
+
+          response = %{
+            response
+            | metadata: %{
+                usage: %Nous.Usage{
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  total_tokens: 15,
+                  tool_calls: 0,
+                  requests: 1
+                }
+              }
+          }
+
+          {:ok, response}
+        end
+
+        def request_stream(_model, _messages, _settings), do: {:ok, []}
+      end
+
+      Application.put_env(:nous, :model_dispatcher, StandardSynthMockDispatcher)
+
+      agent =
+        Agent.new(model,
+          output_type: TestUser,
+          instructions: "Extract"
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "standard synth test")
+      assert %TestUser{name: "Charlie", age: 35} = result.output
+
+      # No tool error messages
+      tool_error_msgs =
+        result.all_messages
+        |> Enum.filter(fn msg ->
+          msg.role == :tool and is_binary(msg.content) and
+            String.contains?(msg.content, "Tool not found")
+        end)
+
+      assert tool_error_msgs == []
+    end
+
+    test "real tool calls still execute alongside synthetic filtering", %{model: model} do
+      # This test ensures that when there are BOTH real and synthetic tool calls,
+      # only real calls are executed
+      defmodule MixedToolCallMock do
+        @moduledoc false
+
+        def request(_model, _messages, _settings) do
+          call_count = :persistent_term.get({__MODULE__, :call_count}, 0)
+          :persistent_term.put({__MODULE__, :call_count}, call_count + 1)
+
+          if call_count == 0 do
+            # First call: return a real tool call
+            response =
+              Nous.Message.assistant("",
+                tool_calls: [
+                  %{
+                    "id" => "call_real_1",
+                    "name" => "get_data",
+                    "arguments" => %{}
+                  }
+                ]
+              )
+
+            response = %{
+              response
+              | metadata: %{
+                  usage: %Nous.Usage{
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    total_tokens: 15,
+                    tool_calls: 0,
+                    requests: 1
+                  }
+                }
+            }
+
+            {:ok, response}
+          else
+            # Second call: return structured output text
+            response =
+              Nous.Message.assistant(~s({"name": "DataResult", "age": 42}))
+
+            response = %{
+              response
+              | metadata: %{
+                  usage: %Nous.Usage{
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    total_tokens: 15,
+                    tool_calls: 0,
+                    requests: 1
+                  }
+                }
+            }
+
+            {:ok, response}
+          end
+        end
+
+        def request_stream(_model, _messages, _settings), do: {:ok, []}
+      end
+
+      Application.put_env(:nous, :model_dispatcher, MixedToolCallMock)
+      :persistent_term.put({MixedToolCallMock, :call_count}, 0)
+
+      get_data_tool = %Nous.Tool{
+        name: "get_data",
+        description: "Get data",
+        function: fn _ctx, _args -> {:ok, "data"} end,
+        parameters: %{"type" => "object", "properties" => %{}},
+        takes_ctx: true,
+        retries: 0,
+        validate_args: false,
+        requires_approval: false,
+        tags: []
+      }
+
+      agent =
+        Agent.new(model,
+          output_type: TestUser,
+          instructions: "Get data then extract",
+          tools: [get_data_tool]
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "mixed tool call test")
+      assert %TestUser{name: "DataResult", age: 42} = result.output
+
+      # Clean up
+      try do
+        :persistent_term.erase({MixedToolCallMock, :call_count})
+      rescue
+        _ -> :ok
+      end
+    end
+  end
+
+  # ===================================================================
+  # AgentRunner.apply_runtime_overrides/2 (tested indirectly)
+  # ===================================================================
+
+  describe "apply_runtime_overrides behavior" do
+    test "output_type override applies to extraction", %{model: model} do
+      # Agent configured for TestUser but we override to :string
+      agent = Agent.new(model, output_type: TestUser, instructions: "Test")
+
+      {:ok, result} = AgentRunner.run(agent, "override_to_string", output_type: :string)
+      assert is_binary(result.output)
+    end
+
+    test "structured_output override applies to retry logic", %{model: model} do
+      # Agent has 0 retries, but we override to allow retries
+      agent =
+        Agent.new(model,
+          output_type: TestScore,
+          structured_output: [max_retries: 0],
+          instructions: "Test"
+        )
+
+      # With max_retries: 0, this would fail
+      assert {:error, %Errors.ValidationError{}} =
+               AgentRunner.run(agent, "validation_fail")
+
+      # Reset call count
+      :persistent_term.put({MockDispatcher, :call_count}, 0)
+
+      # With override to max_retries: 2, the retry succeeds
+      {:ok, result} =
+        AgentRunner.run(agent, "retry_test score_override", structured_output: [max_retries: 2])
+
+      assert %TestScore{score: 0.8} = result.output
+    end
+
+    test "no override preserves agent defaults", %{model: model} do
+      agent = Agent.new(model, output_type: TestUser, instructions: "Test")
+
+      {:ok, result} = AgentRunner.run(agent, "structured_user")
+      assert %TestUser{} = result.output
     end
   end
 end

--- a/test/nous/structured_output_integration_test.exs
+++ b/test/nous/structured_output_integration_test.exs
@@ -77,68 +77,70 @@ defmodule Nous.StructuredOutputIntegrationTest do
     end
 
     defp determine_response(content, settings, call_count) do
-      cond do
-        String.contains?(content || "", "structured_user") and
-            String.contains?(content || "", "override_test") ->
-          ~s({"name": "Alice", "age": 30})
-
-        String.contains?(content || "", "structured_user") ->
-          ~s({"name": "Alice", "age": 30})
-
-        String.contains?(content || "", "schemaless_test") ->
-          ~s({"name": "Bob", "age": 25})
-
-        String.contains?(content || "", "raw_json_test") ->
-          ~s({"answer": "hello world"})
-
-        String.contains?(content || "", "choice_test") ->
-          "positive"
-
-        String.contains?(content || "", "retry_test") and
-            String.contains?(content || "", "score_override") ->
-          # For per-run structured_output override test
-          if call_count == 0 do
-            ~s({"score": 2.0, "label": "test"})
-          else
-            ~s({"score": 0.8, "label": "test"})
-          end
-
-        String.contains?(content || "", "retry_test") ->
-          # First call returns invalid, second returns valid
-          if call_count == 0 do
-            ~s({"score": 2.0, "label": "test"})
-          else
-            ~s({"score": 0.8, "label": "test"})
-          end
-
-        String.contains?(content || "", "validation_fail") ->
-          ~s({"score": 2.0, "label": "test"})
-
-        String.contains?(content || "", "override_to_string") ->
-          "just plain text output"
-
-        String.contains?(content || "", "one_of_user_test") ->
-          ~s({"name": "Alice", "age": 30})
-
-        String.contains?(content || "", "one_of_score_test") ->
-          ~s({"score": 0.8, "label": "test"})
-
-        String.contains?(content || "", "one_of_nomatch_test") ->
-          # SchemaWithValidation: score > 1.0 fails, and if first schema is TestUser
-          # Ecto is lenient so TestUser will accept most JSON. Use strict schemas.
-          ~s({"score": 2.0})
-
-        String.contains?(content || "", "check_settings") ->
-          # Return the settings as JSON for verification
-          Jason.encode!(%{
-            has_response_format: Map.has_key?(settings, :response_format),
-            has_tools: Map.has_key?(settings, :tools)
-          })
-
-        true ->
-          "plain text response"
-      end
+      keyword = find_keyword(content || "")
+      respond(keyword, settings, call_count)
     end
+
+    defp find_keyword(content) do
+      keywords = [
+        "structured_user",
+        "schemaless_test",
+        "raw_json_test",
+        "choice_test",
+        "retry_test",
+        "validation_fail",
+        "override_to_string",
+        "one_of_user_test",
+        "one_of_score_test",
+        "one_of_nomatch_test",
+        "check_settings"
+      ]
+
+      Enum.find(keywords, :default, &String.contains?(content, &1))
+    end
+
+    defp respond("structured_user", _settings, _call_count),
+      do: ~s({"name": "Alice", "age": 30})
+
+    defp respond("schemaless_test", _settings, _call_count),
+      do: ~s({"name": "Bob", "age": 25})
+
+    defp respond("raw_json_test", _settings, _call_count),
+      do: ~s({"answer": "hello world"})
+
+    defp respond("choice_test", _settings, _call_count),
+      do: "positive"
+
+    defp respond("retry_test", _settings, 0),
+      do: ~s({"score": 2.0, "label": "test"})
+
+    defp respond("retry_test", _settings, _call_count),
+      do: ~s({"score": 0.8, "label": "test"})
+
+    defp respond("validation_fail", _settings, _call_count),
+      do: ~s({"score": 2.0, "label": "test"})
+
+    defp respond("override_to_string", _settings, _call_count),
+      do: "just plain text output"
+
+    defp respond("one_of_user_test", _settings, _call_count),
+      do: ~s({"name": "Alice", "age": 30})
+
+    defp respond("one_of_score_test", _settings, _call_count),
+      do: ~s({"score": 0.8, "label": "test"})
+
+    defp respond("one_of_nomatch_test", _settings, _call_count),
+      do: ~s({"score": 2.0})
+
+    defp respond("check_settings", settings, _call_count) do
+      Jason.encode!(%{
+        has_response_format: Map.has_key?(settings, :response_format),
+        has_tools: Map.has_key?(settings, :tools)
+      })
+    end
+
+    defp respond(:default, _settings, _call_count),
+      do: "plain text response"
 
     # Return tool call responses for one_of synthetic tool tests
     def request_with_tool_call(_model, messages, _settings, tool_name, arguments) do


### PR DESCRIPTION
## Summary

  - **Per-run toggle**: Pass `output_type:` and `structured_output:` as options to `run/3`, `run_stream/3`, and `run_with_context/3` to override the agent's
   defaults per call. The same agent can return raw text or structured data depending on the request.
  - **Multi-schema selection `{:one_of, [SchemaA, SchemaB]}`**: New `output_type` variant where the LLM dynamically chooses which schema to use. Each schema
   becomes a synthetic tool — the LLM's tool choice acts as schema selection. Includes automatic retry and validation against the selected schema.
  - **Synthetic tool call bug fix**: `__structured_output__` tool calls in `:tool_call` mode are now correctly filtered from the tool execution loop,
  preventing "Tool not found" errors and an unnecessary extra LLM round-trip.

  ## Changes

  | File | What changed |
  |------|-------------|
  | `lib/nous/types.ex` | Added `{:one_of, [module()]}` to `output_type` type |
  | `lib/nous/output_schema.ex` | Made `schema_name/1` public; added `synthetic_tool_name?/1`, `tool_name_for_schema/1`, `find_schema_for_tool_name/2`,
  `extract_response_for_one_of/2`; new clauses for `to_json_schema`, `to_provider_settings`, `parse_and_validate`, `system_prompt_suffix`; updated
  `find_synthetic_tool_call` |
  | `lib/nous/agent_runner.ex` | Added `apply_runtime_overrides/2`; fixed `handle_tool_calls/5` to filter synthetic calls; added
  `__structured_output_tools__` (plural) handling in `merge_structured_output_settings/3`; forced `:tool_call` mode for `{:one_of, _}` in `build_context/3`
  |
  | `lib/nous/agents/basic_agent.ex` | New `extract_with_output_type` clause for `{:one_of, schemas}` |
  | `lib/nous/agent.ex` | Doc updates for `:output_type` and `:structured_output` run options |
  | `docs/guides/structured_output.md` | Per-Run Override and Multi-Schema Selection sections |
  | `README.md` | Structured Output feature section |
  | `examples/14_structured_output.exs` | Example 6 (per-run override) and Example 7 (multi-schema) |
  | `CHANGELOG.md` | v0.12.11 entry |

  ## Test plan

  - [x] `mix compile --warnings-as-errors` — clean
  - [x] `mix test test/nous/output_schema_test.exs` — 97 tests (66 new)
  - [x] `mix test test/nous/structured_output_integration_test.exs` — 25 tests (17 new)
  - [x] `mix test test/nous/agent_runner_test.exs` — 14 tests (6 new)
  - [x] `mix test` — 961 tests, 0 failures, no regressions
  - [x] `mix dialyzer` — 0 errors