### PR TITLE
feat: consolidate custom provider to `custom:` prefix with env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,99 @@ IO.puts("Tokens: #{result.usage.total_tokens}")
 | OpenRouter | `openrouter:anthropic/claude-3.5-sonnet` | ✅ |
 | Together AI | `together:meta-llama/Llama-3-70b-chat-hf` | ✅ |
 | LlamaCpp | `llamacpp:local` + `:llamacpp_model` | ✅ |
-| Custom | `openai_compatible:model` + `:base_url` | ✅ |
+| **Custom** | `custom:model` + `:base_url` | ✅ |
 
 All HTTP providers use pure Elixir HTTP clients (Req + Finch). LlamaCpp runs in-process via NIFs.
+
+> **Tip**: The `custom:` prefix works with **any** OpenAI-compatible endpoint—Groq, Together,
+> OpenRouter, local servers (vLLM, SGLang, LM Studio), or self-hosted endpoints. See
+> [Custom Providers](#custom-providers) for details.
+
+### Custom Providers
+
+Use the `custom:` prefix to connect to any OpenAI-compatible API endpoint:
+
+```elixir
+# Quick example with explicit options
+agent = Nous.new("custom:llama-3.1-70b",
+  base_url: "https://api.groq.com/openai/v1",
+  api_key: System.get_env("GROQ_API_KEY")
+)
+{:ok, result} = Nous.run(agent, "Hello!")
+```
+
+#### Configuration Methods
+
+Configuration is loaded in this precedence (higher overrides lower):
+
+1. **Direct options** (per-request):
+   ```elixir
+   Nous.new("custom:my-model",
+     base_url: "https://api.example.com/v1",
+     api_key: "sk-..."
+   )
+   ```
+
+2. **Environment variables**:
+   ```bash
+   export CUSTOM_BASE_URL="https://api.example.com/v1"
+   export CUSTOM_API_KEY="sk-..."
+   ```
+
+3. **Application config**:
+   ```elixir
+   config :nous, :custom,
+     base_url: "https://api.example.com/v1",
+     api_key: "sk-..."
+   ```
+
+#### Examples by Service
+
+**Groq** (fast inference):
+```elixir
+agent = Nous.new("custom:llama-3.1-70b",
+  base_url: "https://api.groq.com/openai/v1",
+  api_key: System.get_env("GROQ_API_KEY")
+)
+```
+
+**Together AI** (model variety):
+```elixir
+agent = Nous.new("custom:meta-llama/Llama-3-70b",
+  base_url: "https://api.together.xyz/v1",
+  api_key: System.get_env("TOGETHER_API_KEY")
+)
+```
+
+**OpenRouter** (unified API):
+```elixir
+agent = Nous.new("custom:anthropic/claude-3.5-sonnet",
+  base_url: "https://openrouter.ai/api/v1",
+  api_key: System.get_env("OPENROUTER_API_KEY")
+)
+```
+
+**Local Servers** (LM Studio, Ollama, vLLM, SGLang):
+```elixir
+# LM Studio (default: localhost:1234)
+agent = Nous.new("custom:qwen3", base_url: "http://localhost:1234/v1")
+
+# Ollama (default: localhost:11434)
+agent = Nous.new("custom:llama2", base_url: "http://localhost:11434/v1")
+
+# vLLM (default: localhost:8000)
+agent = Nous.new("custom:my-model", base_url: "http://localhost:8000/v1")
+
+# SGLang (default: localhost:30000)
+agent = Nous.new("custom:my-model", base_url: "http://localhost:30000/v1")
+
+# Or use environment variables
+# export CUSTOM_BASE_URL="http://localhost:1234/v1"
+agent = Nous.new("custom:qwen3")  # base_url read from env
+```
+
+> **Note**: The legacy `openai_compatible:` prefix still works for backward compatibility
+> but `custom:` is the recommended approach going forward.
 
 ```elixir
 # Switch providers with one line change

--- a/docs/guides/custom_providers.md
+++ b/docs/guides/custom_providers.md
@@ -1,0 +1,304 @@
+# Custom Providers Guide
+
+This guide covers using the `custom:` provider prefix to connect to any OpenAI-compatible API endpoint.
+
+## Overview
+
+The `custom:` provider is the recommended way to connect to LLM services that implement the OpenAI Chat Completions API. It works with:
+
+- Cloud providers: Groq, Together AI, OpenRouter, Anyscale, Fireworks, etc.
+- Local servers: LM Studio, Ollama, vLLM, SGLang, TGI, etc.
+- Self-hosted endpoints: Your own OpenAI-compatible API
+
+> **Note**: The legacy `openai_compatible:` prefix still works for backward compatibility, but `custom:` is the recommended approach.
+
+## Quick Start
+
+```elixir
+# Basic usage with explicit options
+agent = Nous.new("custom:llama-3.1-70b",
+  base_url: "https://api.groq.com/openai/v1",
+  api_key: System.get_env("GROQ_API_KEY")
+)
+
+{:ok, result} = Nous.run(agent, "What is Elixir?")
+```
+
+## Configuration Methods
+
+Configuration is loaded in precedence order (higher overrides lower):
+
+### 1. Direct Options (Per-Request)
+
+Pass options directly to `Nous.new/2`:
+
+```elixir
+agent = Nous.new("custom:my-model",
+  base_url: "https://api.example.com/v1",
+  api_key: "sk-...",
+  receive_timeout: 120_000
+)
+```
+
+### 2. Environment Variables
+
+Set environment variables for global defaults:
+
+```bash
+export CUSTOM_BASE_URL="https://api.example.com/v1"
+export CUSTOM_API_KEY="sk-..."
+```
+
+Then use without options:
+
+```elixir
+agent = Nous.new("custom:my-model")
+```
+
+### 3. Application Config
+
+Configure in `config/config.exs` or environment-specific config:
+
+```elixir
+config :nous, :custom,
+  base_url: "https://api.example.com/v1",
+  api_key: "sk-..."
+```
+
+## Examples by Service
+
+### Groq
+
+Fast inference with various open models:
+
+```elixir
+# Via explicit options
+agent = Nous.new("custom:llama-3.1-70b-versatile",
+  base_url: "https://api.groq.com/openai/v1",
+  api_key: System.get_env("GROQ_API_KEY")
+)
+
+# Or if using the built-in groq provider
+agent = Nous.new("groq:llama-3.1-70b-versatile")
+```
+
+### Together AI
+
+Wide model selection including Qwen, Llama, and more:
+
+```elixir
+agent = Nous.new("custom:meta-llama/Llama-3-70b-chat-hf",
+  base_url: "https://api.together.xyz/v1",
+  api_key: System.get_env("TOGETHER_API_KEY")
+)
+
+# Or use the built-in together provider
+agent = Nous.new("together:meta-llama/Llama-3-70b-chat-hf")
+```
+
+### OpenRouter
+
+Unified API for many providers:
+
+```elixir
+agent = Nous.new("custom:anthropic/claude-3.5-sonnet",
+  base_url: "https://openrouter.ai/api/v1",
+  api_key: System.get_env("OPENROUTER_API_KEY")
+)
+
+# Or use the built-in openrouter provider
+agent = Nous.new("openrouter:anthropic/claude-3.5-sonnet")
+```
+
+### LM Studio
+
+Local models with GUI (no API key needed):
+
+```elixir
+agent = Nous.new("custom:qwen3",
+  base_url: "http://localhost:1234/v1"
+)
+
+# Or use the built-in lmstudio provider (same default URL)
+agent = Nous.new("lmstudio:qwen3")
+```
+
+### Ollama
+
+Local CLI-based models (no API key needed):
+
+```elixir
+# Using custom with explicit base_url
+agent = Nous.new("custom:llama2",
+  base_url: "http://localhost:11434/v1"
+)
+
+# Or use the built-in ollama provider
+agent = Nous.new("ollama:llama2")
+```
+
+### vLLM
+
+High-performance local inference:
+
+```elixir
+# Using custom with explicit base_url
+agent = Nous.new("custom:meta-llama/Llama-3-8B-Instruct",
+  base_url: "http://localhost:8000/v1"
+)
+
+# Or use the built-in vllm provider
+agent = Nous.new("vllm:meta-llama/Llama-3-8B-Instruct",
+  base_url: "http://localhost:8000/v1"
+)
+```
+
+### SGLang
+
+Structured generation with RadixAttention:
+
+```elixir
+# Using custom with explicit base_url
+agent = Nous.new("custom:meta-llama/Llama-3-8B-Instruct",
+  base_url: "http://localhost:30000/v1"
+)
+
+# Or use the built-in sglang provider
+agent = Nous.new("sglang:meta-llama/Llama-3-8B-Instruct")
+```
+
+### Custom Self-Hosted Endpoints
+
+Point to your own OpenAI-compatible server:
+
+```elixir
+agent = Nous.new("custom:my-custom-model",
+  base_url: "https://llm.internal.company.com/v1",
+  api_key: System.get_env("INTERNAL_API_KEY")
+)
+```
+
+## Advanced Options
+
+### Custom Timeouts
+
+Slow local models may need longer timeouts:
+
+```elixir
+agent = Nous.new("custom:large-model",
+  base_url: "http://localhost:8000/v1",
+  receive_timeout: 300_000  # 5 minutes
+)
+```
+
+### Organization Headers
+
+Some providers support organization IDs:
+
+```elixir
+agent = Nous.new("custom:model",
+  base_url: "https://api.openai.com/v1",
+  api_key: System.get_env("OPENAI_API_KEY"),
+  organization: "org-..."
+)
+```
+
+### Using with Tools
+
+The custom provider supports function calling if the underlying model supports it:
+
+```elixir
+get_weather = fn _ctx, %{"city" => city} ->
+  %{temperature: 72, condition: "sunny"}
+end
+
+agent = Nous.new("custom:meta-llama/Llama-3-70b",
+  base_url: "https://api.together.xyz/v1",
+  api_key: System.get_env("TOGETHER_API_KEY"),
+  instructions: "You can check the weather.",
+  tools: [get_weather]
+)
+
+{:ok, result} = Nous.run(agent, "What's the weather in San Francisco?")
+```
+
+### Streaming
+
+Streaming works the same as any other provider:
+
+```elixir
+{:ok, stream} = Nous.run_stream(agent, "Write a haiku about Elixir")
+
+stream
+|> Enum.each(fn
+  {:text_delta, text} -> IO.write(text)
+  {:finish, _} -> IO.puts("")
+  _ -> :ok
+end)
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+Ensure the server is running and accessible:
+
+```bash
+# LM Studio - check server is enabled in settings
+# vLLM
+vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# SGLang
+python -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct
+
+# Ollama
+ollama run llama2
+ollama serve
+```
+
+### Authentication Errors
+
+Check your API key:
+
+```elixir
+# With explicit key
+agent = Nous.new("custom:model",
+  base_url: "...",
+  api_key: System.get_env("CORRECT_API_KEY")
+)
+
+# Or set env var
+System.put_env("CUSTOM_API_KEY", "your-key")
+```
+
+### Base URL Format
+
+Most servers expect the base URL to include `/v1`:
+
+```elixir
+# Correct
+base_url: "http://localhost:1234/v1"
+base_url: "https://api.groq.com/openai/v1"
+
+# Might not work
+base_url: "http://localhost:1234"           # missing /v1
+base_url: "http://localhost:1234/v1/chat"   # too specific
+```
+
+## Backward Compatibility
+
+The `openai_compatible:` prefix still works and is equivalent to `custom:`:
+
+```elixir
+# Legacy (still works)
+agent = Nous.new("openai_compatible:my-model", base_url: "...")
+
+# Recommended
+agent = Nous.new("custom:my-model", base_url: "...")
+```
+
+## See Also
+
+- `Nous.Providers.Custom` - The custom provider module
+- `Nous.Providers.OpenAICompatible` - Underlying implementation
+- [vLLM & SGLang examples](../../examples/providers/vllm_sglang.exs) - High-performance local inference

--- a/examples/providers/custom_providers.exs
+++ b/examples/providers/custom_providers.exs
@@ -1,0 +1,250 @@
+#!/usr/bin/env elixir
+
+# Nous AI - Custom Provider Examples
+# Demonstrates using the `custom:` prefix with various OpenAI-compatible endpoints
+
+IO.puts("=== Nous AI - Custom Provider Examples ===\n")
+
+# ============================================================================
+# Configuration Methods
+# ============================================================================
+
+IO.puts("""
+--- Configuration Precedence ---
+
+The custom provider loads configuration in this order (higher overrides lower):
+
+1. Direct options (Nous.new/2)
+2. Environment variables (CUSTOM_BASE_URL, CUSTOM_API_KEY)
+3. Application config (config :nous, :custom, ...)
+
+Examples below show all three methods.
+
+""")
+
+# ============================================================================
+# Example 1: Groq (Cloud Provider)
+# ============================================================================
+
+IO.puts("--- Example 1: Groq (with explicit options) ---")
+
+# Option 1: Explicit options
+agent =
+  Nous.new("custom:llama-3.1-70b-versatile",
+    base_url: "https://api.groq.com/openai/v1",
+    api_key: System.get_env("GROQ_API_KEY"),
+    instructions: "Be concise."
+  )
+
+# Note: This will fail without GROQ_API_KEY set
+if System.get_env("GROQ_API_KEY") do
+  case Nous.run(agent, "What is the BEAM VM? One sentence.") do
+    {:ok, result} ->
+      IO.puts("Response: #{result.output}")
+      IO.puts("Tokens: #{result.usage.total_tokens}")
+
+    {:error, error} ->
+      IO.puts("Error: #{inspect(error)}")
+  end
+else
+  IO.puts("(Skipped - set GROQ_API_KEY to run this example)")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Example 2: Together AI (Cloud Provider)
+# ============================================================================
+
+IO.puts("--- Example 2: Together AI (with explicit options) ---")
+
+if System.get_env("TOGETHER_API_KEY") do
+  agent =
+    Nous.new("custom:meta-llama/Llama-3-70b-chat-hf",
+      base_url: "https://api.together.xyz/v1",
+      api_key: System.get_env("TOGETHER_API_KEY"),
+      instructions: "Be helpful and concise."
+    )
+
+  case Nous.run(agent, "What language is Elixir built on?") do
+    {:ok, result} ->
+      IO.puts("Response: #{result.output}")
+      IO.puts("Tokens: #{result.usage.total_tokens}")
+
+    {:error, error} ->
+      IO.puts("Error: #{inspect(error)}")
+  end
+else
+  IO.puts("(Skipped - set TOGETHER_API_KEY to run this example)")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Example 3: Local Server (LM Studio)
+# ============================================================================
+
+IO.puts("--- Example 3: Local Server (LM Studio style) ---")
+IO.puts("Using custom: prefix with localhost:1234 (LM Studio default)")
+
+local_agent =
+  Nous.new("custom:qwen3",
+    base_url: "http://localhost:1234/v1",
+    instructions: "You are a helpful local assistant."
+  )
+
+case Nous.run(local_agent, "Hello from the custom provider!") do
+  {:ok, result} ->
+    IO.puts("Response: #{result.output}")
+
+  {:error, error} ->
+    IO.puts("Could not connect to local server (expected if none running)")
+    IO.puts("To test: Start LM Studio and load a model")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Example 4: Environment Variable Configuration
+# ============================================================================
+
+IO.puts("--- Example 4: Environment Variable Configuration ---")
+
+IO.puts("""
+Set these environment variables for global defaults:
+
+  export CUSTOM_BASE_URL="http://localhost:1234/v1"
+  export CUSTOM_API_KEY="not-needed"
+
+Then use without options:
+
+  agent = Nous.new("custom:my-model")
+""")
+
+# Demonstrate with explicit env vars
+original_base = System.get_env("CUSTOM_BASE_URL")
+original_key = System.get_env("CUSTOM_API_KEY")
+
+System.put_env("CUSTOM_BASE_URL", "http://localhost:1234/v1")
+System.put_env("CUSTOM_API_KEY", "not-needed")
+
+# Now create agent without base_url - it reads from env
+env_agent = Nous.new("custom:qwen3")
+IO.puts("Created agent with base_url from CUSTOM_BASE_URL env var")
+
+# Restore original values
+if original_base,
+  do: System.put_env("CUSTOM_BASE_URL", original_base),
+  else: System.delete_env("CUSTOM_BASE_URL")
+
+if original_key,
+  do: System.put_env("CUSTOM_API_KEY", original_key),
+  else: System.delete_env("CUSTOM_API_KEY")
+
+IO.puts("")
+
+# ============================================================================
+# Example 5: Streaming with Custom Provider
+# ============================================================================
+
+IO.puts("--- Example 5: Streaming with Custom Provider ---")
+
+streaming_agent =
+  Nous.new("custom:qwen3",
+    base_url: "http://localhost:1234/v1",
+    instructions: "Write a haiku."
+  )
+
+case Nous.run_stream(streaming_agent, "Write a haiku about coding") do
+  {:ok, stream} ->
+    IO.write("Response: ")
+
+    stream
+    |> Enum.each(fn
+      {:text_delta, text} -> IO.write(text)
+      {:finish, _} -> IO.puts("")
+      _ -> :ok
+    end)
+
+  {:error, _} ->
+    IO.puts("(Skipped - no local server running)")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Example 6: Tools with Custom Provider
+# ============================================================================
+
+IO.puts("--- Example 6: Tools with Custom Provider ---")
+
+get_weather = fn _ctx, %{"city" => city} ->
+  forecasts = %{
+    "San Francisco" => %{temp: 62, condition: "foggy"},
+    "Tokyo" => %{temp: 75, condition: "sunny"},
+    "London" => %{temp: 55, condition: "rainy"}
+  }
+
+  Map.get(forecasts, city, %{temp: 70, condition: "unknown"})
+end
+
+tool_agent =
+  Nous.new("custom:meta-llama/Llama-3-70b",
+    base_url: "https://api.together.xyz/v1",
+    api_key: System.get_env("TOGETHER_API_KEY"),
+    instructions: "Use tools when asked about weather.",
+    tools: [get_weather]
+  )
+
+if System.get_env("TOGETHER_API_KEY") do
+  case Nous.run(tool_agent, "What's the weather in Tokyo?") do
+    {:ok, result} ->
+      IO.puts("Response: #{result.output}")
+
+    {:error, error} ->
+      IO.puts("Error: #{inspect(error)}")
+  end
+else
+  IO.puts("(Skipped - set TOGETHER_API_KEY to run this example)")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Example 7: Backward Compatibility
+# ============================================================================
+
+IO.puts("--- Example 7: Backward Compatibility ---")
+
+IO.puts("""
+The legacy openai_compatible: prefix still works:
+
+  # Legacy (backward compatible)
+  Nous.new("openai_compatible:my-model", base_url: "...")
+
+  # Recommended approach
+  Nous.new("custom:my-model", base_url: "...")
+
+Both create a model with provider: :custom
+""")
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+IO.puts("""
+--- Summary ---
+
+The custom: provider supports:
+- Groq, Together AI, OpenRouter, and other cloud providers
+- Local servers: LM Studio, Ollama, vLLM, SGLang
+- Self-hosted OpenAI-compatible APIs
+
+Configuration methods (precedence):
+1. Direct options (Nous.new/2)
+2. Environment variables (CUSTOM_BASE_URL, CUSTOM_API_KEY)
+3. Application config (config :nous, :custom, ...)
+
+For more details, see the Custom Providers guide:
+  docs/guides/custom_providers.md
+""")

--- a/examples/providers/vllm_sglang.exs
+++ b/examples/providers/vllm_sglang.exs
@@ -318,6 +318,13 @@ Both vLLM and SGLang can serve behind a reverse proxy or on a remote host:
   )
 
   # Any OpenAI-compatible server (Together, Anyscale, etc.)
+  # Using the recommended custom: prefix
+  agent = Nous.new("custom:meta-llama/Llama-3.1-8B-Instruct",
+    base_url: "https://api.together.xyz/v1",
+    api_key: System.get_env("TOGETHER_API_KEY")
+  )
+
+  # Legacy openai_compatible: prefix still works (backward compatible)
   agent = Nous.new("openai_compatible:meta-llama/Llama-3.1-8B-Instruct",
     base_url: "https://api.together.xyz/v1",
     api_key: System.get_env("TOGETHER_API_KEY")
@@ -354,5 +361,6 @@ Both:
 Model name format:
   vllm:<org>/<model>       → http://localhost:8000/v1
   sglang:<org>/<model>     → http://localhost:30000/v1
-  openai_compatible:<model> → any OpenAI-compatible endpoint
+  custom:<model>           → any OpenAI-compatible endpoint (recommended)
+  openai_compatible:<model> → any OpenAI-compatible endpoint (legacy, still works)
 """)

--- a/lib/nous/model.ex
+++ b/lib/nous/model.ex
@@ -74,7 +74,10 @@ defmodule Nous.Model do
     * `"sglang:meta-llama/Llama-3-8B"` - SGLang server
     * `"openrouter:anthropic/claude-3.5-sonnet"` - OpenRouter
     * `"together:meta-llama/Llama-3-70b-chat-hf"` - Together AI
-    * `"custom:my-model"` - Custom endpoint (requires `:base_url` option)
+    * `"custom:my-model"` - Custom OpenAI-compatible endpoint (requires `:base_url` option)
+
+  > **Note**: The `"custom:"` prefix is the recommended approach for any OpenAI-compatible
+  > endpoint. The legacy `"openai_compatible:"` prefix still works for backward compatibility.
 
   ## Examples
 
@@ -89,6 +92,28 @@ defmodule Nous.Model do
       iex> model = Model.parse("custom:my-model", base_url: "http://localhost:8080/v1")
       iex> {model.provider, model.model, model.base_url}
       {:custom, "my-model", "http://localhost:8080/v1"}
+
+  ## Custom Providers with base_url
+
+  The `custom:` prefix works with any OpenAI-compatible endpoint:
+
+      # Groq
+      Model.parse("custom:llama-3.1-70b",
+        base_url: "https://api.groq.com/openai/v1",
+        api_key: System.get_env("GROQ_API_KEY")
+      )
+
+      # Together AI
+      Model.parse("custom:meta-llama/Llama-3-70b",
+        base_url: "https://api.together.xyz/v1",
+        api_key: System.get_env("TOGETHER_API_KEY")
+      )
+
+      # Local server (LM Studio, Ollama, etc.)
+      Model.parse("custom:qwen3", base_url: "http://localhost:1234/v1")
+
+  Also supports `CUSTOM_API_KEY` and `CUSTOM_BASE_URL` environment variables
+  as defaults (can be overridden per-call).
 
   """
   @spec parse(String.t(), keyword()) :: t()
@@ -137,10 +162,34 @@ defmodule Nous.Model do
   end
 
   def parse("custom:" <> model_name, opts) do
-    unless Keyword.has_key?(opts, :base_url) do
+    # Check for base_url in opts, env var, or application config
+    base_url =
+      Keyword.get(opts, :base_url) ||
+        System.get_env("CUSTOM_BASE_URL") ||
+        get_in(Application.get_env(:nous, :custom, []), [:base_url])
+
+    unless base_url do
       raise ArgumentError,
             "custom provider requires :base_url option. " <>
               "Example: parse(\"custom:my-model\", base_url: \"http://localhost:8080/v1\")"
+    end
+
+    new(:custom, model_name, opts)
+  end
+
+  # Backward compatibility: openai_compatible: is now custom:
+  # Note: The `custom:` prefix is the recommended approach going forward.
+  def parse("openai_compatible:" <> model_name, opts) do
+    # Check for base_url in opts, env var, or application config
+    base_url =
+      Keyword.get(opts, :base_url) ||
+        System.get_env("CUSTOM_BASE_URL") ||
+        get_in(Application.get_env(:nous, :custom, []), [:base_url])
+
+    unless base_url do
+      raise ArgumentError,
+            "openai_compatible provider requires :base_url option. " <>
+              "Example: parse(\"openai_compatible:my-model\", base_url: \"http://localhost:8080/v1\")"
     end
 
     new(:custom, model_name, opts)
@@ -219,7 +268,8 @@ defmodule Nous.Model do
   defp default_base_url(:vllm), do: nil
   defp default_base_url(:sglang), do: "http://localhost:30000/v1"
   defp default_base_url(:llamacpp), do: "local"
-  defp default_base_url(:custom), do: nil
+  # CUSTOM_BASE_URL env var takes precedence; explicit opts override this
+  defp default_base_url(:custom), do: System.get_env("CUSTOM_BASE_URL")
 
   @spec default_api_key(provider()) :: String.t() | nil
   defp default_api_key(:openai), do: Application.get_env(:nous, :openai_api_key)
@@ -238,7 +288,8 @@ defmodule Nous.Model do
   defp default_api_key(:sglang), do: nil
   # LlamaCpp runs locally via NIFs, no API key needed
   defp default_api_key(:llamacpp), do: nil
-  defp default_api_key(:custom), do: nil
+  # CUSTOM_API_KEY env var takes precedence; explicit opts override this
+  defp default_api_key(:custom), do: System.get_env("CUSTOM_API_KEY")
 
   # Default receive timeouts per provider
   # Local providers get longer timeouts since they're typically slower

--- a/lib/nous/model_dispatcher.ex
+++ b/lib/nous/model_dispatcher.ex
@@ -11,6 +11,7 @@ defmodule Nous.ModelDispatcher do
   - `:vllm` → `Nous.Providers.VLLM`
   - `:sglang` → `Nous.Providers.SGLang`
   - `:openai` → `Nous.Providers.OpenAI`
+  - `:custom` → `Nous.Providers.Custom`
   - Others → `Nous.Providers.OpenAICompatible`
   """
 
@@ -65,6 +66,11 @@ defmodule Nous.ModelDispatcher do
   def request(%Model{provider: :openai} = model, messages, settings) do
     Logger.debug("Routing to OpenAI provider for model: #{model.model}")
     Providers.OpenAI.request(model, messages, settings)
+  end
+
+  def request(%Model{provider: :custom} = model, messages, settings) do
+    Logger.debug("Routing to Custom provider for model: #{model.model}")
+    Providers.Custom.request(model, messages, settings)
   end
 
   def request(%Model{} = model, messages, settings) do
@@ -122,6 +128,11 @@ defmodule Nous.ModelDispatcher do
     Providers.OpenAI.request_stream(model, messages, settings)
   end
 
+  def request_stream(%Model{provider: :custom} = model, messages, settings) do
+    Logger.debug("Routing streaming request to Custom provider for model: #{model.model}")
+    Providers.Custom.request_stream(model, messages, settings)
+  end
+
   def request_stream(%Model{} = model, messages, settings) do
     Logger.debug(
       "Routing streaming request to OpenAI-compatible provider for: #{model.provider}:#{model.model}"
@@ -168,6 +179,10 @@ defmodule Nous.ModelDispatcher do
 
   def count_tokens(%Model{provider: :openai}, messages) do
     Providers.OpenAI.count_tokens(messages)
+  end
+
+  def count_tokens(%Model{provider: :custom}, messages) do
+    Providers.Custom.count_tokens(messages)
   end
 
   def count_tokens(%Model{}, messages) do

--- a/lib/nous/providers/custom.ex
+++ b/lib/nous/providers/custom.ex
@@ -1,0 +1,205 @@
+defmodule Nous.Providers.Custom do
+  @moduledoc """
+  Custom provider for any OpenAI-compatible endpoint.
+
+  The `custom:` provider is the recommended way to connect to any server
+  implementing the OpenAI Chat Completions API. It supports flexible configuration
+  via options, environment variables, or application config.
+
+  ## Configuration
+
+  The custom provider looks up configuration in the following precedence:
+
+  1. **Direct options** (highest priority):
+     ```elixir
+     Nous.new("custom:my-model",
+       base_url: "https://api.example.com/v1",
+       api_key: "sk-..."
+     )
+     ```
+
+  2. **Environment variables**:
+     ```bash
+     export CUSTOM_BASE_URL="https://api.example.com/v1"
+     export CUSTOM_API_KEY="sk-..."
+     ```
+
+  3. **Application config**:
+     ```elixir
+     # config/config.exs
+     config :nous, :custom,
+       base_url: "https://api.example.com/v1",
+       api_key: "sk-..."
+     ```
+
+  ## Options
+
+  | Option | Type | Default | Description |
+  |--------|------|---------|-------------|
+  | `base_url` | `String.t()` | From env/config | API endpoint URL (required if not in env) |
+  | `api_key` | `String.t()` | From env/config | Authentication token (optional for local servers) |
+  | `organization` | `String.t()` | `nil` | Organization ID (some providers) |
+  | `timeout` | `non_neg_integer()` | `120000` | Request timeout in milliseconds |
+
+  ## Examples
+
+  ### Groq
+
+  ```elixir
+  # Via environment variables:
+  # export CUSTOM_BASE_URL="https://api.groq.com/openai/v1"
+  # export CUSTOM_API_KEY="gsk_..."
+  agent = Nous.new("custom:llama-3.1-70b")
+
+  # With explicit options:
+  agent = Nous.new("custom:llama-3.1-70b",
+    base_url: "https://api.groq.com/openai/v1",
+    api_key: System.get_env("GROQ_API_KEY")
+  )
+  ```
+
+  ### Together AI
+
+  ```elixir
+  agent = Nous.new("custom:meta-llama/Llama-3-70b",
+    base_url: "https://api.together.xyz/v1",
+    api_key: System.get_env("TOGETHER_API_KEY")
+  )
+  ```
+
+  ### OpenRouter
+
+  ```elixir
+  agent = Nous.new("custom:anthropic/claude-3.5-sonnet",
+    base_url: "https://openrouter.ai/api/v1",
+    api_key: System.get_env("OPENROUTER_API_KEY")
+  )
+  ```
+
+  ### Local Servers (LM Studio, Ollama, etc.)
+
+  ```elixir
+  # LM Studio (no API key needed)
+  agent = Nous.new("custom:qwen3",
+    base_url: "http://localhost:1234/v1"
+  )
+
+  # Ollama (no API key needed)
+  agent = Nous.new("custom:llama2",
+    base_url: "http://localhost:11434/v1"
+  )
+  ```
+
+  ### Custom Base URL with Built-in Providers
+
+  You can also use `base_url` to point built-in providers to custom endpoints:
+
+  ```elixir
+  # Use OpenAI provider format with custom endpoint
+  agent = Nous.new("openai:gpt-4",
+    base_url: "https://my-proxy.example.com/v1"
+  )
+  ```
+
+  ## Backward Compatibility
+
+  The legacy `openai_compatible:` prefix still works and is equivalent to `custom:`:
+
+  ```elixir
+  # Legacy (still works)
+  agent = Nous.new("openai_compatible:my-model", base_url: "...")
+
+  # Recommended
+  agent = Nous.new("custom:my-model", base_url: "...")
+  ```
+
+  ## Direct Provider Usage
+
+  For low-level access without the agent:
+
+  ```elixir
+  {:ok, response} = Nous.Providers.Custom.chat(%{
+    "model" => "llama-3.1-70b",
+    "messages" => [%{"role" => "user", "content" => "Hello"}]
+  },
+    base_url: "https://api.groq.com/openai/v1",
+    api_key: System.get_env("GROQ_API_KEY")
+  )
+  ```
+
+  See `Nous.Providers.OpenAICompatible` for implementation details.
+  """
+
+  use Nous.Provider,
+    id: :custom,
+    default_base_url: "",
+    default_env_key: "CUSTOM_API_KEY"
+
+  alias Nous.Providers.HTTP
+
+  @default_timeout 120_000
+  @streaming_timeout 300_000
+
+  @impl Nous.Provider
+  def chat(params, opts \\ []) do
+    url = "#{get_base_url(opts)}/chat/completions"
+    headers = build_headers(api_key(opts), opts)
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    HTTP.post(url, params, headers, timeout: timeout)
+  end
+
+  @impl Nous.Provider
+  def chat_stream(params, opts \\ []) do
+    url = "#{get_base_url(opts)}/chat/completions"
+    headers = build_headers(api_key(opts), opts)
+    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+    finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
+
+    params = Map.put(params, "stream", true)
+
+    HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
+  end
+
+  # Get base URL from opts, env var, or config (required for custom provider)
+  defp get_base_url(opts) do
+    base =
+      Keyword.get(opts, :base_url) ||
+        System.get_env("CUSTOM_BASE_URL") ||
+        get_in(Application.get_env(:nous, :custom, []), [:base_url])
+
+    if is_nil(base) or base == "" do
+      raise ArgumentError, """
+      Custom provider requires a base_url.
+
+      Set one of:
+      1. Option: Nous.new("custom:model", base_url: "http://...")
+      2. Environment: export CUSTOM_BASE_URL="http://..."
+      3. Config: config :nous, :custom, base_url: "http://..."
+      """
+    end
+
+    base
+  end
+
+  # Build headers for the request
+  defp build_headers(api_key, opts) do
+    headers = [
+      {"content-type", "application/json"}
+    ]
+
+    # Add authorization if API key provided (skip for "not-needed" sentinel)
+    headers =
+      if api_key && api_key != "" && api_key != "not-needed" do
+        [{"authorization", "Bearer #{api_key}"} | headers]
+      else
+        headers
+      end
+
+    # Add organization header if provided
+    case Keyword.get(opts, :organization) do
+      nil -> headers
+      org -> [{"openai-organization", org} | headers]
+    end
+  end
+end

--- a/lib/nous/providers/openai_compatible.ex
+++ b/lib/nous/providers/openai_compatible.ex
@@ -2,6 +2,10 @@ defmodule Nous.Providers.OpenAICompatible do
   @moduledoc """
   Generic OpenAI-compatible provider implementation.
 
+  > **Note**: This module implements the underlying HTTP API for OpenAI-compatible
+  > endpoints. For normal usage, prefer the `custom:` model prefix which routes
+  > through `Nous.Providers.Custom` with better configuration support.
+
   Works with any server that implements the OpenAI Chat Completions API:
   - Groq (api.groq.com)
   - Together (api.together.xyz)
@@ -15,7 +19,81 @@ defmodule Nous.Providers.OpenAICompatible do
 
   For OpenAI-specific features (Responses API, Assistants, etc.), use `Nous.Providers.OpenAI`.
 
+  ## Configuration
+
+  Configuration is looked up in the following precedence (highest to lowest):
+
+  1. **Direct options** passed to functions or `Nous.new/2`:
+     ```elixir
+     Nous.new("custom:my-model",
+       base_url: "https://api.example.com/v1",
+       api_key: "sk-..."
+     )
+     ```
+
+  2. **Environment variables**:
+     ```bash
+     export CUSTOM_BASE_URL="https://api.example.com/v1"
+     export CUSTOM_API_KEY="sk-..."
+     ```
+
+  3. **Application config** (in `config/config.exs`):
+     ```elixir
+     config :nous, :custom,
+       base_url: "https://api.example.com/v1",
+       api_key: "sk-..."
+     ```
+
+  4. **Defaults** (used by this module directly):
+     - `base_url`: `"https://api.openai.com/v1"`
+     - `api_key`: From `OPENAI_API_KEY` env var
+
+  ## Options
+
+  | Option | Type | Default | Description |
+  |--------|------|---------|-------------|
+  | `base_url` | `String.t()` | `"https://api.openai.com/v1"` | API endpoint URL |
+  | `api_key` | `String.t()` | `nil` | Authentication token |
+  | `organization` | `String.t()` | `nil` | OpenAI organization ID |
+  | `timeout` | `non_neg_integer()` | `60000` | Request timeout (ms) |
+
   ## Usage
+
+  ### With the `custom:` prefix (Recommended)
+
+  Use this for any OpenAI-compatible endpoint:
+
+      # Groq
+      agent = Nous.new("custom:llama-3.1-70b",
+        base_url: "https://api.groq.com/openai/v1",
+        api_key: System.get_env("GROQ_API_KEY")
+      )
+
+      # Together AI
+      agent = Nous.new("custom:meta-llama/Llama-3-70b",
+        base_url: "https://api.together.xyz/v1",
+        api_key: System.get_env("TOGETHER_API_KEY")
+      )
+
+      # OpenRouter
+      agent = Nous.new("custom:anthropic/claude-3.5-sonnet",
+        base_url: "https://openrouter.ai/api/v1",
+        api_key: System.get_env("OPENROUTER_API_KEY")
+      )
+
+      # LM Studio (local)
+      agent = Nous.new("custom:qwen3",
+        base_url: "http://localhost:1234/v1"
+      )
+
+      # Using environment variables
+      # export CUSTOM_BASE_URL="http://localhost:1234/v1"
+      # export CUSTOM_API_KEY="not-needed"
+      agent = Nous.new("custom:my-model")
+
+  ### Direct Provider Usage (Low-level)
+
+  For direct API access without the agent:
 
       # Using with Groq
       {:ok, response} = Nous.Providers.OpenAICompatible.chat(
@@ -33,6 +111,18 @@ defmodule Nous.Providers.OpenAICompatible do
       # Streaming
       {:ok, stream} = Nous.Providers.OpenAICompatible.chat_stream(params, opts)
       Enum.each(stream, fn event -> IO.inspect(event) end)
+
+  ## Backward Compatibility
+
+  The legacy `openai_compatible:` prefix still works and is equivalent to `custom:`:
+
+      # Legacy (still works)
+      agent = Nous.new("openai_compatible:my-model", base_url: "...")
+
+      # Recommended
+      agent = Nous.new("custom:my-model", base_url: "...")
+
+  See `Nous.Providers.Custom` for the dedicated custom provider implementation.
   """
 
   use Nous.Provider,


### PR DESCRIPTION
## Summary

  This PR consolidates the custom OpenAI-compatible provider approach to use the `custom:` prefix as the recommended way, while maintaining backward compatibility with the legacy
  `openai_compatible:` prefix. It adds environment variable support and comprehensive documentation.

  ## Changes

  ### New Files
  - **`lib/nous/providers/custom.ex`** - New dedicated Custom provider module with:
    - `CUSTOM_API_KEY` and `CUSTOM_BASE_URL` environment variable support
    - Configuration precedence: options → env vars → config → defaults
    - Comprehensive moduledoc with examples

  - **`docs/guides/custom_providers.md`** - Complete guide covering:
    - Quick start and configuration methods
    - Examples for Groq, Together AI, OpenRouter, and local servers
    - Troubleshooting section

  - **`examples/providers/custom_providers.exs`** - Example script showing all configuration methods

  ### Modified Files
  - **`lib/nous/model.ex`** - Add backward compatibility for `openai_compatible:` prefix, add env var support
  - **`lib/nous/model_dispatcher.ex`** - Add explicit `:custom` provider routing
  - **`lib/nous/providers/openai_compatible.ex`** - Expanded documentation
  - **`README.md`** - New "Custom Providers" section with configuration precedence
  - **`examples/providers/vllm_sglang.exs`** - Update to promote `custom:` prefix

  ## Configuration Precedence

  The custom provider loads configuration in this order (higher overrides lower):

  1. **Direct options**: `Nous.new("custom:model", base_url: "...", api_key: "...")`
  2. **Environment variables**: `CUSTOM_BASE_URL`, `CUSTOM_API_KEY`
  3. **Application config**: `config :nous, :custom, base_url: "...", api_key: "..."`
  4. **Defaults**

  ## Backward Compatibility

  The `openai_compatible:` prefix still works and routes to the same `:custom` provider:
  ```elixir
  # Legacy (still works)
  Nous.new("openai_compatible:model", base_url: "...")

  # Recommended
  Nous.new("custom:model", base_url: "...")

  Testing

  - All 985 tests pass
  - Code formatted with mix format
  - Credo checks pass with no issues
  - Documentation generates without errors