### PR TITLE
docs: add file-based skill loading examples and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,45 @@ agent = Nous.new("openai:gpt-4",
 )
 ```
 
+#### File-Based Skills
+
+Define skills as markdown files with YAML frontmatter — no Elixir code needed:
+
+```markdown
+<!-- priv/skills/api_design.md -->
+---
+name: api_design
+description: RESTful API design best practices
+tags: [api, rest, design]
+group: planning
+activation: auto
+priority: 50
+---
+
+When designing APIs:
+1. Use nouns for resources, verbs for actions
+2. Version your API (v1, v2)
+3. Use proper HTTP status codes
+4. Paginate list endpoints
+```
+
+Load from files, directories, or parse inline:
+
+```elixir
+alias Nous.Skill.Loader
+
+# Load a single file
+{:ok, skill} = Loader.load_file("priv/skills/api_design.md")
+
+# Load all .md files from a directory (recursive)
+skills = Loader.load_directory("priv/skills/")
+
+# Or let the agent scan directories automatically
+agent = Nous.new("openai:gpt-4",
+  skill_dirs: ["priv/skills/", "~/.nous/skills/"]
+)
+```
+
 **21 built-in skills** across 7 groups:
 
 | Group | Skills |

--- a/examples/17_skills.exs
+++ b/examples/17_skills.exs
@@ -53,36 +53,50 @@ IO.puts("\nMatches 'write elixir code': #{ElixirExpert.match?("write elixir code
 IO.puts("Matches 'write python code': #{ElixirExpert.match?("write python code")}")
 
 # =============================================================================
-# Example 2: File-based skill (inline parsing)
+# Example 2: File-based skill — loading from markdown files
 # =============================================================================
 
 IO.puts("\n=== Example 2: File-Based Skill ===\n")
 
-markdown_content = """
----
-name: api_design
-description: RESTful API design best practices
-tags: [api, rest, design]
-group: planning
-activation: auto
-priority: 50
----
+# --- 2a: Load a single skill from a .md file ---
+IO.puts("--- 2a: Load a single file ---\n")
 
-When designing APIs:
-1. Use nouns for resources, verbs for actions
-2. Version your API (v1, v2)
-3. Use proper HTTP status codes
-4. Paginate list endpoints
-5. Include HATEOAS links where appropriate
-"""
-
-{:ok, file_skill} = Loader.parse_skill(markdown_content, "api_design.md")
+{:ok, file_skill} = Loader.load_file("examples/skills/api_design.md")
 IO.puts("Loaded skill: #{file_skill.name}")
 IO.puts("Description: #{file_skill.description}")
+IO.puts("Tags: #{inspect(file_skill.tags)}")
 IO.puts("Group: #{file_skill.group}")
 IO.puts("Activation: #{file_skill.activation}")
 IO.puts("Priority: #{file_skill.priority}")
+IO.puts("Source: #{file_skill.source}")
 IO.puts("Instructions preview: #{String.slice(file_skill.instructions, 0..60)}...")
+
+# --- 2b: Load all skills from a directory ---
+IO.puts("\n--- 2b: Load a directory ---\n")
+
+dir_skills = Loader.load_directory("examples/skills/")
+IO.puts("Loaded #{length(dir_skills)} skills from examples/skills/:")
+
+for s <- dir_skills do
+  IO.puts("  #{s.name} (group: #{s.group}, activation: #{s.activation})")
+end
+
+# --- 2c: Parse a skill from an inline markdown string ---
+IO.puts("\n--- 2c: Parse from inline string ---\n")
+
+markdown_content = """
+---
+name: quick_tips
+description: Quick coding tips
+tags: [tips]
+group: coding
+---
+
+Always write tests before shipping.
+"""
+
+{:ok, inline_skill} = Loader.parse_skill(markdown_content, "quick_tips.md")
+IO.puts("Parsed skill: #{inline_skill.name} — #{inline_skill.description}")
 
 # =============================================================================
 # Example 3: Skill Registry — groups, activation, matching
@@ -113,14 +127,16 @@ test_skill = %Skill{
   status: :loaded
 }
 
-# Build registry
+# Build registry — mix module, file-based, and inline skills
 registry =
   Registry.new()
-  # ElixirExpert from above
   |> Registry.register(skill)
   |> Registry.register(file_skill)
   |> Registry.register(review_skill)
   |> Registry.register(test_skill)
+
+# You can also register an entire directory at once:
+# |> Registry.register_directory("priv/skills/")
 
 IO.puts("Registry has #{length(Registry.list(registry))} skills:")
 
@@ -182,6 +198,7 @@ end
 
 IO.puts("\n=== Example 5: Agent with Skills ===\n")
 
+# Mix all skill sources: modules, inline structs, groups, and file directories
 agent =
   Agent.new("openai:gpt-4o-mini",
     instructions: "You are a helpful coding assistant.",
@@ -189,10 +206,13 @@ agent =
       ElixirExpert,
       review_skill,
       {:group, :testing}
-    ]
+    ],
+    # Load .md skill files from directories (scanned recursively)
+    skill_dirs: ["examples/skills/"]
   )
 
 IO.puts("Agent created with #{length(agent.skills)} skill spec(s)")
+IO.puts("Skills list: #{inspect(agent.skills, pretty: true)}")
 IO.puts("Plugins auto-included: #{inspect(agent.plugins)}")
 
 IO.puts("\n=== Done ===")

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ Progressive learning path from basics to advanced features:
 | [14_structured_output.exs](https://github.com/nyo16/nous/blob/master/examples/14_structured_output.exs) | Ecto schemas, JSON schema, multi-schema selection |
 | [15_input_guard.exs](https://github.com/nyo16/nous/blob/master/examples/15_input_guard.exs) | Prompt injection detection and blocking |
 | [16_hooks.exs](https://github.com/nyo16/nous/blob/master/examples/16_hooks.exs) | Lifecycle hooks: blocking, modification, priority ordering |
-| [17_skills.exs](https://github.com/nyo16/nous/blob/master/examples/17_skills.exs) | Skills: modules, file-based, groups, matching, built-in catalog |
+| [17_skills.exs](https://github.com/nyo16/nous/blob/master/examples/17_skills.exs) | Skills: modules, file-based (load from .md files/dirs), groups, matching, built-in catalog |
 
 ## Provider Examples
 

--- a/examples/skills/api_design.md
+++ b/examples/skills/api_design.md
@@ -1,0 +1,15 @@
+---
+name: api_design
+description: RESTful API design best practices
+tags: [api, rest, design]
+group: planning
+activation: auto
+priority: 50
+---
+
+When designing APIs:
+1. Use nouns for resources, verbs for actions
+2. Version your API (v1, v2)
+3. Use proper HTTP status codes
+4. Paginate list endpoints
+5. Include HATEOAS links where appropriate

--- a/examples/skills/security_checklist.md
+++ b/examples/skills/security_checklist.md
@@ -1,0 +1,17 @@
+---
+name: security_checklist
+description: Security review checklist for web applications
+tags: [security, review]
+group: review
+activation: manual
+allowed_tools: [read_file, grep]
+priority: 75
+---
+
+When reviewing code for security:
+1. Check for SQL injection vulnerabilities
+2. Validate and sanitize all user inputs
+3. Ensure proper authentication and authorization
+4. Look for hardcoded secrets or credentials
+5. Verify CORS and CSP headers are configured
+6. Check for path traversal vulnerabilities


### PR DESCRIPTION
Expand Example 17 to demonstrate Loader.load_file/1, load_directory/1, and parse_skill/2. Add sample .md skill files and a File-Based Skills subsection to the README.