### PR TITLE
fix: pass receive_timeout through LLM simple API and remove dead time…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.5] - 2026-03-26
+
+### Fixed
+
+- **`receive_timeout` silently dropped in `Nous.LLM`**: `generate_text/3` and `stream_text/3` with a string model only passed `[:base_url, :api_key, :llamacpp_model]` to `Model.parse`, so `receive_timeout` was silently ignored. Now correctly forwarded.
+
+### Removed
+
+- **Dead timeout config**: Removed unused `default_timeout` and `stream_timeout` from `config/config.exs`. Timeouts are determined by per-provider defaults in `Model.default_receive_timeout/1` and each provider module's `@default_timeout`/`@streaming_timeout` constants.
+
+### Documentation
+
+- Added "Timeouts" section to README documenting `receive_timeout` option and default timeouts per provider.
+
 ## [0.13.0] - 2026-03-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.9.5] - 2026-03-26
+## [0.12.15] - 2026-03-26
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,29 @@ agent = Nous.new("openai:gpt-4",
 )
 ```
 
+### Timeouts
+
+Each provider has sensible default timeouts (60s for cloud APIs, 120s for local models). Override per-model with `receive_timeout`:
+
+```elixir
+# Increase timeout for slow models or large responses
+agent = Nous.new("lmstudio:qwen3",
+  receive_timeout: 300_000  # 5 minutes
+)
+
+# Works with any provider
+agent = Nous.new("openai:gpt-4",
+  receive_timeout: 180_000  # 3 minutes
+)
+```
+
+Default timeouts by provider:
+
+| Provider | Default |
+|----------|---------|
+| OpenAI, Anthropic, Gemini, Groq, Mistral, OpenRouter, Together | 60s |
+| LM Studio, Ollama, vLLM, SGLang, LlamaCpp, Custom | 120s |
+
 ### Google Vertex AI Setup
 
 Vertex AI provides enterprise access to Gemini models via Google Cloud. It supports

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,9 +12,6 @@ config :nous,
   brave_api_key: System.get_env("BRAVE_API_KEY"),
   # Finch pool name
   finch: Nous.Finch,
-  # Timeouts
-  default_timeout: 60_000,
-  stream_timeout: 120_000,
   # Telemetry
   enable_telemetry: true
 

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -48,6 +48,7 @@ defmodule Nous.LLM do
           | {:top_p, float()}
           | {:base_url, String.t()}
           | {:api_key, String.t()}
+          | {:receive_timeout, non_neg_integer()}
           | {:tools, [function() | Tool.t()]}
           | {:deps, map()}
           | {:fallback, [String.t() | Model.t()]}
@@ -75,6 +76,7 @@ defmodule Nous.LLM do
     * `:top_p` - Nucleus sampling parameter
     * `:base_url` - Override API base URL
     * `:api_key` - Override API key
+    * `:receive_timeout` - HTTP receive timeout in milliseconds (default varies by provider)
     * `:tools` - List of tool functions or Tool structs
     * `:deps` - Dependencies to pass to tool functions
     * `:fallback` - Ordered list of fallback model strings or `Model` structs to try
@@ -101,7 +103,12 @@ defmodule Nous.LLM do
   def generate_text(model, prompt, opts \\ [])
 
   def generate_text(model_string, prompt, opts) when is_binary(model_string) do
-    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key, :llamacpp_model]))
+    model =
+      Model.parse(
+        model_string,
+        Keyword.take(opts, [:base_url, :api_key, :llamacpp_model, :receive_timeout])
+      )
+
     generate_text(model, prompt, opts)
   end
 
@@ -164,7 +171,12 @@ defmodule Nous.LLM do
   def stream_text(model, prompt, opts \\ [])
 
   def stream_text(model_string, prompt, opts) when is_binary(model_string) do
-    model = Model.parse(model_string, Keyword.take(opts, [:base_url, :api_key, :llamacpp_model]))
+    model =
+      Model.parse(
+        model_string,
+        Keyword.take(opts, [:base_url, :api_key, :llamacpp_model, :receive_timeout])
+      )
+
     stream_text(model, prompt, opts)
   end
 

--- a/test/nous/llm_test.exs
+++ b/test/nous/llm_test.exs
@@ -1,0 +1,117 @@
+defmodule Nous.LLMTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.{Model, Message, Usage}
+
+  # Mock dispatcher that captures the model struct passed to it
+  defmodule CapturingDispatcher do
+    @moduledoc false
+
+    def configure do
+      if :ets.whereis(:llm_test_captures) != :undefined do
+        :ets.delete(:llm_test_captures)
+      end
+
+      :ets.new(:llm_test_captures, [:named_table, :public, :set])
+      :ets.insert(:llm_test_captures, {:models, []})
+    end
+
+    def get_models do
+      [{:models, models}] = :ets.lookup(:llm_test_captures, :models)
+      Enum.reverse(models)
+    end
+
+    def request(model, _messages, _settings) do
+      record(model)
+
+      {:ok,
+       %Message{
+         role: :assistant,
+         content: "ok",
+         metadata: %{usage: %Usage{input_tokens: 5, output_tokens: 2, total_tokens: 7}}
+       }}
+    end
+
+    def request_stream(model, _messages, _settings) do
+      record(model)
+      {:ok, [{:text_delta, "ok"}, {:finish, "stop"}]}
+    end
+
+    defp record(model) do
+      [{:models, models}] = :ets.lookup(:llm_test_captures, :models)
+      :ets.insert(:llm_test_captures, {:models, [model | models]})
+    end
+  end
+
+  setup do
+    CapturingDispatcher.configure()
+    prev = Application.get_env(:nous, :model_dispatcher)
+    Application.put_env(:nous, :model_dispatcher, CapturingDispatcher)
+    on_exit(fn -> Application.put_env(:nous, :model_dispatcher, prev) end)
+    :ok
+  end
+
+  describe "generate_text/3 passes receive_timeout to model" do
+    test "with string model and receive_timeout option" do
+      {:ok, _text} =
+        Nous.LLM.generate_text("openai:gpt-4", "hi", receive_timeout: 300_000)
+
+      [model] = CapturingDispatcher.get_models()
+      assert model.receive_timeout == 300_000
+    end
+
+    test "with string model uses provider default when receive_timeout not given" do
+      {:ok, _text} = Nous.LLM.generate_text("openai:gpt-4", "hi")
+
+      [model] = CapturingDispatcher.get_models()
+      # OpenAI default is 60_000
+      assert model.receive_timeout == 60_000
+    end
+
+    test "with string model for local provider uses its default" do
+      {:ok, _text} = Nous.LLM.generate_text("lmstudio:qwen3", "hi")
+
+      [model] = CapturingDispatcher.get_models()
+      # LMStudio default is 120_000
+      assert model.receive_timeout == 120_000
+    end
+
+    test "with %Model{} struct preserves receive_timeout" do
+      model = Model.new(:openai, "gpt-4", receive_timeout: 600_000)
+      {:ok, _text} = Nous.LLM.generate_text(model, "hi")
+
+      [captured] = CapturingDispatcher.get_models()
+      assert captured.receive_timeout == 600_000
+    end
+  end
+
+  describe "stream_text/3 passes receive_timeout to model" do
+    test "with string model and receive_timeout option" do
+      {:ok, stream} =
+        Nous.LLM.stream_text("openai:gpt-4", "hi", receive_timeout: 300_000)
+
+      # Consume the stream so the request is made
+      _chunks = Enum.to_list(stream)
+
+      [model] = CapturingDispatcher.get_models()
+      assert model.receive_timeout == 300_000
+    end
+
+    test "with string model uses provider default when receive_timeout not given" do
+      {:ok, stream} = Nous.LLM.stream_text("openai:gpt-4", "hi")
+      _chunks = Enum.to_list(stream)
+
+      [model] = CapturingDispatcher.get_models()
+      assert model.receive_timeout == 60_000
+    end
+
+    test "with %Model{} struct preserves receive_timeout" do
+      model = Model.new(:openai, "gpt-4", receive_timeout: 600_000)
+      {:ok, stream} = Nous.LLM.stream_text(model, "hi")
+      _chunks = Enum.to_list(stream)
+
+      [captured] = CapturingDispatcher.get_models()
+      assert captured.receive_timeout == 600_000
+    end
+  end
+end


### PR DESCRIPTION
…out config

generate_text/3 and stream_text/3 with string models silently dropped receive_timeout because Keyword.take only forwarded [:base_url, :api_key, :llamacpp_model] to Model.parse. Also removes unused default_timeout and stream_timeout from config/config.exs, and documents timeout configuration in README.