### PR TITLE
feat: add LLM-compiled knowledge base system

### DIFF
--- a/lib/nous/agents/knowledge_base_agent.ex
+++ b/lib/nous/agents/knowledge_base_agent.ex
@@ -85,7 +85,7 @@ defmodule Nous.Agents.KnowledgeBaseAgent do
     ctx = Context.add_message(ctx, response)
 
     # Track KB operations for reporting
-    tool_calls = response.tool_calls || []
+    tool_calls = response.tool_calls
 
     kb_calls =
       Enum.filter(tool_calls, fn call ->

--- a/lib/nous/agents/knowledge_base_agent.ex
+++ b/lib/nous/agents/knowledge_base_agent.ex
@@ -1,0 +1,324 @@
+defmodule Nous.Agents.KnowledgeBaseAgent do
+  @moduledoc """
+  Knowledge Base Agent behaviour implementation.
+
+  Specializes agents for knowledge base curation: ingesting documents,
+  compiling wiki entries, querying, generating outputs, and maintaining
+  the knowledge base.
+
+  Adds KB reasoning tools on top of the standard KB plugin tools:
+  - `kb_plan_compilation` — Plan which entries to create from documents
+  - `kb_verify_entry` — Cross-check an entry against source documents
+  - `kb_suggest_links` — Suggest links between entries
+  - `kb_summarize_topic` — Synthesize across multiple entries
+
+  ## Example
+
+      agent = Agent.new("openai:gpt-4",
+        behaviour_module: Nous.Agents.KnowledgeBaseAgent,
+        plugins: [Nous.Plugins.KnowledgeBase],
+        deps: %{kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}}
+      )
+
+      {:ok, result} = Agent.run(agent, "Ingest this article about GenServers: ...")
+      {:ok, result} = Agent.run(agent, "What do we know about OTP?")
+      {:ok, result} = Agent.run(agent, "Generate a report on Elixir patterns")
+  """
+
+  @behaviour Nous.Agent.Behaviour
+
+  alias Nous.{Message, Tool}
+  alias Nous.Agent.Context
+
+  @kb_system_prompt """
+  You are a Knowledge Base curator and analyst. Your primary role is to maintain \
+  a structured wiki-style knowledge base.
+
+  ## Capabilities
+
+  1. **INGEST**: Accept raw documents and add them to the knowledge base using `kb_ingest`.
+  2. **COMPILE**: Transform raw content into structured wiki entries with `kb_add_entry`. \
+  Include summaries, concepts, tags, and use [[slug]] format for wiki-links between entries.
+  3. **QUERY**: Search and retrieve information using `kb_search` and `kb_read`. \
+  Always search the knowledge base before answering questions.
+  4. **GENERATE**: Produce reports, summaries, and slide decks using `kb_generate`.
+  5. **MAINTAIN**: Audit entries using `kb_health_check`, create links with `kb_link`, \
+  and check backlinks with `kb_backlinks`.
+
+  ## Reasoning Tools
+
+  - `kb_plan_compilation` — Before compiling, plan which entries to create
+  - `kb_verify_entry` — Cross-check an entry against its sources
+  - `kb_suggest_links` — Analyze entries and suggest connections
+  - `kb_summarize_topic` — Synthesize information across multiple entries
+
+  ## Wiki Link Format
+
+  Use [[slug]] to link between entries. Example: [[elixir-genserver]]
+
+  ## Guidelines
+
+  - Always cite which knowledge base entries you used in your answer
+  - When ingesting documents, plan the compilation first, then create entries
+  - Proactively suggest improvements when you notice gaps or inconsistencies
+  - Prefer updating existing entries over creating duplicates
+  """
+
+  @impl true
+  def init_context(_agent, ctx) do
+    ctx
+    |> Context.merge_deps(%{
+      kb_operations: Map.get(ctx.deps, :kb_operations, []),
+      kb_compile_queue: Map.get(ctx.deps, :kb_compile_queue, [])
+    })
+  end
+
+  @impl true
+  def build_messages(agent, ctx) do
+    system_prompt = build_kb_system_prompt(agent, ctx)
+    non_system_messages = Enum.reject(ctx.messages, &Message.is_system?/1)
+    [Message.system(system_prompt) | non_system_messages]
+  end
+
+  @impl true
+  def process_response(_agent, response, ctx) do
+    ctx = Context.add_message(ctx, response)
+
+    # Track KB operations for reporting
+    tool_calls = response.tool_calls || []
+
+    kb_calls =
+      Enum.filter(tool_calls, fn call ->
+        name = call["name"] || call[:name] || ""
+        String.starts_with?(to_string(name), "kb_")
+      end)
+
+    if kb_calls != [] do
+      ops = ctx.deps[:kb_operations] || []
+
+      new_ops =
+        Enum.map(kb_calls, fn call ->
+          %{tool: call["name"] || call[:name], timestamp: DateTime.utc_now()}
+        end)
+
+      Context.merge_deps(ctx, %{kb_operations: ops ++ new_ops})
+    else
+      ctx
+    end
+  end
+
+  @impl true
+  def extract_output(agent, ctx) do
+    Nous.Agents.BasicAgent.extract_output(agent, ctx)
+  end
+
+  @impl true
+  def get_tools(agent) do
+    kb_reasoning_tools() ++ agent.tools
+  end
+
+  # ---------------------------------------------------------------------------
+  # KB Reasoning Tools
+  # ---------------------------------------------------------------------------
+
+  defp kb_reasoning_tools do
+    [
+      plan_compilation_tool(),
+      verify_entry_tool(),
+      suggest_links_tool(),
+      summarize_topic_tool()
+    ]
+  end
+
+  defp plan_compilation_tool do
+    %Tool{
+      name: "kb_plan_compilation",
+      description:
+        "Plan which wiki entries to create from a set of documents. " <>
+          "Call this before compiling to organize your approach.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "document_summaries" => %{
+            "type" => "string",
+            "description" => "Brief summary of the documents to compile"
+          },
+          "planned_entries" => %{
+            "type" => "array",
+            "items" => %{
+              "type" => "object",
+              "properties" => %{
+                "title" => %{"type" => "string"},
+                "concepts" => %{
+                  "type" => "array",
+                  "items" => %{"type" => "string"}
+                },
+                "rationale" => %{"type" => "string"}
+              }
+            },
+            "description" => "List of planned entries with titles, concepts, and rationale"
+          }
+        },
+        "required" => ["document_summaries", "planned_entries"]
+      },
+      function: fn _ctx, args ->
+        {:ok,
+         %{
+           status: "plan_recorded",
+           document_summaries: args["document_summaries"],
+           planned_entries: args["planned_entries"],
+           message: "Compilation plan recorded. Proceed to create entries with kb_add_entry."
+         }}
+      end,
+      takes_ctx: true,
+      category: :execute
+    }
+  end
+
+  defp verify_entry_tool do
+    %Tool{
+      name: "kb_verify_entry",
+      description:
+        "Cross-check a wiki entry against its source documents. " <>
+          "Record whether the entry accurately represents its sources.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "entry_slug" => %{
+            "type" => "string",
+            "description" => "Slug of the entry to verify"
+          },
+          "verification_notes" => %{
+            "type" => "string",
+            "description" => "Your assessment of accuracy and completeness"
+          },
+          "confidence" => %{
+            "type" => "number",
+            "description" => "Updated confidence score (0.0-1.0)"
+          },
+          "issues" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Any issues found"
+          }
+        },
+        "required" => ["entry_slug", "verification_notes", "confidence"]
+      },
+      function: fn _ctx, args ->
+        {:ok,
+         %{
+           status: "verified",
+           entry_slug: args["entry_slug"],
+           confidence: args["confidence"],
+           issues: args["issues"] || [],
+           notes: args["verification_notes"]
+         }}
+      end,
+      takes_ctx: true,
+      category: :execute
+    }
+  end
+
+  defp suggest_links_tool do
+    %Tool{
+      name: "kb_suggest_links",
+      description:
+        "Analyze entries and suggest links between them based on content overlap and conceptual connections.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "suggestions" => %{
+            "type" => "array",
+            "items" => %{
+              "type" => "object",
+              "properties" => %{
+                "from_slug" => %{"type" => "string"},
+                "to_slug" => %{"type" => "string"},
+                "link_type" => %{"type" => "string"},
+                "rationale" => %{"type" => "string"}
+              }
+            },
+            "description" => "Suggested links with rationale"
+          }
+        },
+        "required" => ["suggestions"]
+      },
+      function: fn _ctx, args ->
+        suggestions = args["suggestions"] || []
+
+        {:ok,
+         %{
+           status: "suggestions_recorded",
+           count: length(suggestions),
+           suggestions: suggestions,
+           message: "Use kb_link to create the suggested links."
+         }}
+      end,
+      takes_ctx: true,
+      category: :execute
+    }
+  end
+
+  defp summarize_topic_tool do
+    %Tool{
+      name: "kb_summarize_topic",
+      description:
+        "Synthesize information across multiple entries on a topic into a coherent summary.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "topic" => %{
+            "type" => "string",
+            "description" => "Topic to summarize"
+          },
+          "entry_slugs" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Slugs of entries consulted"
+          },
+          "summary" => %{
+            "type" => "string",
+            "description" => "Synthesized summary"
+          },
+          "key_points" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Key points extracted"
+          }
+        },
+        "required" => ["topic", "entry_slugs", "summary"]
+      },
+      function: fn _ctx, args ->
+        {:ok,
+         %{
+           status: "summarized",
+           topic: args["topic"],
+           entries_consulted: args["entry_slugs"],
+           summary: args["summary"],
+           key_points: args["key_points"] || []
+         }}
+      end,
+      takes_ctx: true,
+      category: :execute
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp build_kb_system_prompt(agent, _ctx) do
+    base = @kb_system_prompt
+
+    if agent.instructions do
+      instructions =
+        if is_function(agent.instructions, 0),
+          do: agent.instructions.(),
+          else: agent.instructions
+
+      "#{instructions}\n\n#{base}"
+    else
+      base
+    end
+  end
+end

--- a/lib/nous/knowledge_base.ex
+++ b/lib/nous/knowledge_base.ex
@@ -1,0 +1,168 @@
+defmodule Nous.KnowledgeBase do
+  @moduledoc """
+  LLM-compiled personal knowledge base system.
+
+  Inspired by Karpathy's vision: raw documents get ingested, an LLM compiles
+  them into a markdown wiki with summaries, backlinks, and cross-references.
+  You can Q&A over it, generate outputs, and run health checks.
+
+  ## Quick Start — Plugin Mode
+
+  Add the KB plugin to any agent for interactive use:
+
+      agent = Nous.Agent.new("openai:gpt-4",
+        plugins: [Nous.Plugins.KnowledgeBase],
+        deps: %{
+          kb_config: %{
+            store: Nous.KnowledgeBase.Store.ETS,
+            kb_id: "my_kb"
+          }
+        }
+      )
+
+      {:ok, result} = Nous.Agent.run(agent, "Ingest this article: ...")
+      {:ok, result} = Nous.Agent.run(agent, "What do we know about GenServers?")
+
+  ## Quick Start — Workflow Mode
+
+  For batch operations, use the workflow API:
+
+      # Batch ingest
+      {:ok, state} = Nous.KnowledgeBase.ingest(
+        [%{title: "Article 1", content: "..."}],
+        kb_config: config
+      )
+
+      # Health check
+      {:ok, state} = Nous.KnowledgeBase.health_check(kb_config: config)
+
+  ## Quick Start — Agent Behaviour Mode
+
+  For a KB-specialized agent:
+
+      agent = Nous.Agent.new("openai:gpt-4",
+        behaviour_module: Nous.Agents.KnowledgeBaseAgent,
+        plugins: [Nous.Plugins.KnowledgeBase],
+        deps: %{kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}}
+      )
+
+  ## Architecture
+
+  The KB system has four composable layers:
+
+  1. **Data model & store** — `Document`, `Entry`, `Link`, `HealthReport` structs
+     with a pluggable `Store` behaviour (ETS, SQLite, etc.)
+  2. **Plugin & tools** — `Nous.Plugins.KnowledgeBase` integrates with any agent,
+     providing 9 tools (search, read, ingest, add_entry, link, backlinks, list,
+     health_check, generate)
+  3. **Workflows** — Pre-built DAG pipelines for ingest, incremental update,
+     health check, and output generation
+  4. **Agent behaviour** — `Nous.Agents.KnowledgeBaseAgent` for specialized
+     KB curation and reasoning
+  """
+
+  alias Nous.KnowledgeBase.Workflows
+
+  @doc """
+  Ingest documents through the full compilation pipeline.
+
+  ## Options
+
+    * `:kb_config` - Required. Knowledge base configuration map.
+    * `:compiler_model` - Model for compilation (default: "openai:gpt-4o-mini")
+    * `:embedding` - Embedding provider module
+    * `:embedding_opts` - Embedding options
+  """
+  def ingest(documents, opts) do
+    pipeline = Workflows.build_ingest_pipeline(opts)
+    kb_config = Keyword.fetch!(opts, :kb_config)
+    Nous.Workflow.run(pipeline, %{documents: documents, kb_config: kb_config}, opts)
+  end
+
+  @doc """
+  Incrementally update the knowledge base with new or changed documents.
+  """
+  def incremental_update(documents, opts) do
+    pipeline = Workflows.build_incremental_pipeline(opts)
+    kb_config = Keyword.fetch!(opts, :kb_config)
+    Nous.Workflow.run(pipeline, %{documents: documents, kb_config: kb_config}, opts)
+  end
+
+  @doc """
+  Run a health check audit on the knowledge base.
+  """
+  def health_check(opts) do
+    pipeline = Workflows.build_health_check_pipeline(opts)
+    kb_config = Keyword.fetch!(opts, :kb_config)
+    Nous.Workflow.run(pipeline, %{kb_config: kb_config}, opts)
+  end
+
+  @doc """
+  Generate structured output from the knowledge base.
+
+  ## Parameters
+
+    * `output_type` - `:report`, `:summary`, or `:slides`
+    * `opts` - Must include `:kb_config` and `:topic`
+  """
+  def generate(output_type, opts) do
+    pipeline = Workflows.build_output_pipeline(opts)
+    kb_config = Keyword.fetch!(opts, :kb_config)
+    topic = Keyword.fetch!(opts, :topic)
+
+    Nous.Workflow.run(
+      pipeline,
+      %{topic: topic, output_type: output_type, kb_config: kb_config},
+      opts
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Direct store access (no LLM needed)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Search knowledge base entries directly.
+  """
+  def search(store_mod, store_state, query, opts \\ []) do
+    store_mod.search_entries(store_state, query, opts)
+  end
+
+  @doc """
+  Get a specific entry by slug or ID.
+  """
+  def get_entry(store_mod, store_state, slug_or_id) do
+    case store_mod.fetch_entry_by_slug(store_state, slug_or_id) do
+      {:ok, _} = result -> result
+      {:error, :not_found} -> store_mod.fetch_entry(store_state, slug_or_id)
+    end
+  end
+
+  @doc """
+  List all entries, optionally filtered.
+  """
+  def list_entries(store_mod, store_state, opts \\ []) do
+    store_mod.list_entries(store_state, opts)
+  end
+
+  @doc """
+  List all documents, optionally filtered.
+  """
+  def list_documents(store_mod, store_state, opts \\ []) do
+    store_mod.list_documents(store_state, opts)
+  end
+
+  @doc """
+  Get backlinks for an entry.
+  """
+  def backlinks(store_mod, store_state, entry_id) do
+    store_mod.backlinks(store_state, entry_id)
+  end
+
+  @doc """
+  Get related entries (connected by any link direction).
+  """
+  def related_entries(store_mod, store_state, entry_id, opts \\ []) do
+    store_mod.related_entries(store_state, entry_id, opts)
+  end
+end

--- a/lib/nous/knowledge_base/document.ex
+++ b/lib/nous/knowledge_base/document.ex
@@ -1,0 +1,82 @@
+defmodule Nous.KnowledgeBase.Document do
+  @moduledoc """
+  A raw ingested document before compilation into wiki entries.
+
+  Documents represent source material (markdown, text, URLs, etc.) that
+  gets processed by the LLM into structured `Entry` wiki articles.
+  """
+
+  @type doc_type :: :markdown | :text | :url | :pdf | :html
+  @type status :: :pending | :processing | :compiled | :failed
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          content: String.t(),
+          doc_type: doc_type(),
+          source_url: String.t() | nil,
+          source_path: String.t() | nil,
+          status: status(),
+          metadata: map(),
+          checksum: String.t(),
+          compiled_entry_ids: [String.t()],
+          kb_id: String.t() | nil,
+          created_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  defstruct [
+    :id,
+    :title,
+    :content,
+    :source_url,
+    :source_path,
+    :kb_id,
+    doc_type: :markdown,
+    status: :pending,
+    metadata: %{},
+    checksum: nil,
+    compiled_entry_ids: [],
+    created_at: nil,
+    updated_at: nil
+  ]
+
+  @doc """
+  Creates a new Document from attributes.
+
+  Requires `:content` and `:title`. Auto-generates id, checksum, and timestamps.
+  """
+  def new(attrs) when is_map(attrs) do
+    now = DateTime.utc_now()
+    id = Map.get(attrs, :id) || generate_id()
+    content = Map.fetch!(attrs, :content)
+    title = Map.fetch!(attrs, :title)
+
+    %__MODULE__{
+      id: id,
+      title: title,
+      content: content,
+      doc_type: Map.get(attrs, :doc_type, :markdown),
+      source_url: Map.get(attrs, :source_url),
+      source_path: Map.get(attrs, :source_path),
+      status: Map.get(attrs, :status, :pending),
+      metadata: Map.get(attrs, :metadata, %{}),
+      checksum: Map.get(attrs, :checksum) || compute_checksum(content),
+      compiled_entry_ids: Map.get(attrs, :compiled_entry_ids, []),
+      kb_id: Map.get(attrs, :kb_id),
+      created_at: Map.get(attrs, :created_at, now),
+      updated_at: Map.get(attrs, :updated_at, now)
+    }
+  end
+
+  @doc """
+  Computes SHA-256 checksum of content for change detection.
+  """
+  def compute_checksum(content) when is_binary(content) do
+    :crypto.hash(:sha256, content) |> Base.encode16(case: :lower)
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/nous/knowledge_base/entry.ex
+++ b/lib/nous/knowledge_base/entry.ex
@@ -1,0 +1,100 @@
+defmodule Nous.KnowledgeBase.Entry do
+  @moduledoc """
+  A compiled wiki entry — the core unit of the knowledge base.
+
+  Entries are produced by LLM compilation of raw `Document`s. They contain
+  structured markdown with `[[wiki-links]]`, summaries, extracted concepts,
+  and metadata for search and graph traversal.
+  """
+
+  @type entry_type :: :article | :concept | :summary | :index | :glossary
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          slug: String.t(),
+          content: String.t(),
+          summary: String.t() | nil,
+          entry_type: entry_type(),
+          concepts: [String.t()],
+          tags: [String.t()],
+          confidence: float(),
+          source_doc_ids: [String.t()],
+          embedding: [float()] | nil,
+          metadata: map(),
+          kb_id: String.t() | nil,
+          created_at: DateTime.t(),
+          updated_at: DateTime.t(),
+          last_verified_at: DateTime.t() | nil
+        }
+
+  defstruct [
+    :id,
+    :title,
+    :slug,
+    :content,
+    :summary,
+    :embedding,
+    :kb_id,
+    :last_verified_at,
+    entry_type: :article,
+    concepts: [],
+    tags: [],
+    confidence: 0.5,
+    source_doc_ids: [],
+    metadata: %{},
+    created_at: nil,
+    updated_at: nil
+  ]
+
+  @doc """
+  Creates a new Entry from attributes.
+
+  Requires `:title` and `:content`. Auto-generates id, slug, and timestamps.
+  """
+  def new(attrs) when is_map(attrs) do
+    now = DateTime.utc_now()
+    id = Map.get(attrs, :id) || generate_id()
+    title = Map.fetch!(attrs, :title)
+
+    %__MODULE__{
+      id: id,
+      title: title,
+      slug: Map.get(attrs, :slug) || slugify(title),
+      content: Map.fetch!(attrs, :content),
+      summary: Map.get(attrs, :summary),
+      entry_type: Map.get(attrs, :entry_type, :article),
+      concepts: Map.get(attrs, :concepts, []),
+      tags: Map.get(attrs, :tags, []),
+      confidence: Map.get(attrs, :confidence, 0.5),
+      source_doc_ids: Map.get(attrs, :source_doc_ids, []),
+      embedding: Map.get(attrs, :embedding),
+      metadata: Map.get(attrs, :metadata, %{}),
+      kb_id: Map.get(attrs, :kb_id),
+      created_at: Map.get(attrs, :created_at, now),
+      updated_at: Map.get(attrs, :updated_at, now),
+      last_verified_at: Map.get(attrs, :last_verified_at)
+    }
+  end
+
+  @doc """
+  Generates a URL-safe slug from a title.
+
+  ## Examples
+
+      iex> Nous.KnowledgeBase.Entry.slugify("Elixir GenServer Patterns")
+      "elixir-genserver-patterns"
+  """
+  def slugify(title) when is_binary(title) do
+    title
+    |> String.downcase()
+    |> String.replace(~r/[^\w\s-]/u, "")
+    |> String.replace(~r/[\s_]+/, "-")
+    |> String.replace(~r/-+/, "-")
+    |> String.trim("-")
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/nous/knowledge_base/health_report.ex
+++ b/lib/nous/knowledge_base/health_report.ex
@@ -1,0 +1,66 @@
+defmodule Nous.KnowledgeBase.HealthReport do
+  @moduledoc """
+  Result of a health check audit on the knowledge base.
+
+  Contains statistics, scores, and identified issues for maintenance.
+  """
+
+  @type issue_type :: :stale | :inconsistent | :orphan | :gap | :low_confidence | :duplicate
+  @type severity :: :low | :medium | :high
+
+  @type issue :: %{
+          type: issue_type(),
+          entry_id: String.t() | nil,
+          description: String.t(),
+          severity: severity(),
+          suggested_action: String.t()
+        }
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          kb_id: String.t() | nil,
+          total_entries: non_neg_integer(),
+          total_links: non_neg_integer(),
+          total_documents: non_neg_integer(),
+          issues: [issue()],
+          coverage_score: float(),
+          freshness_score: float(),
+          coherence_score: float(),
+          created_at: DateTime.t()
+        }
+
+  defstruct [
+    :id,
+    :kb_id,
+    total_entries: 0,
+    total_links: 0,
+    total_documents: 0,
+    issues: [],
+    coverage_score: 0.0,
+    freshness_score: 0.0,
+    coherence_score: 0.0,
+    created_at: nil
+  ]
+
+  @doc """
+  Creates a new HealthReport from attributes.
+  """
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{
+      id: Map.get(attrs, :id) || generate_id(),
+      kb_id: Map.get(attrs, :kb_id),
+      total_entries: Map.get(attrs, :total_entries, 0),
+      total_links: Map.get(attrs, :total_links, 0),
+      total_documents: Map.get(attrs, :total_documents, 0),
+      issues: Map.get(attrs, :issues, []),
+      coverage_score: Map.get(attrs, :coverage_score, 0.0),
+      freshness_score: Map.get(attrs, :freshness_score, 0.0),
+      coherence_score: Map.get(attrs, :coherence_score, 0.0),
+      created_at: Map.get(attrs, :created_at, DateTime.utc_now())
+    }
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/nous/knowledge_base/link.ex
+++ b/lib/nous/knowledge_base/link.ex
@@ -1,0 +1,54 @@
+defmodule Nous.KnowledgeBase.Link do
+  @moduledoc """
+  A directed edge in the wiki graph between two entries.
+
+  Links represent relationships like backlinks, cross-references,
+  concept connections, and parent-child hierarchies.
+  """
+
+  @type link_type :: :backlink | :cross_reference | :concept | :see_also | :parent_child
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          from_entry_id: String.t(),
+          to_entry_id: String.t(),
+          link_type: link_type(),
+          label: String.t() | nil,
+          weight: float(),
+          kb_id: String.t() | nil,
+          created_at: DateTime.t()
+        }
+
+  defstruct [
+    :id,
+    :from_entry_id,
+    :to_entry_id,
+    :label,
+    :kb_id,
+    link_type: :cross_reference,
+    weight: 1.0,
+    created_at: nil
+  ]
+
+  @doc """
+  Creates a new Link from attributes.
+
+  Requires `:from_entry_id` and `:to_entry_id`.
+  """
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{
+      id: Map.get(attrs, :id) || generate_id(),
+      from_entry_id: Map.fetch!(attrs, :from_entry_id),
+      to_entry_id: Map.fetch!(attrs, :to_entry_id),
+      link_type: Map.get(attrs, :link_type, :cross_reference),
+      label: Map.get(attrs, :label),
+      weight: Map.get(attrs, :weight, 1.0),
+      kb_id: Map.get(attrs, :kb_id),
+      created_at: Map.get(attrs, :created_at, DateTime.utc_now())
+    }
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/nous/knowledge_base/prompts.ex
+++ b/lib/nous/knowledge_base/prompts.ex
@@ -1,0 +1,219 @@
+defmodule Nous.KnowledgeBase.Prompts do
+  @moduledoc """
+  LLM prompt templates for knowledge base compilation, linking, auditing,
+  and output generation.
+  """
+
+  @doc """
+  Builds a prompt for extracting concepts from raw documents.
+  """
+  def extraction_prompt(documents) do
+    doc_texts =
+      documents
+      |> Enum.with_index(1)
+      |> Enum.map(fn {doc, i} ->
+        """
+        ### Document #{i}: #{doc.title}
+        #{String.slice(doc.content, 0, 3000)}
+        """
+      end)
+      |> Enum.join("\n")
+
+    """
+    Analyze the following documents and extract key concepts, topics, and potential wiki entry titles.
+
+    For each potential wiki entry, provide:
+    - title: A clear, descriptive title
+    - concepts: Key concepts covered
+    - summary: A 1-2 sentence description
+
+    Output as a JSON array of objects with keys: title, concepts, summary.
+
+    #{doc_texts}
+
+    Output the JSON array only, no markdown fences.
+    """
+  end
+
+  @doc """
+  Builds a prompt for compiling raw documents into wiki entries.
+  """
+  def compilation_prompt(documents, concepts) do
+    doc_texts =
+      documents
+      |> Enum.with_index(1)
+      |> Enum.map(fn {doc, i} ->
+        "### Document #{i}: #{doc.title}\n#{doc.content}"
+      end)
+      |> Enum.join("\n\n")
+
+    concept_text =
+      concepts
+      |> Enum.map(fn c ->
+        "- #{c["title"]}: #{c["summary"]}"
+      end)
+      |> Enum.join("\n")
+
+    """
+    You are a knowledge base curator. Compile the following source documents into \
+    structured wiki entries.
+
+    ## Source Documents
+    #{doc_texts}
+
+    ## Planned Entries
+    #{concept_text}
+
+    ## Instructions
+
+    For each planned entry, create a wiki article with:
+    1. A clear title
+    2. Well-structured markdown content
+    3. Use [[slug-format]] to link to other entries in the wiki
+    4. A 1-3 sentence summary
+    5. A list of key concepts
+    6. Appropriate tags
+
+    Output as a JSON array of objects with keys:
+    - title (string)
+    - slug (string, lowercase-hyphenated)
+    - content (string, markdown with [[wiki-links]])
+    - summary (string)
+    - concepts (array of strings)
+    - tags (array of strings)
+    - entry_type (string: "article", "concept", "summary", "glossary")
+    - confidence (float 0.0-1.0, how confident you are in the accuracy)
+
+    Output the JSON array only, no markdown fences.
+    """
+  end
+
+  @doc """
+  Builds a prompt for generating links between wiki entries.
+  """
+  def linking_prompt(entries) do
+    entry_texts =
+      entries
+      |> Enum.map(fn entry ->
+        "- [[#{entry.slug}]] #{entry.title}: #{entry.summary || String.slice(entry.content, 0, 200)}"
+      end)
+      |> Enum.join("\n")
+
+    """
+    You are a knowledge base curator. Analyze these wiki entries and identify \
+    meaningful relationships between them.
+
+    ## Entries
+    #{entry_texts}
+
+    ## Instructions
+
+    For each relationship you find, create a link with:
+    - from_slug: the slug of the source entry
+    - to_slug: the slug of the target entry
+    - link_type: one of "cross_reference", "concept", "see_also", "parent_child"
+    - label: a brief description of the relationship
+
+    Only create links where there is a genuine conceptual connection.
+    Do not create redundant bidirectional links — one direction is sufficient.
+
+    Output as a JSON array of objects with keys: from_slug, to_slug, link_type, label.
+    Output the JSON array only, no markdown fences.
+    """
+  end
+
+  @doc """
+  Builds a prompt for auditing the knowledge base.
+  """
+  def audit_prompt(stats, entry_summaries) do
+    entries_text =
+      entry_summaries
+      |> Enum.map(fn e ->
+        "- [[#{e.slug}]] #{e.title} (type: #{e.entry_type}, confidence: #{e.confidence}, links: #{e.link_count})"
+      end)
+      |> Enum.join("\n")
+
+    """
+    You are a knowledge base auditor. Review the following wiki and identify issues.
+
+    ## Statistics
+    - Total entries: #{stats.total_entries}
+    - Total links: #{stats.total_links}
+    - Total documents: #{stats.total_documents}
+
+    ## Entries
+    #{entries_text}
+
+    ## Check For
+    1. **Stale entries** — entries that may be outdated
+    2. **Inconsistencies** — entries that contradict each other
+    3. **Orphans** — entries with no links or source documents
+    4. **Gaps** — topics that should have entries but don't
+    5. **Low confidence** — entries with low confidence scores
+    6. **Duplicates** — entries covering the same topic
+
+    For each issue found, provide:
+    - type: one of "stale", "inconsistent", "orphan", "gap", "low_confidence", "duplicate"
+    - entry_id: the entry slug (or null for gaps)
+    - description: what the issue is
+    - severity: "low", "medium", or "high"
+    - suggested_action: what to do about it
+
+    Output as a JSON array of issue objects.
+    Output the JSON array only, no markdown fences.
+    """
+  end
+
+  @doc """
+  Builds a prompt for generating an output (report/summary/slides) from entries.
+  """
+  def output_prompt(topic, entries, output_type) do
+    entry_texts =
+      entries
+      |> Enum.map(fn entry ->
+        "## #{entry.title}\n#{entry.content}"
+      end)
+      |> Enum.join("\n\n---\n\n")
+
+    format_instructions =
+      case output_type do
+        :slides ->
+          """
+          Format as a Marp slide deck:
+          - Start with YAML frontmatter: ---\\nmarp: true\\ntheme: default\\n---
+          - Use --- to separate slides
+          - Each slide should have a heading and 3-5 bullet points
+          - Keep slides concise and visual
+          """
+
+        :report ->
+          """
+          Format as a comprehensive markdown report with:
+          - Executive summary
+          - Key findings with inline citations [[slug]]
+          - Analysis and discussion
+          - Conclusion
+          """
+
+        _ ->
+          """
+          Format as a concise summary with:
+          - Key points as bullet list
+          - Important concepts highlighted
+          - References to source entries using [[slug]]
+          """
+      end
+
+    """
+    Generate a #{output_type} about "#{topic}" using the following knowledge base entries.
+
+    ## Source Entries
+    #{entry_texts}
+
+    ## Format Instructions
+    #{format_instructions}
+
+    Generate the output now.
+    """
+  end
+end

--- a/lib/nous/knowledge_base/store.ex
+++ b/lib/nous/knowledge_base/store.ex
@@ -1,0 +1,70 @@
+defmodule Nous.KnowledgeBase.Store do
+  @moduledoc """
+  Storage behaviour for knowledge base backends.
+
+  Defines callbacks for document, entry, and link CRUD operations
+  plus search and graph traversal. Follows the same pattern as
+  `Nous.Memory.Store` but with wiki-specific operations.
+
+  All list/search callbacks accept a `:kb_id` option for scoping.
+  """
+
+  alias Nous.KnowledgeBase.{Document, Entry, Link}
+
+  # --- Document CRUD ---
+
+  @callback init(opts :: keyword()) :: {:ok, term()} | {:error, term()}
+
+  @callback store_document(state :: term(), doc :: Document.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback fetch_document(state :: term(), id :: String.t()) ::
+              {:ok, Document.t()} | {:error, :not_found}
+
+  @callback update_document(state :: term(), id :: String.t(), updates :: map()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback list_documents(state :: term(), opts :: keyword()) :: {:ok, [Document.t()]}
+
+  @callback delete_document(state :: term(), id :: String.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  # --- Entry CRUD + search ---
+
+  @callback store_entry(state :: term(), entry :: Entry.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback fetch_entry(state :: term(), id :: String.t()) ::
+              {:ok, Entry.t()} | {:error, :not_found}
+
+  @callback fetch_entry_by_slug(state :: term(), slug :: String.t()) ::
+              {:ok, Entry.t()} | {:error, :not_found}
+
+  @callback update_entry(state :: term(), id :: String.t(), updates :: map()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback delete_entry(state :: term(), id :: String.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback list_entries(state :: term(), opts :: keyword()) :: {:ok, [Entry.t()]}
+
+  @callback search_entries(state :: term(), query :: String.t(), opts :: keyword()) ::
+              {:ok, [{Entry.t(), float()}]}
+
+  # --- Link CRUD + graph ---
+
+  @callback store_link(state :: term(), link :: Link.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback delete_link(state :: term(), id :: String.t()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback backlinks(state :: term(), entry_id :: String.t()) :: {:ok, [Link.t()]}
+
+  @callback outlinks(state :: term(), entry_id :: String.t()) :: {:ok, [Link.t()]}
+
+  @callback related_entries(state :: term(), entry_id :: String.t(), opts :: keyword()) ::
+              {:ok, [Entry.t()]}
+
+  @optional_callbacks [search_entries: 3, related_entries: 3]
+end

--- a/lib/nous/knowledge_base/store/ets.ex
+++ b/lib/nous/knowledge_base/store/ets.ex
@@ -1,0 +1,271 @@
+defmodule Nous.KnowledgeBase.Store.ETS do
+  @moduledoc """
+  ETS-backed knowledge base store implementation.
+
+  Uses three unnamed ETS tables (documents, entries, links) so multiple
+  instances can coexist. Text search uses `String.jaro_distance/2` for
+  fuzzy matching on entry content and title.
+  """
+
+  @behaviour Nous.KnowledgeBase.Store
+
+  alias Nous.KnowledgeBase.{Document, Entry, Link}
+
+  @type state :: %{
+          documents: :ets.table(),
+          entries: :ets.table(),
+          links: :ets.table()
+        }
+
+  @impl true
+  def init(_opts) do
+    state = %{
+      documents: :ets.new(:kb_documents, [:set, :public]),
+      entries: :ets.new(:kb_entries, [:set, :public]),
+      links: :ets.new(:kb_links, [:set, :public])
+    }
+
+    {:ok, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Document CRUD
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def store_document(state, %Document{} = doc) do
+    :ets.insert(state.documents, {doc.id, doc})
+    {:ok, state}
+  end
+
+  @impl true
+  def fetch_document(state, id) do
+    case :ets.lookup(state.documents, id) do
+      [{^id, doc}] -> {:ok, doc}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @impl true
+  def update_document(state, id, updates) do
+    case fetch_document(state, id) do
+      {:ok, doc} ->
+        now = DateTime.utc_now()
+        updated = struct(doc, Map.put(updates, :updated_at, now))
+        :ets.insert(state.documents, {id, updated})
+        {:ok, state}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def list_documents(state, opts) do
+    kb_id = Keyword.get(opts, :kb_id)
+    status = Keyword.get(opts, :status)
+
+    docs =
+      state.documents
+      |> all_records()
+      |> filter_by_kb_id(kb_id)
+      |> maybe_filter(fn doc -> is_nil(status) || doc.status == status end)
+
+    {:ok, docs}
+  end
+
+  @impl true
+  def delete_document(state, id) do
+    :ets.delete(state.documents, id)
+    {:ok, state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Entry CRUD + search
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def store_entry(state, %Entry{} = entry) do
+    :ets.insert(state.entries, {entry.id, entry})
+    {:ok, state}
+  end
+
+  @impl true
+  def fetch_entry(state, id) do
+    case :ets.lookup(state.entries, id) do
+      [{^id, entry}] -> {:ok, entry}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @impl true
+  def fetch_entry_by_slug(state, slug) do
+    result =
+      state.entries
+      |> all_records()
+      |> Enum.find(fn entry -> entry.slug == slug end)
+
+    case result do
+      nil -> {:error, :not_found}
+      entry -> {:ok, entry}
+    end
+  end
+
+  @impl true
+  def update_entry(state, id, updates) do
+    case fetch_entry(state, id) do
+      {:ok, entry} ->
+        now = DateTime.utc_now()
+        updated = struct(entry, Map.put(updates, :updated_at, now))
+        :ets.insert(state.entries, {id, updated})
+        {:ok, state}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def delete_entry(state, id) do
+    :ets.delete(state.entries, id)
+    {:ok, state}
+  end
+
+  @impl true
+  def list_entries(state, opts) do
+    kb_id = Keyword.get(opts, :kb_id)
+    tags = Keyword.get(opts, :tags)
+    concepts = Keyword.get(opts, :concepts)
+    entry_type = Keyword.get(opts, :entry_type)
+    limit = Keyword.get(opts, :limit)
+
+    entries =
+      state.entries
+      |> all_records()
+      |> filter_by_kb_id(kb_id)
+      |> maybe_filter(fn entry -> is_nil(entry_type) || entry.entry_type == entry_type end)
+      |> maybe_filter(fn entry ->
+        is_nil(tags) || Enum.any?(tags, &(&1 in entry.tags))
+      end)
+      |> maybe_filter(fn entry ->
+        is_nil(concepts) || Enum.any?(concepts, &(&1 in entry.concepts))
+      end)
+      |> maybe_take(limit)
+
+    {:ok, entries}
+  end
+
+  @impl true
+  def search_entries(state, query, opts) do
+    kb_id = Keyword.get(opts, :kb_id)
+    limit = Keyword.get(opts, :limit, 10)
+    min_score = Keyword.get(opts, :min_score, 0.0)
+
+    query_down = String.downcase(query)
+
+    results =
+      state.entries
+      |> all_records()
+      |> filter_by_kb_id(kb_id)
+      |> Enum.map(fn entry ->
+        # Score against both title and content for better matching
+        title_score = String.jaro_distance(query_down, String.downcase(entry.title))
+        content_score = String.jaro_distance(query_down, String.downcase(entry.content))
+        # Weight title matches higher
+        score = max(title_score * 1.2, content_score) |> min(1.0)
+        {entry, score}
+      end)
+      |> Enum.filter(fn {_entry, score} -> score > min_score end)
+      |> Enum.sort_by(fn {_entry, score} -> score end, :desc)
+      |> Enum.take(limit)
+
+    {:ok, results}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Link CRUD + graph
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def store_link(state, %Link{} = link) do
+    :ets.insert(state.links, {link.id, link})
+    {:ok, state}
+  end
+
+  @impl true
+  def delete_link(state, id) do
+    :ets.delete(state.links, id)
+    {:ok, state}
+  end
+
+  @impl true
+  def backlinks(state, entry_id) do
+    links =
+      state.links
+      |> all_records()
+      |> Enum.filter(fn link -> link.to_entry_id == entry_id end)
+
+    {:ok, links}
+  end
+
+  @impl true
+  def outlinks(state, entry_id) do
+    links =
+      state.links
+      |> all_records()
+      |> Enum.filter(fn link -> link.from_entry_id == entry_id end)
+
+    {:ok, links}
+  end
+
+  @impl true
+  def related_entries(state, entry_id, opts) do
+    limit = Keyword.get(opts, :limit, 10)
+
+    # Get all linked entry IDs (both directions)
+    linked_ids =
+      state.links
+      |> all_records()
+      |> Enum.flat_map(fn link ->
+        cond do
+          link.from_entry_id == entry_id -> [link.to_entry_id]
+          link.to_entry_id == entry_id -> [link.from_entry_id]
+          true -> []
+        end
+      end)
+      |> Enum.uniq()
+
+    # Fetch the actual entries
+    entries =
+      linked_ids
+      |> Enum.map(fn id ->
+        case fetch_entry(state, id) do
+          {:ok, entry} -> entry
+          _ -> nil
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.take(limit)
+
+    {:ok, entries}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp all_records(table) do
+    :ets.tab2list(table) |> Enum.map(fn {_id, record} -> record end)
+  end
+
+  defp filter_by_kb_id(records, nil), do: records
+
+  defp filter_by_kb_id(records, kb_id) do
+    Enum.filter(records, fn record -> record.kb_id == kb_id end)
+  end
+
+  defp maybe_filter(records, fun), do: Enum.filter(records, fun)
+
+  defp maybe_take(records, nil), do: records
+  defp maybe_take(records, limit), do: Enum.take(records, limit)
+end

--- a/lib/nous/knowledge_base/tools.ex
+++ b/lib/nous/knowledge_base/tools.ex
@@ -1,0 +1,888 @@
+defmodule Nous.KnowledgeBase.Tools do
+  @moduledoc """
+  Agent tools for knowledge base operations.
+
+  Follows the `Nous.Memory.Tools` pattern — each tool receives `ctx`
+  via `takes_ctx: true` and returns `{:ok, result, ContextUpdate.new()}`.
+  """
+
+  alias Nous.KnowledgeBase.{Document, Entry, Link}
+  alias Nous.Tool
+  alias Nous.Tool.ContextUpdate
+
+  @doc """
+  Returns all knowledge base tools as a list.
+  """
+  def all_tools do
+    [
+      kb_search_tool(),
+      kb_read_tool(),
+      kb_list_tool(),
+      kb_ingest_tool(),
+      kb_add_entry_tool(),
+      kb_link_tool(),
+      kb_backlinks_tool(),
+      kb_health_check_tool(),
+      kb_generate_tool()
+    ]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tool definitions
+  # ---------------------------------------------------------------------------
+
+  defp kb_search_tool do
+    %Tool{
+      name: "kb_search",
+      description:
+        "Search the knowledge base wiki for relevant entries. Returns entries ranked by relevance.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "query" => %{
+            "type" => "string",
+            "description" => "Search query"
+          },
+          "limit" => %{
+            "type" => "integer",
+            "description" => "Maximum number of results (default: 5)"
+          },
+          "tags" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Filter by tags"
+          },
+          "entry_type" => %{
+            "type" => "string",
+            "enum" => ["article", "concept", "summary", "index", "glossary"],
+            "description" => "Filter by entry type"
+          }
+        },
+        "required" => ["query"]
+      },
+      function: &__MODULE__.kb_search/2,
+      takes_ctx: true,
+      category: :search
+    }
+  end
+
+  defp kb_read_tool do
+    %Tool{
+      name: "kb_read",
+      description:
+        "Read a specific knowledge base entry by its slug or ID. Returns the full entry content.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "slug_or_id" => %{
+            "type" => "string",
+            "description" => "Entry slug (e.g. 'elixir-genserver') or entry ID"
+          }
+        },
+        "required" => ["slug_or_id"]
+      },
+      function: &__MODULE__.kb_read/2,
+      takes_ctx: true,
+      category: :read
+    }
+  end
+
+  defp kb_list_tool do
+    %Tool{
+      name: "kb_list",
+      description:
+        "List knowledge base entries, optionally filtered by tags, concepts, or entry type.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "tags" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Filter by tags"
+          },
+          "concepts" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Filter by concepts"
+          },
+          "entry_type" => %{
+            "type" => "string",
+            "enum" => ["article", "concept", "summary", "index", "glossary"],
+            "description" => "Filter by entry type"
+          },
+          "limit" => %{
+            "type" => "integer",
+            "description" => "Maximum number of entries (default: 20)"
+          }
+        }
+      },
+      function: &__MODULE__.kb_list/2,
+      takes_ctx: true,
+      category: :read
+    }
+  end
+
+  defp kb_ingest_tool do
+    %Tool{
+      name: "kb_ingest",
+      description:
+        "Ingest a raw document into the knowledge base for later compilation into wiki entries.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "title" => %{
+            "type" => "string",
+            "description" => "Document title"
+          },
+          "content" => %{
+            "type" => "string",
+            "description" => "Raw document content (markdown, text, etc.)"
+          },
+          "doc_type" => %{
+            "type" => "string",
+            "enum" => ["markdown", "text", "url", "pdf", "html"],
+            "description" => "Document type (default: markdown)"
+          },
+          "source_url" => %{
+            "type" => "string",
+            "description" => "Original source URL if applicable"
+          }
+        },
+        "required" => ["title", "content"]
+      },
+      function: &__MODULE__.kb_ingest/2,
+      takes_ctx: true,
+      category: :write
+    }
+  end
+
+  defp kb_add_entry_tool do
+    %Tool{
+      name: "kb_add_entry",
+      description:
+        "Directly create or update a compiled wiki entry in the knowledge base. Use [[slug]] for wiki-links.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "title" => %{
+            "type" => "string",
+            "description" => "Entry title"
+          },
+          "content" => %{
+            "type" => "string",
+            "description" =>
+              "Wiki entry content in markdown. Use [[slug]] for links to other entries."
+          },
+          "summary" => %{
+            "type" => "string",
+            "description" => "1-3 sentence summary"
+          },
+          "concepts" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Key concepts covered in this entry"
+          },
+          "tags" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "Tags for categorization"
+          },
+          "entry_type" => %{
+            "type" => "string",
+            "enum" => ["article", "concept", "summary", "index", "glossary"],
+            "description" => "Entry type (default: article)"
+          },
+          "source_doc_ids" => %{
+            "type" => "array",
+            "items" => %{"type" => "string"},
+            "description" => "IDs of source documents this entry was compiled from"
+          }
+        },
+        "required" => ["title", "content"]
+      },
+      function: &__MODULE__.kb_add_entry/2,
+      takes_ctx: true,
+      category: :write
+    }
+  end
+
+  defp kb_link_tool do
+    %Tool{
+      name: "kb_link",
+      description: "Create a link between two knowledge base entries.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "from_slug" => %{
+            "type" => "string",
+            "description" => "Slug or ID of the source entry"
+          },
+          "to_slug" => %{
+            "type" => "string",
+            "description" => "Slug or ID of the target entry"
+          },
+          "link_type" => %{
+            "type" => "string",
+            "enum" => ["backlink", "cross_reference", "concept", "see_also", "parent_child"],
+            "description" => "Type of link (default: cross_reference)"
+          },
+          "label" => %{
+            "type" => "string",
+            "description" => "Display label for the link"
+          }
+        },
+        "required" => ["from_slug", "to_slug"]
+      },
+      function: &__MODULE__.kb_link/2,
+      takes_ctx: true,
+      category: :write
+    }
+  end
+
+  defp kb_backlinks_tool do
+    %Tool{
+      name: "kb_backlinks",
+      description: "Find all entries that link to a given entry.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "slug_or_id" => %{
+            "type" => "string",
+            "description" => "Entry slug or ID to find backlinks for"
+          }
+        },
+        "required" => ["slug_or_id"]
+      },
+      function: &__MODULE__.kb_backlinks/2,
+      takes_ctx: true,
+      category: :read
+    }
+  end
+
+  defp kb_health_check_tool do
+    %Tool{
+      name: "kb_health_check",
+      description:
+        "Run a health audit on the knowledge base. Checks for orphaned entries, stale content, missing links, and gaps.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{}
+      },
+      function: &__MODULE__.kb_health_check/2,
+      takes_ctx: true,
+      category: :read
+    }
+  end
+
+  defp kb_generate_tool do
+    %Tool{
+      name: "kb_generate",
+      description:
+        "Generate a structured output (report, summary, or slides) from knowledge base entries on a given topic.",
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "topic" => %{
+            "type" => "string",
+            "description" => "Topic to generate output about"
+          },
+          "output_type" => %{
+            "type" => "string",
+            "enum" => ["report", "summary", "slides"],
+            "description" => "Type of output to generate (default: summary)"
+          },
+          "limit" => %{
+            "type" => "integer",
+            "description" => "Maximum number of entries to include (default: 10)"
+          }
+        },
+        "required" => ["topic"]
+      },
+      function: &__MODULE__.kb_generate/2,
+      takes_ctx: true,
+      category: :execute
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tool implementations
+  # ---------------------------------------------------------------------------
+
+  def kb_search(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      query = Map.fetch!(args, "query")
+      limit = Map.get(args, "limit", 5)
+      entry_type = parse_entry_type(Map.get(args, "entry_type"))
+
+      opts =
+        [limit: limit, kb_id: get_kb_id(ctx)]
+        |> maybe_put(:entry_type, entry_type)
+        |> maybe_put(:tags, Map.get(args, "tags"))
+
+      case store_mod.search_entries(store_state, query, opts) do
+        {:ok, results} ->
+          formatted =
+            Enum.map(results, fn {entry, score} ->
+              %{
+                slug: entry.slug,
+                title: entry.title,
+                summary: entry.summary,
+                entry_type: to_string(entry.entry_type),
+                concepts: entry.concepts,
+                tags: entry.tags,
+                confidence: entry.confidence,
+                score: Float.round(score, 4)
+              }
+            end)
+
+          {:ok, %{status: "found", count: length(formatted), entries: formatted},
+           ContextUpdate.new()}
+
+        {:error, reason} ->
+          {:ok, %{status: "error", message: "Search failed: #{inspect(reason)}"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_read(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      slug_or_id = Map.fetch!(args, "slug_or_id")
+
+      result =
+        case store_mod.fetch_entry_by_slug(store_state, slug_or_id) do
+          {:ok, _} = ok -> ok
+          {:error, :not_found} -> store_mod.fetch_entry(store_state, slug_or_id)
+        end
+
+      case result do
+        {:ok, entry} ->
+          {:ok,
+           %{
+             id: entry.id,
+             slug: entry.slug,
+             title: entry.title,
+             content: entry.content,
+             summary: entry.summary,
+             entry_type: to_string(entry.entry_type),
+             concepts: entry.concepts,
+             tags: entry.tags,
+             confidence: entry.confidence,
+             source_doc_ids: entry.source_doc_ids,
+             created_at: DateTime.to_iso8601(entry.created_at),
+             updated_at: DateTime.to_iso8601(entry.updated_at)
+           }, ContextUpdate.new()}
+
+        {:error, :not_found} ->
+          {:ok, %{status: "not_found", message: "Entry '#{slug_or_id}' not found"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_list(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      limit = Map.get(args, "limit", 20)
+      entry_type = parse_entry_type(Map.get(args, "entry_type"))
+
+      opts =
+        [limit: limit, kb_id: get_kb_id(ctx)]
+        |> maybe_put(:entry_type, entry_type)
+        |> maybe_put(:tags, Map.get(args, "tags"))
+        |> maybe_put(:concepts, Map.get(args, "concepts"))
+
+      case store_mod.list_entries(store_state, opts) do
+        {:ok, entries} ->
+          formatted =
+            Enum.map(entries, fn entry ->
+              %{
+                slug: entry.slug,
+                title: entry.title,
+                entry_type: to_string(entry.entry_type),
+                concepts: entry.concepts,
+                tags: entry.tags
+              }
+            end)
+
+          {:ok, %{status: "ok", count: length(formatted), entries: formatted},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_ingest(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      doc =
+        Document.new(%{
+          title: Map.fetch!(args, "title"),
+          content: Map.fetch!(args, "content"),
+          doc_type: parse_doc_type(Map.get(args, "doc_type", "markdown")),
+          source_url: Map.get(args, "source_url"),
+          kb_id: get_kb_id(ctx)
+        })
+
+      case store_mod.store_document(store_state, doc) do
+        {:ok, new_state} ->
+          {:ok,
+           %{
+             status: "ingested",
+             id: doc.id,
+             title: doc.title,
+             checksum: doc.checksum
+           }, update_store_state(ctx, new_state)}
+
+        {:error, reason} ->
+          {:ok, %{status: "error", message: "Ingest failed: #{inspect(reason)}"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_add_entry(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      config = ctx.deps[:kb_config] || %{}
+      title = Map.fetch!(args, "title")
+      content = Map.fetch!(args, "content")
+
+      # Generate embedding if provider configured
+      embedding = maybe_embed(config, content)
+
+      entry =
+        Entry.new(%{
+          title: title,
+          content: content,
+          summary: Map.get(args, "summary"),
+          concepts: Map.get(args, "concepts", []),
+          tags: Map.get(args, "tags", []),
+          entry_type: parse_entry_type(Map.get(args, "entry_type")) || :article,
+          source_doc_ids: Map.get(args, "source_doc_ids", []),
+          embedding: embedding,
+          kb_id: get_kb_id(ctx)
+        })
+
+      case store_mod.store_entry(store_state, entry) do
+        {:ok, new_state} ->
+          {:ok,
+           %{
+             status: "created",
+             id: entry.id,
+             slug: entry.slug,
+             title: entry.title
+           }, update_store_state(ctx, new_state)}
+
+        {:error, reason} ->
+          {:ok, %{status: "error", message: "Failed to add entry: #{inspect(reason)}"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_link(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      from_slug = Map.fetch!(args, "from_slug")
+      to_slug = Map.fetch!(args, "to_slug")
+
+      with {:ok, from_entry} <- resolve_entry(store_mod, store_state, from_slug),
+           {:ok, to_entry} <- resolve_entry(store_mod, store_state, to_slug) do
+        link =
+          Link.new(%{
+            from_entry_id: from_entry.id,
+            to_entry_id: to_entry.id,
+            link_type: parse_link_type(Map.get(args, "link_type")),
+            label: Map.get(args, "label"),
+            kb_id: get_kb_id(ctx)
+          })
+
+        case store_mod.store_link(store_state, link) do
+          {:ok, new_state} ->
+            {:ok,
+             %{
+               status: "linked",
+               id: link.id,
+               from: from_entry.slug,
+               to: to_entry.slug,
+               link_type: to_string(link.link_type)
+             }, update_store_state(ctx, new_state)}
+
+          {:error, reason} ->
+            {:ok, %{status: "error", message: "Link failed: #{inspect(reason)}"},
+             ContextUpdate.new()}
+        end
+      else
+        {:error, :not_found} ->
+          {:ok,
+           %{status: "error", message: "Could not find entry '#{from_slug}' or '#{to_slug}'"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_backlinks(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      slug_or_id = Map.fetch!(args, "slug_or_id")
+
+      with {:ok, entry} <- resolve_entry(store_mod, store_state, slug_or_id),
+           {:ok, links} <- store_mod.backlinks(store_state, entry.id) do
+        # Fetch the source entries for each backlink
+        entries =
+          links
+          |> Enum.map(fn link ->
+            case store_mod.fetch_entry(store_state, link.from_entry_id) do
+              {:ok, e} ->
+                %{
+                  slug: e.slug,
+                  title: e.title,
+                  link_type: to_string(link.link_type),
+                  label: link.label
+                }
+
+              _ ->
+                nil
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+
+        {:ok,
+         %{
+           status: "ok",
+           entry: entry.slug,
+           backlink_count: length(entries),
+           backlinks: entries
+         }, ContextUpdate.new()}
+      else
+        {:error, :not_found} ->
+          {:ok, %{status: "not_found", message: "Entry '#{slug_or_id}' not found"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_health_check(ctx, _args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      kb_id = get_kb_id(ctx)
+      opts = if kb_id, do: [kb_id: kb_id], else: []
+
+      {:ok, entries} = store_mod.list_entries(store_state, opts)
+      {:ok, docs} = store_mod.list_documents(store_state, opts)
+
+      # Count links
+      link_count =
+        entries
+        |> Enum.reduce(0, fn entry, acc ->
+          case store_mod.outlinks(store_state, entry.id) do
+            {:ok, links} -> acc + length(links)
+            _ -> acc
+          end
+        end)
+
+      # Identify issues
+      issues = identify_issues(store_mod, store_state, entries, docs)
+
+      # Compute scores
+      now = DateTime.utc_now()
+
+      freshness_score =
+        if entries == [] do
+          0.0
+        else
+          avg_age =
+            entries
+            |> Enum.map(fn e -> DateTime.diff(now, e.updated_at, :hour) end)
+            |> then(fn ages -> Enum.sum(ages) / length(ages) end)
+
+          # Score decays over 30 days (720 hours)
+          Float.round(:math.exp(-avg_age / 720), 3)
+        end
+
+      pending_docs = Enum.count(docs, fn d -> d.status == :pending end)
+
+      coverage_score =
+        if docs == [] do
+          1.0
+        else
+          compiled = Enum.count(docs, fn d -> d.status == :compiled end)
+          Float.round(compiled / length(docs), 3)
+        end
+
+      report =
+        Nous.KnowledgeBase.HealthReport.new(%{
+          kb_id: kb_id,
+          total_entries: length(entries),
+          total_links: link_count,
+          total_documents: length(docs),
+          issues: issues,
+          coverage_score: coverage_score,
+          freshness_score: freshness_score,
+          coherence_score:
+            if(issues == [],
+              do: 1.0,
+              else: Float.round(1.0 - length(issues) * 0.1, 3) |> max(0.0)
+            )
+        })
+
+      {:ok,
+       %{
+         status: "ok",
+         total_entries: report.total_entries,
+         total_links: report.total_links,
+         total_documents: report.total_documents,
+         pending_documents: pending_docs,
+         coverage_score: report.coverage_score,
+         freshness_score: report.freshness_score,
+         coherence_score: report.coherence_score,
+         issue_count: length(report.issues),
+         issues:
+           Enum.map(report.issues, fn issue ->
+             %{
+               type: to_string(issue.type),
+               description: issue.description,
+               severity: to_string(issue.severity)
+             }
+           end)
+       }, ContextUpdate.new()}
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  def kb_generate(ctx, args) do
+    with {:ok, store_mod, store_state} <- get_store(ctx) do
+      topic = Map.fetch!(args, "topic")
+      output_type = Map.get(args, "output_type", "summary")
+      limit = Map.get(args, "limit", 10)
+
+      # Search for relevant entries
+      opts = [limit: limit, kb_id: get_kb_id(ctx)]
+
+      case store_mod.search_entries(store_state, topic, opts) do
+        {:ok, results} ->
+          entries = Enum.map(results, fn {entry, _score} -> entry end)
+
+          content =
+            case output_type do
+              "slides" -> format_as_slides(topic, entries)
+              "report" -> format_as_report(topic, entries)
+              _ -> format_as_summary(topic, entries)
+            end
+
+          {:ok,
+           %{
+             status: "generated",
+             output_type: output_type,
+             topic: topic,
+             entry_count: length(entries),
+             content: content
+           }, ContextUpdate.new()}
+
+        {:error, reason} ->
+          {:ok, %{status: "error", message: "Generation failed: #{inspect(reason)}"},
+           ContextUpdate.new()}
+      end
+    else
+      {:error, :not_initialized} -> not_initialized_error()
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp get_store(ctx) do
+    config = ctx.deps[:kb_config] || %{}
+    store_mod = config[:store]
+    store_state = config[:store_state]
+
+    if store_mod && store_state do
+      {:ok, store_mod, store_state}
+    else
+      {:error, :not_initialized}
+    end
+  end
+
+  defp not_initialized_error do
+    {:ok, %{status: "error", message: "Knowledge base not initialized"}, ContextUpdate.new()}
+  end
+
+  defp get_kb_id(ctx) do
+    config = ctx.deps[:kb_config] || %{}
+    config[:kb_id]
+  end
+
+  defp resolve_entry(store_mod, store_state, slug_or_id) do
+    case store_mod.fetch_entry_by_slug(store_state, slug_or_id) do
+      {:ok, _} = ok -> ok
+      {:error, :not_found} -> store_mod.fetch_entry(store_state, slug_or_id)
+    end
+  end
+
+  defp update_store_state(ctx, new_state) do
+    config = ctx.deps[:kb_config] || %{}
+    updated_config = Map.put(config, :store_state, new_state)
+    ContextUpdate.new() |> ContextUpdate.set(:kb_config, updated_config)
+  end
+
+  defp maybe_embed(config, content) do
+    embedding_provider = config[:embedding]
+    embedding_opts = config[:embedding_opts] || []
+
+    if embedding_provider do
+      case Nous.Memory.Embedding.embed(embedding_provider, content, embedding_opts) do
+        {:ok, emb} -> emb
+        {:error, _} -> nil
+      end
+    end
+  end
+
+  defp identify_issues(store_mod, store_state, entries, docs) do
+    issues = []
+
+    # Orphaned entries (no source documents and no links)
+    orphan_issues =
+      entries
+      |> Enum.filter(fn entry ->
+        entry.source_doc_ids == [] &&
+          case store_mod.backlinks(store_state, entry.id) do
+            {:ok, []} -> true
+            _ -> false
+          end &&
+          case store_mod.outlinks(store_state, entry.id) do
+            {:ok, []} -> true
+            _ -> false
+          end
+      end)
+      |> Enum.map(fn entry ->
+        %{
+          type: :orphan,
+          entry_id: entry.id,
+          description: "Entry '#{entry.title}' has no source documents and no links",
+          severity: :low,
+          suggested_action: "Add source documents or link to related entries"
+        }
+      end)
+
+    # Low confidence entries
+    low_confidence_issues =
+      entries
+      |> Enum.filter(fn entry -> entry.confidence < 0.3 end)
+      |> Enum.map(fn entry ->
+        %{
+          type: :low_confidence,
+          entry_id: entry.id,
+          description: "Entry '#{entry.title}' has low confidence (#{entry.confidence})",
+          severity: :medium,
+          suggested_action: "Verify and update entry content from source documents"
+        }
+      end)
+
+    # Failed documents
+    failed_doc_issues =
+      docs
+      |> Enum.filter(fn doc -> doc.status == :failed end)
+      |> Enum.map(fn doc ->
+        %{
+          type: :inconsistent,
+          entry_id: nil,
+          description: "Document '#{doc.title}' failed to compile",
+          severity: :high,
+          suggested_action: "Re-ingest or manually review document"
+        }
+      end)
+
+    issues ++ orphan_issues ++ low_confidence_issues ++ failed_doc_issues
+  end
+
+  defp format_as_summary(topic, entries) do
+    entry_texts =
+      entries
+      |> Enum.map(fn entry ->
+        "### #{entry.title}\n#{entry.summary || String.slice(entry.content, 0, 200)}"
+      end)
+      |> Enum.join("\n\n")
+
+    """
+    # Summary: #{topic}
+
+    #{entry_texts}
+    """
+  end
+
+  defp format_as_report(topic, entries) do
+    entry_texts =
+      entries
+      |> Enum.map(fn entry ->
+        concepts =
+          if entry.concepts != [],
+            do: "**Concepts:** #{Enum.join(entry.concepts, ", ")}\n\n",
+            else: ""
+
+        "## #{entry.title}\n\n#{concepts}#{entry.content}"
+      end)
+      |> Enum.join("\n\n---\n\n")
+
+    """
+    # Report: #{topic}
+
+    **Entries consulted:** #{length(entries)}
+
+    #{entry_texts}
+    """
+  end
+
+  defp format_as_slides(topic, entries) do
+    slides =
+      entries
+      |> Enum.map(fn entry ->
+        "---\n\n# #{entry.title}\n\n#{entry.summary || String.slice(entry.content, 0, 300)}"
+      end)
+      |> Enum.join("\n\n")
+
+    """
+    ---
+    marp: true
+    theme: default
+    ---
+
+    # #{topic}
+
+    #{slides}
+    """
+  end
+
+  defp parse_entry_type("article"), do: :article
+  defp parse_entry_type("concept"), do: :concept
+  defp parse_entry_type("summary"), do: :summary
+  defp parse_entry_type("index"), do: :index
+  defp parse_entry_type("glossary"), do: :glossary
+  defp parse_entry_type(_), do: nil
+
+  defp parse_doc_type("markdown"), do: :markdown
+  defp parse_doc_type("text"), do: :text
+  defp parse_doc_type("url"), do: :url
+  defp parse_doc_type("pdf"), do: :pdf
+  defp parse_doc_type("html"), do: :html
+  defp parse_doc_type(_), do: :markdown
+
+  defp parse_link_type("backlink"), do: :backlink
+  defp parse_link_type("cross_reference"), do: :cross_reference
+  defp parse_link_type("concept"), do: :concept
+  defp parse_link_type("see_also"), do: :see_also
+  defp parse_link_type("parent_child"), do: :parent_child
+  defp parse_link_type(_), do: :cross_reference
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/lib/nous/knowledge_base/workflows.ex
+++ b/lib/nous/knowledge_base/workflows.ex
@@ -261,7 +261,7 @@ defmodule Nous.KnowledgeBase.Workflows do
 
   defp build_health_report(state) do
     audit_output = state.data.audit_entries
-    issues = parse_json_output(audit_output) || []
+    issues = parse_json_output(audit_output)
     stats = state.data.stats
 
     report =

--- a/lib/nous/knowledge_base/workflows.ex
+++ b/lib/nous/knowledge_base/workflows.ex
@@ -1,0 +1,456 @@
+defmodule Nous.KnowledgeBase.Workflows do
+  @moduledoc """
+  Pre-built workflow DAG pipelines for knowledge base operations.
+
+  Provides ready-made workflows for:
+  - **Ingest pipeline** — raw documents → compiled wiki entries
+  - **Incremental update** — detect changes and recompile affected entries
+  - **Health check** — audit the knowledge base for issues
+  - **Output generation** — produce reports, summaries, or slides
+  """
+
+  alias Nous.Workflow
+  alias Nous.KnowledgeBase.{Document, Entry, Link, HealthReport, Prompts}
+
+  # ---------------------------------------------------------------------------
+  # Ingest Pipeline
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Builds an ingest pipeline workflow.
+
+  Nodes: ingest_docs → extract_concepts → compile_entries → generate_links → embed_entries → persist
+
+  ## Required input data
+
+      %{
+        documents: [%{title: "...", content: "...", doc_type: :markdown}],
+        kb_config: %{store: ..., store_state: ..., kb_id: ...}
+      }
+
+  ## Options
+
+    * `:compiler_model` - Model string for LLM steps (default: "openai:gpt-4o-mini")
+    * `:embedding` - Embedding provider module
+    * `:embedding_opts` - Embedding options
+  """
+  def build_ingest_pipeline(opts \\ []) do
+    Workflow.new("kb_ingest", name: "Knowledge Base Ingest Pipeline")
+    |> Workflow.add_node(:ingest_docs, :transform, %{
+      transform_fn: &ingest_raw_documents/1
+    })
+    |> Workflow.add_node(:extract_concepts, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        Prompts.extraction_prompt(state.data.documents_parsed)
+      end
+    })
+    |> Workflow.add_node(:compile_entries, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        concepts = parse_json_output(state.data.extract_concepts)
+        Prompts.compilation_prompt(state.data.documents_parsed, concepts)
+      end
+    })
+    |> Workflow.add_node(:generate_links, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        entries = parse_entries_from_output(state.data.compile_entries)
+        Prompts.linking_prompt(entries)
+      end
+    })
+    |> Workflow.add_node(:embed_entries, :transform, %{
+      transform_fn: embed_entries_fn(opts)
+    })
+    |> Workflow.add_node(:persist, :transform, %{
+      transform_fn: &persist_to_store/1
+    })
+    |> Workflow.chain([
+      :ingest_docs,
+      :extract_concepts,
+      :compile_entries,
+      :generate_links,
+      :embed_entries,
+      :persist
+    ])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Incremental Update Pipeline
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Builds an incremental update pipeline.
+
+  Detects changed documents and recompiles only affected entries.
+
+  ## Required input data
+
+      %{
+        documents: [%{title: "...", content: "..."}],
+        kb_config: %{store: ..., store_state: ..., kb_id: ...}
+      }
+  """
+  def build_incremental_pipeline(opts \\ []) do
+    Workflow.new("kb_incremental", name: "KB Incremental Update")
+    |> Workflow.add_node(:detect_changes, :transform, %{
+      transform_fn: &detect_changed_documents/1
+    })
+    |> Workflow.add_node(:recompile, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        changed = state.data.changed_documents
+        Prompts.compilation_prompt(changed, [])
+      end
+    })
+    |> Workflow.add_node(:persist_changes, :transform, %{
+      transform_fn: &persist_to_store/1
+    })
+    |> Workflow.chain([:detect_changes, :recompile, :persist_changes])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Health Check Pipeline
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Builds a health check pipeline.
+
+  ## Required input data
+
+      %{kb_config: %{store: ..., store_state: ..., kb_id: ...}}
+  """
+  def build_health_check_pipeline(opts \\ []) do
+    Workflow.new("kb_health_check", name: "KB Health Check")
+    |> Workflow.add_node(:gather_stats, :transform, %{
+      transform_fn: &gather_kb_statistics/1
+    })
+    |> Workflow.add_node(:audit_entries, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        Prompts.audit_prompt(state.data.stats, state.data.entry_summaries)
+      end
+    })
+    |> Workflow.add_node(:build_report, :transform, %{
+      transform_fn: &build_health_report/1
+    })
+    |> Workflow.chain([:gather_stats, :audit_entries, :build_report])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Output Generation Pipeline
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Builds an output generation pipeline.
+
+  ## Required input data
+
+      %{
+        topic: "...",
+        output_type: :report | :summary | :slides,
+        kb_config: %{store: ..., store_state: ..., kb_id: ...}
+      }
+  """
+  def build_output_pipeline(opts \\ []) do
+    Workflow.new("kb_output", name: "KB Output Generation")
+    |> Workflow.add_node(:select_entries, :transform, %{
+      transform_fn: &select_relevant_entries/1
+    })
+    |> Workflow.add_node(:generate_output, :agent_step, %{
+      agent: compiler_agent(opts),
+      prompt: fn state ->
+        Prompts.output_prompt(
+          state.data.topic,
+          state.data.selected_entries,
+          state.data.output_type
+        )
+      end
+    })
+    |> Workflow.chain([:select_entries, :generate_output])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Transform functions
+  # ---------------------------------------------------------------------------
+
+  defp ingest_raw_documents(state) do
+    documents =
+      state.data.documents
+      |> Enum.map(fn raw ->
+        Document.new(%{
+          title: raw[:title] || raw["title"],
+          content: raw[:content] || raw["content"],
+          doc_type: raw[:doc_type] || raw["doc_type"] || :markdown,
+          source_url: raw[:source_url] || raw["source_url"],
+          kb_id: get_in(state.data, [:kb_config, :kb_id])
+        })
+      end)
+
+    %{state | data: Map.put(state.data, :documents_parsed, documents)}
+  end
+
+  defp detect_changed_documents(state) do
+    config = state.data.kb_config
+    store_mod = config[:store]
+    store_state = config[:store_state]
+
+    {:ok, existing_docs} = store_mod.list_documents(store_state, kb_id: config[:kb_id])
+    existing_checksums = Map.new(existing_docs, fn doc -> {doc.checksum, doc} end)
+
+    new_documents =
+      state.data.documents
+      |> Enum.map(fn raw ->
+        content = raw[:content] || raw["content"]
+        checksum = Document.compute_checksum(content)
+
+        unless Map.has_key?(existing_checksums, checksum) do
+          Document.new(%{
+            title: raw[:title] || raw["title"],
+            content: content,
+            kb_id: config[:kb_id]
+          })
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    %{state | data: Map.put(state.data, :changed_documents, new_documents)}
+  end
+
+  defp gather_kb_statistics(state) do
+    config = state.data.kb_config
+    store_mod = config[:store]
+    store_state = config[:store_state]
+    kb_id = config[:kb_id]
+    opts = if kb_id, do: [kb_id: kb_id], else: []
+
+    {:ok, entries} = store_mod.list_entries(store_state, opts)
+    {:ok, docs} = store_mod.list_documents(store_state, opts)
+
+    link_count =
+      Enum.reduce(entries, 0, fn entry, acc ->
+        case store_mod.outlinks(store_state, entry.id) do
+          {:ok, links} -> acc + length(links)
+          _ -> acc
+        end
+      end)
+
+    stats = %{
+      total_entries: length(entries),
+      total_links: link_count,
+      total_documents: length(docs)
+    }
+
+    entry_summaries =
+      Enum.map(entries, fn entry ->
+        {:ok, outlinks} = store_mod.outlinks(store_state, entry.id)
+
+        %{
+          slug: entry.slug,
+          title: entry.title,
+          entry_type: entry.entry_type,
+          confidence: entry.confidence,
+          link_count: length(outlinks)
+        }
+      end)
+
+    state
+    |> put_in([Access.key(:data), :stats], stats)
+    |> put_in([Access.key(:data), :entry_summaries], entry_summaries)
+  end
+
+  defp build_health_report(state) do
+    audit_output = state.data.audit_entries
+    issues = parse_json_output(audit_output) || []
+    stats = state.data.stats
+
+    report =
+      HealthReport.new(%{
+        kb_id: get_in(state.data, [:kb_config, :kb_id]),
+        total_entries: stats.total_entries,
+        total_links: stats.total_links,
+        total_documents: stats.total_documents,
+        issues:
+          Enum.map(issues, fn issue ->
+            %{
+              type: String.to_existing_atom(issue["type"] || "gap"),
+              entry_id: issue["entry_id"],
+              description: issue["description"] || "",
+              severity: String.to_existing_atom(issue["severity"] || "low"),
+              suggested_action: issue["suggested_action"] || ""
+            }
+          end)
+      })
+
+    %{state | data: Map.put(state.data, :health_report, report)}
+  end
+
+  defp select_relevant_entries(state) do
+    config = state.data.kb_config
+    store_mod = config[:store]
+    store_state = config[:store_state]
+    topic = state.data.topic
+    limit = state.data[:limit] || 10
+
+    {:ok, results} =
+      store_mod.search_entries(store_state, topic, limit: limit, kb_id: config[:kb_id])
+
+    entries = Enum.map(results, fn {entry, _score} -> entry end)
+    %{state | data: Map.put(state.data, :selected_entries, entries)}
+  end
+
+  defp embed_entries_fn(opts) do
+    embedding = opts[:embedding]
+    embedding_opts = opts[:embedding_opts] || []
+
+    fn state ->
+      if embedding do
+        entries = parse_entries_from_output(state.data.compile_entries)
+
+        embedded =
+          Enum.map(entries, fn entry ->
+            case Nous.Memory.Embedding.embed(embedding, entry.content, embedding_opts) do
+              {:ok, emb} -> %{entry | embedding: emb}
+              {:error, _} -> entry
+            end
+          end)
+
+        %{state | data: Map.put(state.data, :compiled_entries, embedded)}
+      else
+        entries = parse_entries_from_output(state.data.compile_entries)
+        %{state | data: Map.put(state.data, :compiled_entries, entries)}
+      end
+    end
+  end
+
+  defp persist_to_store(state) do
+    config = state.data.kb_config
+    store_mod = config[:store]
+    store_state = config[:store_state]
+    kb_id = config[:kb_id]
+
+    # Persist compiled entries
+    entries = state.data[:compiled_entries] || []
+
+    store_state =
+      Enum.reduce(entries, store_state, fn entry, acc ->
+        entry = if entry.kb_id, do: entry, else: %{entry | kb_id: kb_id}
+
+        case store_mod.store_entry(acc, entry) do
+          {:ok, new_state} -> new_state
+          {:error, _} -> acc
+        end
+      end)
+
+    # Persist links
+    links_output = state.data[:generate_links]
+    links = parse_links_from_output(links_output, entries, kb_id)
+
+    store_state =
+      Enum.reduce(links, store_state, fn link, acc ->
+        case store_mod.store_link(acc, link) do
+          {:ok, new_state} -> new_state
+          {:error, _} -> acc
+        end
+      end)
+
+    # Persist documents
+    docs = state.data[:documents_parsed] || []
+
+    store_state =
+      Enum.reduce(docs, store_state, fn doc, acc ->
+        compiled_doc = %{doc | status: :compiled}
+
+        case store_mod.store_document(acc, compiled_doc) do
+          {:ok, new_state} -> new_state
+          {:error, _} -> acc
+        end
+      end)
+
+    updated_config = Map.put(config, :store_state, store_state)
+    %{state | data: Map.put(state.data, :kb_config, updated_config)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp compiler_agent(opts) do
+    model = opts[:compiler_model] || "openai:gpt-4o-mini"
+
+    Nous.Agent.new(model,
+      instructions: "You are a knowledge base curator. Output valid JSON only."
+    )
+  end
+
+  defp parse_json_output(text) when is_binary(text) do
+    cleaned =
+      text
+      |> String.trim()
+      |> String.replace(~r/^```(?:json)?\s*/m, "")
+      |> String.replace(~r/\s*```$/m, "")
+      |> String.trim()
+
+    case JSON.decode(cleaned) do
+      {:ok, parsed} when is_list(parsed) -> parsed
+      _ -> []
+    end
+  end
+
+  defp parse_json_output(_), do: []
+
+  defp parse_entries_from_output(text) when is_binary(text) do
+    parse_json_output(text)
+    |> Enum.map(fn raw ->
+      Entry.new(%{
+        title: raw["title"] || "Untitled",
+        slug: raw["slug"],
+        content: raw["content"] || "",
+        summary: raw["summary"],
+        concepts: raw["concepts"] || [],
+        tags: raw["tags"] || [],
+        entry_type: parse_entry_type(raw["entry_type"]),
+        confidence: raw["confidence"] || 0.5
+      })
+    end)
+  end
+
+  defp parse_entries_from_output(_), do: []
+
+  defp parse_links_from_output(text, entries, kb_id) when is_binary(text) do
+    slug_to_id = Map.new(entries, fn e -> {e.slug, e.id} end)
+
+    parse_json_output(text)
+    |> Enum.map(fn raw ->
+      from_id = slug_to_id[raw["from_slug"]]
+      to_id = slug_to_id[raw["to_slug"]]
+
+      if from_id && to_id do
+        Link.new(%{
+          from_entry_id: from_id,
+          to_entry_id: to_id,
+          link_type: parse_link_type(raw["link_type"]),
+          label: raw["label"],
+          kb_id: kb_id
+        })
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp parse_links_from_output(_, _, _), do: []
+
+  defp parse_entry_type("article"), do: :article
+  defp parse_entry_type("concept"), do: :concept
+  defp parse_entry_type("summary"), do: :summary
+  defp parse_entry_type("index"), do: :index
+  defp parse_entry_type("glossary"), do: :glossary
+  defp parse_entry_type(_), do: :article
+
+  defp parse_link_type("backlink"), do: :backlink
+  defp parse_link_type("cross_reference"), do: :cross_reference
+  defp parse_link_type("concept"), do: :concept
+  defp parse_link_type("see_also"), do: :see_also
+  defp parse_link_type("parent_child"), do: :parent_child
+  defp parse_link_type(_), do: :cross_reference
+end

--- a/lib/nous/plugins/knowledge_base.ex
+++ b/lib/nous/plugins/knowledge_base.ex
@@ -1,0 +1,215 @@
+defmodule Nous.Plugins.KnowledgeBase do
+  @moduledoc """
+  Plugin for LLM-compiled knowledge base with wiki-style entries.
+
+  Provides tools for agents to ingest documents, compile wiki entries,
+  search and query the knowledge base, and run health checks.
+
+  ## Usage
+
+      # Minimal — ETS store
+      agent = Agent.new("openai:gpt-4",
+        plugins: [Nous.Plugins.KnowledgeBase],
+        deps: %{kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}}
+      )
+
+      # With embeddings for semantic search
+      agent = Agent.new("openai:gpt-4",
+        plugins: [Nous.Plugins.KnowledgeBase],
+        deps: %{
+          kb_config: %{
+            store: Nous.KnowledgeBase.Store.ETS,
+            kb_id: "my_kb",
+            embedding: Nous.Memory.Embedding.OpenAI,
+            embedding_opts: %{api_key: "sk-..."}
+          }
+        }
+      )
+
+  ## Composition with Memory Plugin
+
+  The KB plugin composes cleanly with `Nous.Plugins.Memory`:
+
+      agent = Agent.new("openai:gpt-4",
+        plugins: [Nous.Plugins.Memory, Nous.Plugins.KnowledgeBase],
+        deps: %{
+          memory_config: %{store: Nous.Memory.Store.ETS},
+          kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}
+        }
+      )
+
+  ## Configuration (via `deps[:kb_config]`)
+
+  **Required:**
+    * `:store` - Store backend module (e.g. `Nous.KnowledgeBase.Store.ETS`)
+
+  **Optional — store:**
+    * `:store_opts` - Options passed to `store.init/1`
+    * `:kb_id` - Namespace for this knowledge base
+
+  **Optional — embedding:**
+    * `:embedding` - Embedding provider module (reuses `Nous.Memory.Embedding.*`)
+    * `:embedding_opts` - Options passed to embedding provider
+
+  **Optional — auto-injection:**
+    * `:auto_inject` - Auto-inject relevant KB entries before each request (default: true)
+    * `:inject_strategy` - `:first_only` (default) or `:every_iteration`
+    * `:inject_limit` - Max entries to inject (default: 3)
+    * `:inject_min_score` - Minimum score for injection (default: 0.3)
+
+  **Optional — compilation:**
+    * `:compiler_model` - Model string for compilation LLM calls
+    * `:auto_compile` - Auto-compile pending documents after runs (default: false)
+  """
+
+  @behaviour Nous.Plugin
+
+  require Logger
+
+  alias Nous.KnowledgeBase.Tools
+
+  @impl true
+  def init(_agent, ctx) do
+    config = ctx.deps[:kb_config] || %{}
+    store_mod = config[:store]
+
+    unless store_mod do
+      Logger.warning(
+        "Nous.Plugins.KnowledgeBase: No :store configured in deps[:kb_config]. " <>
+          "Knowledge base tools will not function."
+      )
+
+      ctx
+    else
+      store_opts = Map.get(config, :store_opts, [])
+      store_opts = if is_map(store_opts), do: Map.to_list(store_opts), else: store_opts
+
+      case store_mod.init(store_opts) do
+        {:ok, store_state} ->
+          updated_config =
+            config
+            |> Map.put(:store_state, store_state)
+            |> Map.put_new(:auto_inject, true)
+            |> Map.put_new(:inject_strategy, :first_only)
+            |> Map.put_new(:inject_limit, 3)
+            |> Map.put_new(:inject_min_score, 0.3)
+            |> Map.put_new(:auto_compile, false)
+            |> Map.put(:_inject_done, false)
+
+          %{ctx | deps: Map.put(ctx.deps, :kb_config, updated_config)}
+
+        {:error, reason} ->
+          Logger.error("Nous.Plugins.KnowledgeBase: Store init failed: #{inspect(reason)}")
+          ctx
+      end
+    end
+  end
+
+  @impl true
+  def tools(_agent, _ctx) do
+    Tools.all_tools()
+  end
+
+  @impl true
+  def system_prompt(_agent, ctx) do
+    config = ctx.deps[:kb_config] || %{}
+
+    if config[:store_state] do
+      """
+      ## Knowledge Base
+
+      You have access to a curated knowledge base wiki. Use these tools:
+      - `kb_search` — Search the wiki for relevant entries
+      - `kb_read` — Read a specific entry by slug or ID
+      - `kb_ingest` — Add a raw document for LLM compilation
+      - `kb_add_entry` — Directly create or update a wiki entry
+      - `kb_link` — Create a link between entries
+      - `kb_backlinks` — Find entries linking to a given entry
+      - `kb_list` — List entries filtered by tag/concept/type
+      - `kb_health_check` — Audit the wiki for issues
+      - `kb_generate` — Generate a report or summary from entries
+
+      When answering questions, search the knowledge base first. Use [[slug]] format \
+      for wiki-links between entries. Cite which entries you used in your answer.\
+      """
+    end
+  end
+
+  @impl true
+  def before_request(_agent, ctx, tools) do
+    config = ctx.deps[:kb_config] || %{}
+
+    should_inject? =
+      config[:auto_inject] == true &&
+        config[:store_state] != nil &&
+        should_inject_this_iteration?(config)
+
+    if should_inject? do
+      ctx = inject_relevant_entries(ctx, config)
+      updated_config = Map.put(config, :_inject_done, true)
+      ctx = %{ctx | deps: Map.put(ctx.deps, :kb_config, updated_config)}
+      {ctx, tools}
+    else
+      {ctx, tools}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp should_inject_this_iteration?(config) do
+    case config[:inject_strategy] do
+      :every_iteration -> true
+      _ -> config[:_inject_done] != true
+    end
+  end
+
+  defp inject_relevant_entries(ctx, config) do
+    query = latest_user_query(ctx.messages)
+
+    if query do
+      store_mod = config[:store]
+      store_state = config[:store_state]
+      limit = config[:inject_limit] || 3
+      min_score = config[:inject_min_score] || 0.3
+
+      search_opts = [
+        limit: limit,
+        min_score: min_score,
+        kb_id: config[:kb_id]
+      ]
+
+      case store_mod.search_entries(store_state, query, search_opts) do
+        {:ok, []} ->
+          ctx
+
+        {:ok, results} ->
+          kb_text =
+            results
+            |> Enum.map(fn {entry, score} ->
+              summary = entry.summary || String.slice(entry.content, 0, 200)
+              "- [[#{entry.slug}]] #{entry.title} (score: #{Float.round(score, 3)}): #{summary}"
+            end)
+            |> Enum.join("\n")
+
+          kb_msg = Nous.Message.system("[Relevant Knowledge]\n#{kb_text}")
+          %{ctx | messages: ctx.messages ++ [kb_msg]}
+
+        _ ->
+          ctx
+      end
+    else
+      ctx
+    end
+  end
+
+  defp latest_user_query(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{role: :user, content: content} when is_binary(content) -> content
+      _ -> nil
+    end)
+  end
+end

--- a/test/nous/knowledge_base/document_test.exs
+++ b/test/nous/knowledge_base/document_test.exs
@@ -1,0 +1,121 @@
+defmodule Nous.KnowledgeBase.DocumentTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.Document
+
+  describe "new/1" do
+    test "creates document with required title and content" do
+      doc = Document.new(%{title: "GenServer Guide", content: "# GenServer\nHow to use..."})
+
+      assert doc.title == "GenServer Guide"
+      assert doc.content == "# GenServer\nHow to use..."
+      assert is_binary(doc.id)
+      assert byte_size(doc.id) == 32
+    end
+
+    test "defaults doc_type to :markdown" do
+      doc = Document.new(%{title: "test", content: "test"})
+      assert doc.doc_type == :markdown
+    end
+
+    test "defaults status to :pending" do
+      doc = Document.new(%{title: "test", content: "test"})
+      assert doc.status == :pending
+    end
+
+    test "defaults metadata to empty map" do
+      doc = Document.new(%{title: "test", content: "test"})
+      assert doc.metadata == %{}
+    end
+
+    test "defaults compiled_entry_ids to empty list" do
+      doc = Document.new(%{title: "test", content: "test"})
+      assert doc.compiled_entry_ids == []
+    end
+
+    test "auto-generates checksum from content" do
+      doc = Document.new(%{title: "test", content: "hello"})
+      assert is_binary(doc.checksum)
+      assert byte_size(doc.checksum) == 64
+
+      # Same content = same checksum
+      doc2 = Document.new(%{title: "other title", content: "hello"})
+      assert doc.checksum == doc2.checksum
+    end
+
+    test "different content produces different checksums" do
+      doc1 = Document.new(%{title: "test", content: "hello"})
+      doc2 = Document.new(%{title: "test", content: "world"})
+      assert doc1.checksum != doc2.checksum
+    end
+
+    test "auto-generates id and timestamps" do
+      doc = Document.new(%{title: "test", content: "test"})
+
+      assert is_binary(doc.id)
+      assert %DateTime{} = doc.created_at
+      assert %DateTime{} = doc.updated_at
+    end
+
+    test "accepts all optional fields" do
+      now = DateTime.utc_now()
+
+      doc =
+        Document.new(%{
+          title: "My Article",
+          content: "body text",
+          doc_type: :url,
+          source_url: "https://example.com",
+          source_path: "/tmp/article.md",
+          status: :compiled,
+          metadata: %{author: "Alice"},
+          compiled_entry_ids: ["entry-1"],
+          kb_id: "my-kb",
+          created_at: now,
+          updated_at: now
+        })
+
+      assert doc.doc_type == :url
+      assert doc.source_url == "https://example.com"
+      assert doc.source_path == "/tmp/article.md"
+      assert doc.status == :compiled
+      assert doc.metadata == %{author: "Alice"}
+      assert doc.compiled_entry_ids == ["entry-1"]
+      assert doc.kb_id == "my-kb"
+      assert doc.created_at == now
+    end
+
+    test "allows custom id" do
+      doc = Document.new(%{title: "test", content: "test", id: "custom-id"})
+      assert doc.id == "custom-id"
+    end
+
+    test "allows custom checksum" do
+      doc = Document.new(%{title: "test", content: "test", checksum: "custom-checksum"})
+      assert doc.checksum == "custom-checksum"
+    end
+
+    test "raises on missing title" do
+      assert_raise KeyError, fn ->
+        Document.new(%{content: "test"})
+      end
+    end
+
+    test "raises on missing content" do
+      assert_raise KeyError, fn ->
+        Document.new(%{title: "test"})
+      end
+    end
+  end
+
+  describe "compute_checksum/1" do
+    test "produces consistent SHA-256 hex string" do
+      assert Document.compute_checksum("hello") == Document.compute_checksum("hello")
+      assert byte_size(Document.compute_checksum("hello")) == 64
+    end
+
+    test "different inputs produce different checksums" do
+      assert Document.compute_checksum("a") != Document.compute_checksum("b")
+    end
+  end
+end

--- a/test/nous/knowledge_base/entry_test.exs
+++ b/test/nous/knowledge_base/entry_test.exs
@@ -1,0 +1,135 @@
+defmodule Nous.KnowledgeBase.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.Entry
+
+  describe "new/1" do
+    test "creates entry with required title and content" do
+      entry = Entry.new(%{title: "GenServer Patterns", content: "# GenServer\n..."})
+
+      assert entry.title == "GenServer Patterns"
+      assert entry.content == "# GenServer\n..."
+      assert is_binary(entry.id)
+      assert byte_size(entry.id) == 32
+    end
+
+    test "auto-generates slug from title" do
+      entry = Entry.new(%{title: "Elixir GenServer Patterns", content: "test"})
+      assert entry.slug == "elixir-genserver-patterns"
+    end
+
+    test "defaults entry_type to :article" do
+      entry = Entry.new(%{title: "test", content: "test"})
+      assert entry.entry_type == :article
+    end
+
+    test "defaults confidence to 0.5" do
+      entry = Entry.new(%{title: "test", content: "test"})
+      assert entry.confidence == 0.5
+    end
+
+    test "defaults concepts and tags to empty lists" do
+      entry = Entry.new(%{title: "test", content: "test"})
+      assert entry.concepts == []
+      assert entry.tags == []
+    end
+
+    test "defaults source_doc_ids to empty list" do
+      entry = Entry.new(%{title: "test", content: "test"})
+      assert entry.source_doc_ids == []
+    end
+
+    test "defaults metadata to empty map" do
+      entry = Entry.new(%{title: "test", content: "test"})
+      assert entry.metadata == %{}
+    end
+
+    test "auto-generates id and timestamps" do
+      entry = Entry.new(%{title: "test", content: "test"})
+
+      assert is_binary(entry.id)
+      assert %DateTime{} = entry.created_at
+      assert %DateTime{} = entry.updated_at
+    end
+
+    test "accepts all optional fields" do
+      now = DateTime.utc_now()
+
+      entry =
+        Entry.new(%{
+          title: "OTP Supervision",
+          content: "# Supervision\n...",
+          slug: "custom-slug",
+          summary: "How OTP supervision trees work",
+          entry_type: :concept,
+          concepts: ["supervision", "otp", "fault-tolerance"],
+          tags: ["elixir", "otp"],
+          confidence: 0.9,
+          source_doc_ids: ["doc-1", "doc-2"],
+          embedding: [0.1, 0.2, 0.3],
+          metadata: %{reviewed: true},
+          kb_id: "my-kb",
+          created_at: now,
+          updated_at: now,
+          last_verified_at: now
+        })
+
+      assert entry.slug == "custom-slug"
+      assert entry.summary == "How OTP supervision trees work"
+      assert entry.entry_type == :concept
+      assert entry.concepts == ["supervision", "otp", "fault-tolerance"]
+      assert entry.tags == ["elixir", "otp"]
+      assert entry.confidence == 0.9
+      assert entry.source_doc_ids == ["doc-1", "doc-2"]
+      assert entry.embedding == [0.1, 0.2, 0.3]
+      assert entry.metadata == %{reviewed: true}
+      assert entry.kb_id == "my-kb"
+      assert entry.last_verified_at == now
+    end
+
+    test "allows custom id" do
+      entry = Entry.new(%{title: "test", content: "test", id: "custom-id"})
+      assert entry.id == "custom-id"
+    end
+
+    test "raises on missing title" do
+      assert_raise KeyError, fn ->
+        Entry.new(%{content: "test"})
+      end
+    end
+
+    test "raises on missing content" do
+      assert_raise KeyError, fn ->
+        Entry.new(%{title: "test"})
+      end
+    end
+  end
+
+  describe "slugify/1" do
+    test "converts title to lowercase kebab-case" do
+      assert Entry.slugify("Elixir GenServer Patterns") == "elixir-genserver-patterns"
+    end
+
+    test "removes special characters" do
+      assert Entry.slugify("What's New in OTP 27?") == "whats-new-in-otp-27"
+    end
+
+    test "collapses multiple spaces and hyphens" do
+      assert Entry.slugify("Too   Many   Spaces") == "too-many-spaces"
+      assert Entry.slugify("Already---Hyphenated") == "already-hyphenated"
+    end
+
+    test "trims leading and trailing hyphens" do
+      assert Entry.slugify(" Leading Space ") == "leading-space"
+      assert Entry.slugify("-Dashes-") == "dashes"
+    end
+
+    test "handles underscores" do
+      assert Entry.slugify("snake_case_title") == "snake-case-title"
+    end
+
+    test "handles empty string" do
+      assert Entry.slugify("") == ""
+    end
+  end
+end

--- a/test/nous/knowledge_base/link_test.exs
+++ b/test/nous/knowledge_base/link_test.exs
@@ -1,0 +1,71 @@
+defmodule Nous.KnowledgeBase.LinkTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.Link
+
+  describe "new/1" do
+    test "creates link with required from and to entry IDs" do
+      link = Link.new(%{from_entry_id: "entry-1", to_entry_id: "entry-2"})
+
+      assert link.from_entry_id == "entry-1"
+      assert link.to_entry_id == "entry-2"
+      assert is_binary(link.id)
+      assert byte_size(link.id) == 32
+    end
+
+    test "defaults link_type to :cross_reference" do
+      link = Link.new(%{from_entry_id: "a", to_entry_id: "b"})
+      assert link.link_type == :cross_reference
+    end
+
+    test "defaults weight to 1.0" do
+      link = Link.new(%{from_entry_id: "a", to_entry_id: "b"})
+      assert link.weight == 1.0
+    end
+
+    test "auto-generates id and timestamp" do
+      link = Link.new(%{from_entry_id: "a", to_entry_id: "b"})
+
+      assert is_binary(link.id)
+      assert %DateTime{} = link.created_at
+    end
+
+    test "accepts all optional fields" do
+      now = DateTime.utc_now()
+
+      link =
+        Link.new(%{
+          from_entry_id: "entry-1",
+          to_entry_id: "entry-2",
+          link_type: :backlink,
+          label: "See also",
+          weight: 0.8,
+          kb_id: "my-kb",
+          created_at: now
+        })
+
+      assert link.link_type == :backlink
+      assert link.label == "See also"
+      assert link.weight == 0.8
+      assert link.kb_id == "my-kb"
+      assert link.created_at == now
+    end
+
+    test "allows custom id" do
+      link = Link.new(%{from_entry_id: "a", to_entry_id: "b", id: "custom-id"})
+      assert link.id == "custom-id"
+    end
+
+    test "raises on missing from_entry_id" do
+      assert_raise KeyError, fn ->
+        Link.new(%{to_entry_id: "b"})
+      end
+    end
+
+    test "raises on missing to_entry_id" do
+      assert_raise KeyError, fn ->
+        Link.new(%{from_entry_id: "a"})
+      end
+    end
+  end
+end

--- a/test/nous/knowledge_base/store/ets_test.exs
+++ b/test/nous/knowledge_base/store/ets_test.exs
@@ -1,0 +1,368 @@
+defmodule Nous.KnowledgeBase.Store.ETSTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.{Document, Entry, Link}
+  alias Nous.KnowledgeBase.Store.ETS
+
+  setup do
+    {:ok, state} = ETS.init([])
+    %{state: state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Init
+  # ---------------------------------------------------------------------------
+
+  describe "init/1" do
+    test "creates state with three ETS tables" do
+      {:ok, state} = ETS.init([])
+      assert is_reference(state.documents)
+      assert is_reference(state.entries)
+      assert is_reference(state.links)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Document CRUD
+  # ---------------------------------------------------------------------------
+
+  describe "store_document/2 and fetch_document/2" do
+    test "roundtrip stores and fetches a document", %{state: state} do
+      doc = Document.new(%{title: "Test Doc", content: "Hello"})
+      {:ok, _} = ETS.store_document(state, doc)
+
+      assert {:ok, fetched} = ETS.fetch_document(state, doc.id)
+      assert fetched.id == doc.id
+      assert fetched.title == "Test Doc"
+    end
+
+    test "fetch returns error for non-existent document", %{state: state} do
+      assert {:error, :not_found} = ETS.fetch_document(state, "nonexistent")
+    end
+  end
+
+  describe "update_document/3" do
+    test "updates specific fields", %{state: state} do
+      doc = Document.new(%{title: "Test", content: "body", status: :pending})
+      {:ok, _} = ETS.store_document(state, doc)
+
+      {:ok, _} = ETS.update_document(state, doc.id, %{status: :compiled})
+
+      {:ok, updated} = ETS.fetch_document(state, doc.id)
+      assert updated.status == :compiled
+    end
+
+    test "returns error when document not found", %{state: state} do
+      assert {:error, :not_found} =
+               ETS.update_document(state, "nonexistent", %{status: :compiled})
+    end
+  end
+
+  describe "delete_document/2" do
+    test "removes a document", %{state: state} do
+      doc = Document.new(%{title: "Test", content: "body"})
+      {:ok, _} = ETS.store_document(state, doc)
+      {:ok, _} = ETS.delete_document(state, doc.id)
+
+      assert {:error, :not_found} = ETS.fetch_document(state, doc.id)
+    end
+  end
+
+  describe "list_documents/2" do
+    test "lists all documents", %{state: state} do
+      for i <- 1..3 do
+        doc = Document.new(%{title: "Doc #{i}", content: "content #{i}"})
+        ETS.store_document(state, doc)
+      end
+
+      {:ok, docs} = ETS.list_documents(state, [])
+      assert length(docs) == 3
+    end
+
+    test "filters by kb_id", %{state: state} do
+      d1 = Document.new(%{title: "A", content: "a", kb_id: "kb1"})
+      d2 = Document.new(%{title: "B", content: "b", kb_id: "kb2"})
+      ETS.store_document(state, d1)
+      ETS.store_document(state, d2)
+
+      {:ok, docs} = ETS.list_documents(state, kb_id: "kb1")
+      assert length(docs) == 1
+      assert hd(docs).kb_id == "kb1"
+    end
+
+    test "filters by status", %{state: state} do
+      d1 = Document.new(%{title: "A", content: "a", status: :pending})
+      d2 = Document.new(%{title: "B", content: "b", status: :compiled})
+      ETS.store_document(state, d1)
+      ETS.store_document(state, d2)
+
+      {:ok, docs} = ETS.list_documents(state, status: :compiled)
+      assert length(docs) == 1
+      assert hd(docs).status == :compiled
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Entry CRUD + search
+  # ---------------------------------------------------------------------------
+
+  describe "store_entry/2 and fetch_entry/2" do
+    test "roundtrip stores and fetches an entry", %{state: state} do
+      entry = Entry.new(%{title: "GenServer", content: "# GenServer\n..."})
+      {:ok, _} = ETS.store_entry(state, entry)
+
+      assert {:ok, fetched} = ETS.fetch_entry(state, entry.id)
+      assert fetched.id == entry.id
+      assert fetched.title == "GenServer"
+    end
+
+    test "fetch returns error for non-existent entry", %{state: state} do
+      assert {:error, :not_found} = ETS.fetch_entry(state, "nonexistent")
+    end
+  end
+
+  describe "fetch_entry_by_slug/2" do
+    test "finds entry by slug", %{state: state} do
+      entry = Entry.new(%{title: "GenServer Patterns", content: "content"})
+      {:ok, _} = ETS.store_entry(state, entry)
+
+      assert {:ok, fetched} = ETS.fetch_entry_by_slug(state, "genserver-patterns")
+      assert fetched.id == entry.id
+    end
+
+    test "returns error for non-existent slug", %{state: state} do
+      assert {:error, :not_found} = ETS.fetch_entry_by_slug(state, "nonexistent")
+    end
+  end
+
+  describe "update_entry/3" do
+    test "updates specific fields", %{state: state} do
+      entry = Entry.new(%{title: "Test", content: "old", confidence: 0.5})
+      {:ok, _} = ETS.store_entry(state, entry)
+
+      {:ok, _} = ETS.update_entry(state, entry.id, %{confidence: 0.9, content: "new"})
+
+      {:ok, updated} = ETS.fetch_entry(state, entry.id)
+      assert updated.confidence == 0.9
+      assert updated.content == "new"
+    end
+
+    test "returns error when entry not found", %{state: state} do
+      assert {:error, :not_found} = ETS.update_entry(state, "nonexistent", %{confidence: 1.0})
+    end
+  end
+
+  describe "delete_entry/2" do
+    test "removes an entry", %{state: state} do
+      entry = Entry.new(%{title: "Test", content: "body"})
+      {:ok, _} = ETS.store_entry(state, entry)
+      {:ok, _} = ETS.delete_entry(state, entry.id)
+
+      assert {:error, :not_found} = ETS.fetch_entry(state, entry.id)
+    end
+  end
+
+  describe "list_entries/2" do
+    test "lists all entries", %{state: state} do
+      for i <- 1..3 do
+        entry = Entry.new(%{title: "Entry #{i}", content: "content #{i}"})
+        ETS.store_entry(state, entry)
+      end
+
+      {:ok, entries} = ETS.list_entries(state, [])
+      assert length(entries) == 3
+    end
+
+    test "filters by kb_id", %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", kb_id: "kb1"})
+      e2 = Entry.new(%{title: "B", content: "b", kb_id: "kb2"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, entries} = ETS.list_entries(state, kb_id: "kb1")
+      assert length(entries) == 1
+    end
+
+    test "filters by entry_type", %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", entry_type: :article})
+      e2 = Entry.new(%{title: "B", content: "b", entry_type: :concept})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, entries} = ETS.list_entries(state, entry_type: :concept)
+      assert length(entries) == 1
+      assert hd(entries).entry_type == :concept
+    end
+
+    test "filters by tags", %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", tags: ["elixir", "otp"]})
+      e2 = Entry.new(%{title: "B", content: "b", tags: ["python"]})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, entries} = ETS.list_entries(state, tags: ["otp"])
+      assert length(entries) == 1
+      assert hd(entries).title == "A"
+    end
+
+    test "filters by concepts", %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", concepts: ["genserver", "supervision"]})
+      e2 = Entry.new(%{title: "B", content: "b", concepts: ["ecto"]})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, entries} = ETS.list_entries(state, concepts: ["supervision"])
+      assert length(entries) == 1
+      assert hd(entries).title == "A"
+    end
+
+    test "respects limit", %{state: state} do
+      for i <- 1..5 do
+        entry = Entry.new(%{title: "Entry #{i}", content: "content #{i}"})
+        ETS.store_entry(state, entry)
+      end
+
+      {:ok, entries} = ETS.list_entries(state, limit: 2)
+      assert length(entries) == 2
+    end
+  end
+
+  describe "search_entries/3" do
+    test "finds entries by fuzzy text match", %{state: state} do
+      e1 = Entry.new(%{title: "GenServer Patterns", content: "How to use GenServer in Elixir"})
+      e2 = Entry.new(%{title: "Ecto Schemas", content: "Database schemas with Ecto"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, results} = ETS.search_entries(state, "GenServer", [])
+
+      assert length(results) > 0
+      {top_entry, _score} = hd(results)
+      assert top_entry.title == "GenServer Patterns"
+    end
+
+    test "respects limit", %{state: state} do
+      for i <- 1..5 do
+        entry = Entry.new(%{title: "Entry #{i}", content: "content #{i}"})
+        ETS.store_entry(state, entry)
+      end
+
+      {:ok, results} = ETS.search_entries(state, "entry", limit: 2)
+      assert length(results) == 2
+    end
+
+    test "respects min_score", %{state: state} do
+      entry = Entry.new(%{title: "Completely Unrelated", content: "xyz abc 123"})
+      ETS.store_entry(state, entry)
+
+      {:ok, results} = ETS.search_entries(state, "GenServer patterns OTP", min_score: 0.9)
+      assert results == []
+    end
+
+    test "filters by kb_id", %{state: state} do
+      e1 = Entry.new(%{title: "GenServer", content: "content", kb_id: "kb1"})
+      e2 = Entry.new(%{title: "GenServer", content: "content", kb_id: "kb2"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      {:ok, results} = ETS.search_entries(state, "GenServer", kb_id: "kb1")
+      assert length(results) == 1
+      {found, _} = hd(results)
+      assert found.kb_id == "kb1"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Link CRUD + graph
+  # ---------------------------------------------------------------------------
+
+  describe "store_link/2 and backlinks/outlinks" do
+    setup %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", id: "entry-a"})
+      e2 = Entry.new(%{title: "B", content: "b", id: "entry-b"})
+      e3 = Entry.new(%{title: "C", content: "c", id: "entry-c"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+      ETS.store_entry(state, e3)
+
+      # A -> B, A -> C
+      link1 = Link.new(%{from_entry_id: "entry-a", to_entry_id: "entry-b"})
+      link2 = Link.new(%{from_entry_id: "entry-a", to_entry_id: "entry-c"})
+      ETS.store_link(state, link1)
+      ETS.store_link(state, link2)
+
+      %{state: state}
+    end
+
+    test "backlinks returns links pointing to an entry", %{state: state} do
+      {:ok, links} = ETS.backlinks(state, "entry-b")
+      assert length(links) == 1
+      assert hd(links).from_entry_id == "entry-a"
+    end
+
+    test "outlinks returns links from an entry", %{state: state} do
+      {:ok, links} = ETS.outlinks(state, "entry-a")
+      assert length(links) == 2
+    end
+
+    test "backlinks returns empty for no incoming links", %{state: state} do
+      {:ok, links} = ETS.backlinks(state, "entry-a")
+      assert links == []
+    end
+  end
+
+  describe "delete_link/2" do
+    test "removes a link", %{state: state} do
+      link = Link.new(%{from_entry_id: "a", to_entry_id: "b"})
+      {:ok, _} = ETS.store_link(state, link)
+      {:ok, _} = ETS.delete_link(state, link.id)
+
+      {:ok, links} = ETS.backlinks(state, "b")
+      assert links == []
+    end
+  end
+
+  describe "related_entries/3" do
+    test "finds entries connected by links", %{state: state} do
+      e1 = Entry.new(%{title: "A", content: "a", id: "e1"})
+      e2 = Entry.new(%{title: "B", content: "b", id: "e2"})
+      e3 = Entry.new(%{title: "C", content: "c", id: "e3"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+      ETS.store_entry(state, e3)
+
+      # e1 -> e2, e3 -> e1
+      ETS.store_link(state, Link.new(%{from_entry_id: "e1", to_entry_id: "e2"}))
+      ETS.store_link(state, Link.new(%{from_entry_id: "e3", to_entry_id: "e1"}))
+
+      {:ok, related} = ETS.related_entries(state, "e1", [])
+
+      ids = Enum.map(related, & &1.id)
+      assert "e2" in ids
+      assert "e3" in ids
+      assert "e1" not in ids
+    end
+
+    test "respects limit", %{state: state} do
+      source = Entry.new(%{title: "Source", content: "s", id: "source"})
+      ETS.store_entry(state, source)
+
+      for i <- 1..5 do
+        id = "target-#{i}"
+        ETS.store_entry(state, Entry.new(%{title: "T#{i}", content: "t", id: id}))
+        ETS.store_link(state, Link.new(%{from_entry_id: "source", to_entry_id: id}))
+      end
+
+      {:ok, related} = ETS.related_entries(state, "source", limit: 2)
+      assert length(related) == 2
+    end
+
+    test "returns empty for isolated entry", %{state: state} do
+      entry = Entry.new(%{title: "Isolated", content: "alone", id: "isolated"})
+      ETS.store_entry(state, entry)
+
+      {:ok, related} = ETS.related_entries(state, "isolated", [])
+      assert related == []
+    end
+  end
+end

--- a/test/nous/knowledge_base/tools_test.exs
+++ b/test/nous/knowledge_base/tools_test.exs
@@ -1,0 +1,281 @@
+defmodule Nous.KnowledgeBase.ToolsTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.{Entry, Link, Tools}
+  alias Nous.KnowledgeBase.Store.ETS
+
+  defp build_ctx(state, opts \\ []) do
+    kb_config =
+      %{
+        store: ETS,
+        store_state: state,
+        kb_id: Keyword.get(opts, :kb_id)
+      }
+
+    %Nous.Agent.Context{
+      messages: [],
+      deps: %{kb_config: kb_config}
+    }
+  end
+
+  setup do
+    {:ok, state} = ETS.init([])
+    %{state: state}
+  end
+
+  describe "kb_search/2" do
+    test "searches entries and returns formatted results", %{state: state} do
+      entry =
+        Entry.new(%{
+          title: "GenServer Patterns",
+          content: "How to use GenServer",
+          summary: "A guide to GenServer"
+        })
+
+      ETS.store_entry(state, entry)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_search(ctx, %{"query" => "GenServer"})
+
+      assert result.status == "found"
+      assert result.count == 1
+      assert hd(result.entries).slug == "genserver-patterns"
+    end
+
+    test "returns empty when no matches", %{state: state} do
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_search(ctx, %{"query" => "nothing", "limit" => 5})
+
+      assert result.status == "found"
+      assert result.count == 0
+    end
+
+    test "returns error when store not initialized" do
+      ctx = %Nous.Agent.Context{messages: [], deps: %{}}
+      {:ok, result, _update} = Tools.kb_search(ctx, %{"query" => "test"})
+      assert result.status == "error"
+    end
+  end
+
+  describe "kb_read/2" do
+    test "reads entry by slug", %{state: state} do
+      entry = Entry.new(%{title: "GenServer Patterns", content: "body text"})
+      ETS.store_entry(state, entry)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_read(ctx, %{"slug_or_id" => "genserver-patterns"})
+
+      assert result.title == "GenServer Patterns"
+      assert result.content == "body text"
+    end
+
+    test "reads entry by ID", %{state: state} do
+      entry = Entry.new(%{title: "Test", content: "body", id: "my-id"})
+      ETS.store_entry(state, entry)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_read(ctx, %{"slug_or_id" => "my-id"})
+
+      assert result.title == "Test"
+    end
+
+    test "returns not_found for missing entry", %{state: state} do
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_read(ctx, %{"slug_or_id" => "nonexistent"})
+
+      assert result.status == "not_found"
+    end
+  end
+
+  describe "kb_list/2" do
+    test "lists all entries", %{state: state} do
+      for i <- 1..3 do
+        ETS.store_entry(state, Entry.new(%{title: "Entry #{i}", content: "c"}))
+      end
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_list(ctx, %{})
+
+      assert result.status == "ok"
+      assert result.count == 3
+    end
+
+    test "filters by tags", %{state: state} do
+      ETS.store_entry(state, Entry.new(%{title: "A", content: "a", tags: ["elixir"]}))
+      ETS.store_entry(state, Entry.new(%{title: "B", content: "b", tags: ["python"]}))
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_list(ctx, %{"tags" => ["elixir"]})
+
+      assert result.count == 1
+      assert hd(result.entries).title == "A"
+    end
+  end
+
+  describe "kb_ingest/2" do
+    test "ingests a raw document", %{state: state} do
+      ctx = build_ctx(state)
+
+      {:ok, result, update} =
+        Tools.kb_ingest(ctx, %{
+          "title" => "My Article",
+          "content" => "Article body text"
+        })
+
+      assert result.status == "ingested"
+      assert is_binary(result.id)
+      assert is_binary(result.checksum)
+
+      # Verify the context update contains the new store state
+      assert update.operations != []
+    end
+  end
+
+  describe "kb_add_entry/2" do
+    test "creates a wiki entry", %{state: state} do
+      ctx = build_ctx(state)
+
+      {:ok, result, _update} =
+        Tools.kb_add_entry(ctx, %{
+          "title" => "GenServer Patterns",
+          "content" => "# GenServer\nUse GenServer for...",
+          "summary" => "How to use GenServer",
+          "concepts" => ["genserver", "otp"],
+          "tags" => ["elixir"]
+        })
+
+      assert result.status == "created"
+      assert result.slug == "genserver-patterns"
+
+      # Verify it's actually in the store
+      {:ok, entry} = ETS.fetch_entry_by_slug(state, "genserver-patterns")
+      assert entry.concepts == ["genserver", "otp"]
+    end
+  end
+
+  describe "kb_link/2" do
+    test "creates a link between entries", %{state: state} do
+      e1 = Entry.new(%{title: "GenServer", content: "a", id: "e1"})
+      e2 = Entry.new(%{title: "Supervisor", content: "b", id: "e2"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      ctx = build_ctx(state)
+
+      {:ok, result, _update} =
+        Tools.kb_link(ctx, %{
+          "from_slug" => "genserver",
+          "to_slug" => "supervisor",
+          "link_type" => "see_also"
+        })
+
+      assert result.status == "linked"
+      assert result.from == "genserver"
+      assert result.to == "supervisor"
+    end
+
+    test "returns error for missing entry", %{state: state} do
+      ctx = build_ctx(state)
+
+      {:ok, result, _update} =
+        Tools.kb_link(ctx, %{
+          "from_slug" => "nonexistent",
+          "to_slug" => "also-nonexistent"
+        })
+
+      assert result.status == "error"
+    end
+  end
+
+  describe "kb_backlinks/2" do
+    test "finds entries linking to a given entry", %{state: state} do
+      e1 = Entry.new(%{title: "GenServer", content: "a", id: "e1"})
+      e2 = Entry.new(%{title: "Supervisor", content: "b", id: "e2"})
+      ETS.store_entry(state, e1)
+      ETS.store_entry(state, e2)
+
+      link = Link.new(%{from_entry_id: "e1", to_entry_id: "e2"})
+      ETS.store_link(state, link)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_backlinks(ctx, %{"slug_or_id" => "supervisor"})
+
+      assert result.status == "ok"
+      assert result.backlink_count == 1
+      assert hd(result.backlinks).slug == "genserver"
+    end
+  end
+
+  describe "kb_health_check/2" do
+    test "returns health report for empty KB", %{state: state} do
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_health_check(ctx, %{})
+
+      assert result.status == "ok"
+      assert result.total_entries == 0
+      assert result.total_documents == 0
+    end
+
+    test "identifies orphan entries", %{state: state} do
+      entry = Entry.new(%{title: "Orphan", content: "no links or sources"})
+      ETS.store_entry(state, entry)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_health_check(ctx, %{})
+
+      assert result.issue_count > 0
+      assert Enum.any?(result.issues, fn i -> i.type == "orphan" end)
+    end
+
+    test "identifies low confidence entries", %{state: state} do
+      entry = Entry.new(%{title: "Uncertain", content: "maybe", confidence: 0.1})
+      ETS.store_entry(state, entry)
+
+      ctx = build_ctx(state)
+      {:ok, result, _update} = Tools.kb_health_check(ctx, %{})
+
+      assert Enum.any?(result.issues, fn i -> i.type == "low_confidence" end)
+    end
+  end
+
+  describe "kb_generate/2" do
+    test "generates a summary from entries", %{state: state} do
+      ETS.store_entry(
+        state,
+        Entry.new(%{
+          title: "GenServer Guide",
+          content: "GenServer is an OTP behaviour...",
+          summary: "How to use GenServer"
+        })
+      )
+
+      ctx = build_ctx(state)
+
+      {:ok, result, _update} =
+        Tools.kb_generate(ctx, %{"topic" => "GenServer", "output_type" => "summary"})
+
+      assert result.status == "generated"
+      assert result.output_type == "summary"
+      assert String.contains?(result.content, "GenServer")
+    end
+
+    test "generates slides in Marp format", %{state: state} do
+      ETS.store_entry(
+        state,
+        Entry.new(%{
+          title: "OTP Patterns",
+          content: "Supervision trees...",
+          summary: "OTP overview"
+        })
+      )
+
+      ctx = build_ctx(state)
+
+      {:ok, result, _update} =
+        Tools.kb_generate(ctx, %{"topic" => "OTP", "output_type" => "slides"})
+
+      assert result.status == "generated"
+      assert String.contains?(result.content, "marp: true")
+    end
+  end
+end

--- a/test/nous/plugins/knowledge_base_test.exs
+++ b/test/nous/plugins/knowledge_base_test.exs
@@ -1,0 +1,183 @@
+defmodule Nous.Plugins.KnowledgeBaseTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.KnowledgeBase.{Entry, Store}
+  alias Nous.Plugins.KnowledgeBase, as: KBPlugin
+
+  defp build_agent do
+    %Nous.Agent{
+      model: %Nous.Model{provider: :openai, model: "gpt-4"},
+      tools: [],
+      plugins: []
+    }
+  end
+
+  defp build_ctx(deps \\ %{}) do
+    %Nous.Agent.Context{
+      messages: [],
+      deps: deps
+    }
+  end
+
+  describe "init/2" do
+    test "initializes store and sets defaults" do
+      agent = build_agent()
+      ctx = build_ctx(%{kb_config: %{store: Store.ETS, kb_id: "test-kb"}})
+
+      result_ctx = KBPlugin.init(agent, ctx)
+      config = result_ctx.deps[:kb_config]
+
+      assert config[:store_state] != nil
+      assert config[:auto_inject] == true
+      assert config[:inject_strategy] == :first_only
+      assert config[:inject_limit] == 3
+      assert config[:inject_min_score] == 0.3
+      assert config[:auto_compile] == false
+    end
+
+    test "warns and returns ctx unchanged when no store configured" do
+      agent = build_agent()
+      ctx = build_ctx(%{kb_config: %{}})
+
+      result_ctx = KBPlugin.init(agent, ctx)
+      assert result_ctx == ctx
+    end
+
+    test "returns ctx unchanged when no kb_config" do
+      agent = build_agent()
+      ctx = build_ctx(%{})
+
+      result_ctx = KBPlugin.init(agent, ctx)
+      assert result_ctx == ctx
+    end
+  end
+
+  describe "tools/2" do
+    test "returns 9 KB tools" do
+      agent = build_agent()
+      ctx = build_ctx()
+
+      tools = KBPlugin.tools(agent, ctx)
+      assert length(tools) == 9
+
+      names = Enum.map(tools, & &1.name)
+      assert "kb_search" in names
+      assert "kb_read" in names
+      assert "kb_list" in names
+      assert "kb_ingest" in names
+      assert "kb_add_entry" in names
+      assert "kb_link" in names
+      assert "kb_backlinks" in names
+      assert "kb_health_check" in names
+      assert "kb_generate" in names
+    end
+  end
+
+  describe "system_prompt/2" do
+    test "returns prompt when store is initialized" do
+      agent = build_agent()
+      ctx = build_ctx(%{kb_config: %{store_state: :some_state}})
+
+      prompt = KBPlugin.system_prompt(agent, ctx)
+      assert is_binary(prompt)
+      assert String.contains?(prompt, "Knowledge Base")
+      assert String.contains?(prompt, "kb_search")
+    end
+
+    test "returns nil when store not initialized" do
+      agent = build_agent()
+      ctx = build_ctx(%{kb_config: %{}})
+
+      assert KBPlugin.system_prompt(agent, ctx) == nil
+    end
+  end
+
+  describe "before_request/3" do
+    test "injects relevant entries when auto_inject enabled" do
+      {:ok, state} = Store.ETS.init([])
+
+      entry =
+        Entry.new(%{
+          title: "GenServer Guide",
+          content: "How to use GenServer in Elixir",
+          summary: "A comprehensive guide"
+        })
+
+      Store.ETS.store_entry(state, entry)
+
+      agent = build_agent()
+
+      ctx =
+        build_ctx(%{
+          kb_config: %{
+            store: Store.ETS,
+            store_state: state,
+            auto_inject: true,
+            inject_strategy: :first_only,
+            inject_limit: 3,
+            inject_min_score: 0.0,
+            _inject_done: false
+          }
+        })
+
+      ctx = %{ctx | messages: [Nous.Message.user("Tell me about GenServer")]}
+
+      {result_ctx, _tools} = KBPlugin.before_request(agent, ctx, [])
+
+      # Should have injected a system message
+      assert length(result_ctx.messages) > length(ctx.messages)
+
+      injected = List.last(result_ctx.messages)
+      assert injected.role == :system
+      assert String.contains?(injected.content, "Relevant Knowledge")
+      assert String.contains?(injected.content, "genserver-guide")
+    end
+
+    test "does not inject when auto_inject is false" do
+      {:ok, state} = Store.ETS.init([])
+
+      agent = build_agent()
+
+      ctx =
+        build_ctx(%{
+          kb_config: %{
+            store: Store.ETS,
+            store_state: state,
+            auto_inject: false,
+            _inject_done: false
+          }
+        })
+
+      ctx = %{ctx | messages: [Nous.Message.user("test")]}
+
+      {result_ctx, _tools} = KBPlugin.before_request(agent, ctx, [])
+      assert length(result_ctx.messages) == length(ctx.messages)
+    end
+
+    test "respects first_only strategy" do
+      {:ok, state} = Store.ETS.init([])
+
+      agent = build_agent()
+
+      ctx =
+        build_ctx(%{
+          kb_config: %{
+            store: Store.ETS,
+            store_state: state,
+            auto_inject: true,
+            inject_strategy: :first_only,
+            inject_limit: 3,
+            inject_min_score: 0.0,
+            _inject_done: true
+          }
+        })
+
+      ctx = %{ctx | messages: [Nous.Message.user("test")]}
+
+      {result_ctx, _tools} = KBPlugin.before_request(agent, ctx, [])
+
+      # Should not inject since _inject_done is true
+      assert length(result_ctx.messages) == length(ctx.messages)
+    end
+  end
+end


### PR DESCRIPTION
▎ Karpathy-inspired personal knowledge base — raw docs get ingested, LLM compiles them into a markdown wiki with summaries/backlinks/cross-references, you can Q&A over it, generate
  outputs, and run health checks.

  ▎ Four composable layers: data model & ETS store, plugin with 9 agent tools, workflow DAG pipelines (ingest, incremental update, health check, output generation), and a specialized
  KnowledgeBaseAgent behaviour. Composes cleanly with existing Memory plugin. 101 new tests, full suite green.
