### PR TITLE
fix: propagate parent deps to sub-agents by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.2] - 2026-04-13
+
+### Fixed
+
+- **SubAgent deps propagation** — parent deps now flow to sub-agents by default (excluding plugin-internal keys like templates, PubSub, concurrency config). Use `sub_agent_shared_deps: [:key1, :key2]` in deps to restrict which keys are shared.
+
 ## [0.14.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -831,14 +831,17 @@ The `SubAgent` plugin provides two tools:
 - `delegate_task` — run a single sub-agent for sequential delegation
 - `spawn_agents` — run multiple sub-agents concurrently via `Task.Supervisor`
 
-Each sub-agent runs in its own isolated context. Configure concurrency
-limits and timeouts via deps:
+Each sub-agent runs in its own context but inherits parent deps automatically
+(excluding plugin-internal keys). Configure concurrency, timeouts, and
+optionally restrict which deps are shared:
 
 ```elixir
 deps: %{
   sub_agent_templates: templates,
-  parallel_max_concurrency: 3,  # Max concurrent sub-agents (default: 5)
-  parallel_timeout: 60_000      # Per-task timeout in ms (default: 120_000)
+  database: MyApp.Repo,              # shared with sub-agents automatically
+  parallel_max_concurrency: 3,       # max concurrent sub-agents (default: 5)
+  parallel_timeout: 60_000,          # per-task timeout in ms (default: 120_000)
+  sub_agent_shared_deps: [:database] # optional: restrict to specific keys
 }
 ```
 

--- a/lib/nous/plugins/sub_agent.ex
+++ b/lib/nous/plugins/sub_agent.ex
@@ -43,6 +43,19 @@ defmodule Nous.Plugins.SubAgent do
 
     - `:parallel_max_concurrency` — max concurrent sub-agents (default: 5)
     - `:parallel_timeout` — per-task timeout in ms (default: 120_000)
+
+  ## Deps Propagation
+
+  Parent deps are automatically shared with sub-agents, excluding plugin-internal
+  keys (templates, PubSub config, concurrency settings). To restrict which deps
+  are shared, set `:sub_agent_shared_deps`:
+
+      deps: %{
+        sub_agent_templates: %{...},
+        database: MyApp.Repo,
+        api_key: "sk-...",
+        sub_agent_shared_deps: [:database]  # only :database is forwarded
+      }
   """
 
   @behaviour Nous.Plugin
@@ -53,6 +66,15 @@ defmodule Nous.Plugins.SubAgent do
 
   @default_max_concurrency 5
   @default_timeout 120_000
+
+  @plugin_internal_keys [
+    :sub_agent_templates,
+    :sub_agent_shared_deps,
+    :parallel_max_concurrency,
+    :parallel_timeout,
+    :__sub_agent_pubsub__,
+    :__sub_agent_pubsub_topic__
+  ]
 
   # ===========================================================================
   # Plugin callbacks
@@ -294,6 +316,14 @@ defmodule Nous.Plugins.SubAgent do
   # Shared internals
   # ===========================================================================
 
+  @doc false
+  def compute_sub_deps(parent_deps) do
+    case parent_deps[:sub_agent_shared_deps] do
+      keys when is_list(keys) -> Map.take(parent_deps, keys)
+      nil -> Map.drop(parent_deps, @plugin_internal_keys)
+    end
+  end
+
   defp resolve_agent(ctx, template_name, _args) when is_binary(template_name) do
     templates = ctx.deps[:sub_agent_templates] || %{}
 
@@ -340,9 +370,7 @@ defmodule Nous.Plugins.SubAgent do
     label = if index, do: "[sub-agent #{index}]", else: "[sub-agent]"
     Logger.info("#{label} Starting: #{String.slice(task, 0, 80)}")
 
-    # Isolated deps — only pass through explicitly shared keys
-    shared_keys = []
-    sub_deps = Map.take(parent_ctx.deps, shared_keys)
+    sub_deps = compute_sub_deps(parent_ctx.deps)
 
     # Propagate PubSub with scoped topic
     parent_pubsub = parent_ctx.deps[:__sub_agent_pubsub__]

--- a/lib/nous/plugins/sub_agent.ex
+++ b/lib/nous/plugins/sub_agent.ex
@@ -319,8 +319,15 @@ defmodule Nous.Plugins.SubAgent do
   @doc false
   def compute_sub_deps(parent_deps) do
     case parent_deps[:sub_agent_shared_deps] do
-      keys when is_list(keys) -> Map.take(parent_deps, keys)
-      nil -> Map.drop(parent_deps, @plugin_internal_keys)
+      keys when is_list(keys) ->
+        Map.take(parent_deps, keys)
+
+      nil ->
+        Map.drop(parent_deps, @plugin_internal_keys)
+
+      invalid ->
+        raise ArgumentError,
+              ":sub_agent_shared_deps must be a list of keys or nil, got: #{inspect(invalid)}"
     end
   end
 

--- a/test/nous/plugins/sub_agent_test.exs
+++ b/test/nous/plugins/sub_agent_test.exs
@@ -603,6 +603,54 @@ defmodule Nous.Plugins.SubAgentTest do
   end
 
   # ===========================================================================
+  # Deps propagation
+  # ===========================================================================
+
+  describe "compute_sub_deps/1" do
+    test "forwards user deps and excludes plugin-internal keys" do
+      parent_deps = %{
+        workspace_id: 42,
+        database: :fake_db,
+        sub_agent_templates: %{"t" => %{}},
+        sub_agent_shared_deps: nil,
+        parallel_max_concurrency: 3,
+        parallel_timeout: 60_000,
+        __sub_agent_pubsub__: SomePubSub,
+        __sub_agent_pubsub_topic__: "topic:1"
+      }
+
+      result = SubAgent.compute_sub_deps(parent_deps)
+
+      assert result == %{workspace_id: 42, database: :fake_db}
+    end
+
+    test "explicit allowlist restricts to specified keys" do
+      parent_deps = %{
+        workspace_id: 42,
+        database: :fake_db,
+        api_key: "secret",
+        sub_agent_shared_deps: [:workspace_id]
+      }
+
+      result = SubAgent.compute_sub_deps(parent_deps)
+
+      assert result == %{workspace_id: 42}
+    end
+
+    test "empty allowlist returns empty map" do
+      parent_deps = %{
+        workspace_id: 42,
+        database: :fake_db,
+        sub_agent_shared_deps: []
+      }
+
+      result = SubAgent.compute_sub_deps(parent_deps)
+
+      assert result == %{}
+    end
+  end
+
+  # ===========================================================================
   # Integration with Plugin system
   # ===========================================================================
 


### PR DESCRIPTION
## Summary
Solving issue https://github.com/nyo16/nous/issues/44
  - Sub-agent tools always received empty `ctx.deps` because `shared_keys` was hardcoded to `[]` in `run_sub_agent/4`
  - Parent deps now flow to sub-agents automatically, excluding plugin-internal keys (templates, PubSub, concurrency config)
  - Users can restrict which deps are shared via `sub_agent_shared_deps: [:key1, :key2]`

  ## Before

  ```elixir
  # Sub-agent tool always got empty deps
  shared_keys = []
  sub_deps = Map.take(parent_ctx.deps, shared_keys)  # => %{}

  After

  # Default: all user deps forwarded (plugin keys excluded)
  sub_deps = compute_sub_deps(parent_ctx.deps)  # => %{workspace_id: 42, database: :db}

  # Optional: restrict to specific keys
  deps: %{sub_agent_shared_deps: [:workspace_id]}  # => %{workspace_id: 42}

  Test plan

  - 3 new unit tests for compute_sub_deps/1 (default forwarding, explicit allowlist, empty allowlist)
  - All 37 sub-agent tests pass
  - Full suite: 1468 tests, 0 failures