### PR TITLE
feat: streaming + tool execution in Nous.Agent.run/3 (0.15.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,17 @@ agent =
 {:ok, result} = Nous.run(agent, "Find all TODOs in lib/")
 # result.text, result.messages, result.usage
 
-# Streaming agent run
+# Streaming agent run (text deltas only, no tool execution)
 {:ok, stream} = Nous.run_stream(agent, "Summarize this repo")
+
+# Streaming + tool execution in the same call (Nous 0.15.3+)
+{:ok, result} = Nous.run(agent, "Search and summarize",
+  stream: true,
+  callbacks: %{
+    on_llm_new_delta: fn _, t -> IO.write(t) end,
+    on_llm_new_thinking_delta: fn _, t -> IO.write(["[thinking] ", t]) end
+  }
+)
 ```
 
 That's 90% of what most apps need. Everything else is configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.3] - 2026-05-01
+
+Streaming + tool execution. The `Nous.Agent.run/3` loop now has a
+`stream: true` opt that combines per-token deltas with the regular
+tool-call loop. Behavior is identical to non-streaming `run/3` except
+for the additional streaming events: same final result, same callbacks,
+same fallback chain, same hook/plugin pipeline.
+
+### Added
+
+- **`:stream` option on `Nous.Agent.run/3`** — runs the iteration loop
+  with the LLM call streamed. Per-iteration assembly produces a
+  `%Nous.Message{}` structurally identical to what the non-streaming
+  path returns, so `:on_llm_new_message`, `process_response`,
+  `handle_tool_calls`, and the loop continuation are all unchanged.
+  Per-token `:on_llm_new_delta` fires for text and the new
+  `:on_llm_new_thinking_delta` fires for reasoning. Works across all
+  providers (OpenAI-compatible, Anthropic, Gemini, Vertex AI, Mistral)
+  and is compatible with `output_type` for streaming structured output.
+- **`:on_llm_new_thinking_delta` callback** — cleanly-separated reasoning
+  deltas. Pre-existing `Nous.Agent.run_stream/3` keeps emitting
+  `[thinking] …` on `:on_llm_new_delta` for backward compatibility — the
+  split is opt-in via `stream: true`.
+- **`Nous.StreamNormalizer.ToolCallAccumulator`** — polymorphic across
+  the three provider chunk shapes (OpenAI list with split JSON args,
+  Anthropic `_phase`-tagged fragments, Gemini already-complete
+  `functionCall`). Reassembles them into the unified
+  `%{"id", "name", "arguments" => decoded_map}` shape that
+  `Nous.Messages.extract_tool_calls/1` already understands.
+- **`{:usage, %Nous.Usage{}}` stream event** — emitted by
+  `Nous.StreamNormalizer.OpenAI` when chunks carry a `usage` field
+  (auto-enabled by injecting `stream_options.include_usage: true` on
+  the OpenAI-compatible streaming request), by
+  `Nous.StreamNormalizer.Anthropic` from `message_start` and
+  `message_delta` chunks, and by `Nous.StreamNormalizer.Gemini` from
+  `usageMetadata`. The `Nous.Types.stream_event` typespec is updated.
+- **Mid-stream cancellation** — `ctx.cancellation_check` is invoked
+  between every streamed chunk; a thrown `{:cancelled, reason}` halts
+  the run with `Errors.ExecutionCancelled` and discards partial state.
+  No tool execution happens on cancellation.
+- **`Nous.Messages.OpenAI.decode_arguments/1` and `parse_usage/1`**
+  promoted to public helpers (formerly private) so the streaming path
+  and the `ToolCallAccumulator` reuse the same JSON-decode-with-fallback
+  and usage-parsing logic as the non-streaming path. Anthropic and
+  Gemini's `parse_usage/1` are similarly public for the same reason.
+
+### Changed
+
+- Pre-existing `Nous.Agent.run_stream/3` semantics are unchanged. The
+  `[thinking] …` prefix on `:on_llm_new_delta` is preserved for that
+  legacy path so existing consumers don't break.
+- `lib/nous/provider.ex` `build_request_params` allowlist now includes
+  `stream_options` (no-op for non-OpenAI providers — silently ignored).
+
+### Documentation
+
+- New "Streaming with Tool Execution" section in `README.md`.
+- New "Streaming with Tool Execution (Recommended)" section in
+  `docs/guides/liveview-integration.md` with a complete LiveView
+  example wiring `:agent_delta`, `:agent_thinking`, `:tool_call`,
+  `:tool_result`, `:agent_message`, and `:agent_complete`.
+- New "Streaming Structured Output" section in
+  `docs/guides/structured_output.md`.
+- 0.15.2 → 0.15.3 entry in `docs/guides/migration_guide.md`.
+- `AGENTS.md` Quick Start example updated.
+
 ## [0.15.2] - 2026-04-27
 
 Documentation-only release. No code changes.

--- a/README.md
+++ b/README.md
@@ -527,6 +527,33 @@ stream
 end)
 ```
 
+### Streaming with Tool Execution
+
+`Nous.run_stream/3` streams text but does **not** execute tools. To get
+per-token deltas *and* tool execution in the same call, pass `stream: true`
+to `Nous.run/3`. The agent loop runs as usual; deltas fire as the model
+produces them.
+
+```elixir
+agent = Nous.new("openai:gpt-4", tools: [&MyTools.search/2])
+
+{:ok, result} = Nous.run(agent, "Find an Elixir tutorial",
+  stream: true,
+  callbacks: %{
+    on_llm_new_delta: fn _e, t -> IO.write(t) end,
+    on_llm_new_thinking_delta: fn _e, t -> IO.write(["[thinking] ", t]) end,
+    on_tool_call: fn _e, call -> IO.inspect(call, label: "tool") end,
+    on_tool_response: fn _e, resp -> IO.inspect(resp, label: "result") end
+  }
+)
+```
+
+Works across providers (OpenAI-compatible, Anthropic, Gemini). Compatible
+with `output_type` for structured output. `cancellation_check` is honored
+between chunks — a flipped flag aborts the run cleanly without partial
+tool execution. See `docs/guides/liveview-integration.md` for the LiveView
+pattern.
+
 ### Fallback Models
 
 Automatically try alternative models when the primary fails (rate limit, server error, timeout):

--- a/docs/guides/liveview-integration.md
+++ b/docs/guides/liveview-integration.md
@@ -298,6 +298,81 @@ end
 
 ## Streaming Patterns
 
+### Streaming with Tool Execution (Recommended)
+
+`Nous.run/3` with `stream: true` is the cleanest way to combine per-token
+deltas with the tool-call loop. It runs in a background task; events arrive
+as `handle_info` messages via `notify_pid` (or via the `callbacks` map).
+
+```elixir
+defmodule MyAppWeb.ChatLive do
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    agent = Nous.new("openai:gpt-4o", tools: [&MyTools.search/2])
+    {:ok, assign(socket, agent: agent, messages: [], stream: nil, cancel: false)}
+  end
+
+  def handle_event("send", %{"prompt" => prompt}, socket) do
+    parent = self()
+    cancel_ref = make_ref()
+
+    {:ok, task} =
+      Task.start_link(fn ->
+        Nous.run(socket.assigns.agent, prompt,
+          stream: true,
+          notify_pid: parent,
+          cancellation_check: fn ->
+            if Process.get({:cancel, cancel_ref}), do: throw({:cancelled, :user})
+          end
+        )
+      end)
+
+    {:noreply, assign(socket, stream: {task, cancel_ref}, current: "")}
+  end
+
+  def handle_event("stop", _, socket) do
+    {_task, ref} = socket.assigns.stream
+    Process.put({:cancel, ref}, true)
+    {:noreply, socket}
+  end
+
+  # Per-token text delta — append to the in-progress assistant message
+  def handle_info({:agent_delta, text}, socket) do
+    {:noreply, assign(socket, current: socket.assigns.current <> text)}
+  end
+
+  # Per-token reasoning delta — render in a separate "thinking" pane
+  def handle_info({:agent_thinking, text}, socket) do
+    {:noreply, push_event(socket, "thinking", %{text: text})}
+  end
+
+  # Tool was invoked — render a "calling tool…" indicator
+  def handle_info({:tool_call, call}, socket) do
+    {:noreply, push_event(socket, "tool_call", call)}
+  end
+
+  # Tool returned — render the result
+  def handle_info({:tool_result, result}, socket) do
+    {:noreply, push_event(socket, "tool_result", result)}
+  end
+
+  # Iteration complete — flush the assembled assistant message
+  def handle_info({:agent_message, message}, socket) do
+    messages = socket.assigns.messages ++ [message]
+    {:noreply, assign(socket, messages: messages, current: "")}
+  end
+
+  def handle_info({:agent_complete, _result}, socket) do
+    {:noreply, assign(socket, stream: nil)}
+  end
+end
+```
+
+The mapping from callback events to `handle_info` messages is documented in
+`Nous.Agent.Callbacks` — `:on_llm_new_delta` becomes `{:agent_delta, text}`,
+`:on_llm_new_thinking_delta` becomes `{:agent_thinking, text}`, etc.
+
 ### Basic Text Streaming
 
 ```elixir

--- a/docs/guides/migration_guide.md
+++ b/docs/guides/migration_guide.md
@@ -2,6 +2,22 @@
 
 Guide for upgrading Nous AI between versions and migrating configurations.
 
+## 0.15.2 → 0.15.3
+
+Backward-compatible. Two new opt-in features:
+
+- **`stream: true` on `Nous.Agent.run/3`**: combines per-token deltas with
+  the regular tool-call loop. Existing `Nous.Agent.run_stream/3` semantics
+  are unchanged. Works across all providers (OpenAI-compat, Anthropic,
+  Gemini) and is compatible with `output_type` for structured output.
+- **`:on_llm_new_thinking_delta` callback**: cleanly-separated reasoning
+  deltas. Only fires under `stream: true`; `run_stream/3` keeps the
+  existing `[thinking] …` prefix on `:on_llm_new_delta` for back-compat.
+
+No code changes required to upgrade. Add `stream: true` and the new
+callback to opt in. See the "Streaming with Tool Execution" section in
+the README and `docs/guides/liveview-integration.md` for the full pattern.
+
 ## Quick Migration Checklist
 
 **Upgrading Nous?** Follow these steps:

--- a/docs/guides/structured_output.md
+++ b/docs/guides/structured_output.md
@@ -340,6 +340,31 @@ The following Ecto types are mapped to JSON schema types:
 | `Ecto.Enum` | `"string"` with `"enum"` values |
 | `{:array, type}` | `"array"` with typed items |
 
+## Streaming Structured Output
+
+`stream: true` works alongside `output_type`. The model produces JSON via
+the synthetic structured-output tool; the runner streams the tool-call
+fragments, reassembles them, validates the result, and returns the
+structured value as usual.
+
+```elixir
+agent = Nous.new("openai:gpt-4o", output_type: TestUser)
+
+{:ok, result} = Nous.run(agent, "Extract name and age from: Alice is 30",
+  stream: true,
+  callbacks: %{
+    on_tool_call: fn _e, _call -> :ok end  # synthetic tool — internal
+  }
+)
+# result.output #=> %TestUser{name: "Alice", age: 30}
+```
+
+Caveat: `:on_llm_new_delta` will fire **zero or near-zero** times in this
+mode — the model writes JSON to the synthetic tool's arguments, not as
+plain text. Use `:on_tool_call` if you want a "writing structured
+output…" indicator. The synthetic tool is internal and is *not* counted
+in `result.usage.tool_calls`.
+
 ## Per-Run Output Override
 
 Override the agent's `output_type` or `structured_output` options on each `run()` call.

--- a/lib/nous/agent.ex
+++ b/lib/nous/agent.ex
@@ -206,6 +206,19 @@ defmodule Nous.Agent do
         }
       )
 
+      # Streaming + tool execution (works across providers)
+      {:ok, result} = Agent.run(agent, "Search and summarize",
+        stream: true,
+        callbacks: %{
+          on_llm_new_delta: fn _, text -> IO.write(text) end,
+          on_llm_new_thinking_delta: fn _, text -> IO.write(["[thinking] ", text]) end,
+          on_tool_call: fn _, call -> IO.inspect(call, label: "tool") end
+        }
+      )
+
+  See `Nous.AgentRunner.run/3` for the full option list. The `:stream` option
+  combines per-token deltas with the regular tool-call loop.
+
   ## Returns
 
       {:ok, %{

--- a/lib/nous/agent/callbacks.ex
+++ b/lib/nous/agent/callbacks.ex
@@ -10,6 +10,10 @@ defmodule Nous.Agent.Callbacks do
 
   - `:on_agent_start` - Agent run begins
   - `:on_llm_new_delta` - Streaming text chunk received
+  - `:on_llm_new_thinking_delta` - Streaming reasoning/thinking chunk received
+    (only fires under the `stream: true` path of `Nous.Agent.run/3`; the legacy
+    `Nous.Agent.run_stream/3` keeps emitting reasoning as `[thinking] …` on
+    `:on_llm_new_delta` for backward compatibility)
   - `:on_llm_new_message` - Complete LLM response received
   - `:on_tool_call` - Tool invocation started
   - `:on_tool_response` - Tool execution completed
@@ -59,6 +63,7 @@ defmodule Nous.Agent.Callbacks do
   @type event ::
           :on_agent_start
           | :on_llm_new_delta
+          | :on_llm_new_thinking_delta
           | :on_llm_new_message
           | :on_tool_call
           | :on_tool_response
@@ -70,6 +75,7 @@ defmodule Nous.Agent.Callbacks do
   @events [
     :on_agent_start,
     :on_llm_new_delta,
+    :on_llm_new_thinking_delta,
     :on_llm_new_message,
     :on_tool_call,
     :on_tool_response,
@@ -84,6 +90,7 @@ defmodule Nous.Agent.Callbacks do
 
   - `:on_agent_start` - Payload: `%{agent: agent}`
   - `:on_llm_new_delta` - Payload: `String.t()` (text chunk)
+  - `:on_llm_new_thinking_delta` - Payload: `String.t()` (reasoning chunk)
   - `:on_llm_new_message` - Payload: `Message.t()`
   - `:on_tool_call` - Payload: `%{id: String.t(), name: String.t(), arguments: map()}`
   - `:on_tool_response` - Payload: `%{id: String.t(), name: String.t(), result: any()}`
@@ -286,6 +293,7 @@ defmodule Nous.Agent.Callbacks do
   |-------|---------|
   | `:on_agent_start` | `{:agent_start, payload}` |
   | `:on_llm_new_delta` | `{:agent_delta, text}` |
+  | `:on_llm_new_thinking_delta` | `{:agent_thinking, text}` |
   | `:on_llm_new_message` | `{:agent_message, message}` |
   | `:on_tool_call` | `{:tool_call, %{id, name, arguments}}` |
   | `:on_tool_response` | `{:tool_result, %{id, name, result}}` |
@@ -304,6 +312,7 @@ defmodule Nous.Agent.Callbacks do
   @spec to_message(event(), payload()) :: tuple()
   def to_message(:on_agent_start, payload), do: {:agent_start, payload}
   def to_message(:on_llm_new_delta, text), do: {:agent_delta, text}
+  def to_message(:on_llm_new_thinking_delta, text), do: {:agent_thinking, text}
   def to_message(:on_llm_new_message, message), do: {:agent_message, message}
   def to_message(:on_tool_call, call), do: {:tool_call, call}
   def to_message(:on_tool_response, result), do: {:tool_result, result}

--- a/lib/nous/agent/context.ex
+++ b/lib/nous/agent/context.ex
@@ -93,7 +93,11 @@ defmodule Nous.Agent.Context do
           hook_registry: Nous.Hook.Registry.t() | nil,
 
           # Skills (runtime-only, never serialized)
-          active_skills: [Nous.Skill.t()]
+          active_skills: [Nous.Skill.t()],
+
+          # Streaming flag — when true, the LLM call site streams chunks
+          # through the new tool-aware path. Runtime-only.
+          stream: boolean()
         }
 
   defstruct messages: [],
@@ -113,7 +117,8 @@ defmodule Nous.Agent.Context do
             pubsub: nil,
             pubsub_topic: nil,
             hook_registry: nil,
-            active_skills: []
+            active_skills: [],
+            stream: false
 
   @doc """
   Create a new context with options.
@@ -129,6 +134,7 @@ defmodule Nous.Agent.Context do
     * `:agent_name` - Name for telemetry/logging
     * `:cancellation_check` - Function to check for cancellation
     * `:approval_handler` - Function called for tools with `requires_approval: true`
+    * `:stream` - When true, the runner uses streaming + tool execution (default: false)
 
   ## Examples
 
@@ -158,7 +164,8 @@ defmodule Nous.Agent.Context do
       cancellation_check: Keyword.get(opts, :cancellation_check),
       approval_handler: Keyword.get(opts, :approval_handler),
       pubsub: Keyword.get(opts, :pubsub) || Nous.PubSub.configured_pubsub(),
-      pubsub_topic: Keyword.get(opts, :pubsub_topic)
+      pubsub_topic: Keyword.get(opts, :pubsub_topic),
+      stream: Keyword.get(opts, :stream, false)
     }
   end
 

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -56,12 +56,21 @@ defmodule Nous.AgentRunner do
     * `:usage_limits` - Usage limits (not implemented yet)
     * `:model_settings` - Override model settings
     * `:max_iterations` - Maximum iterations (default: 10)
-    * `:cancellation_check` - Function to check if execution should be cancelled
+    * `:cancellation_check` - Function to check if execution should be cancelled.
+      Under `stream: true`, also invoked between every streamed chunk; on
+      cancellation the consumer aborts cleanly without partial tool execution.
     * `:callbacks` - Map of callback functions
     * `:notify_pid` - PID to receive event messages
     * `:context` - Existing context to continue from
     * `:output_type` - Override the agent's `output_type` for this run
     * `:structured_output` - Override the agent's `structured_output` options for this run
+    * `:stream` - When `true`, the LLM call streams chunks while still running
+      the tool-call loop (default: `false`). Fires `:on_llm_new_delta` per
+      text chunk and `:on_llm_new_thinking_delta` per reasoning chunk.
+      `:on_llm_new_message` still fires once per iteration with the assembled
+      message, identical in shape to the non-streaming path. Works across all
+      providers (OpenAI-compatible, Anthropic, Gemini) and is compatible with
+      `output_type` (the synthetic-tool path is honored under streaming).
 
   """
   @spec run(Agent.t(), String.t(), keyword()) :: {:ok, map()} | {:error, term()}
@@ -225,6 +234,7 @@ defmodule Nous.AgentRunner do
       ctx
       |> maybe_update_callbacks(opts)
       |> maybe_update_notify_pid(opts)
+      |> maybe_update_stream(opts)
       |> Context.set_needs_response(true)
       |> Context.patch_dangling_tool_calls()
 
@@ -353,10 +363,12 @@ defmodule Nous.AgentRunner do
         |> Context.set_needs_response(true)
         |> maybe_update_callbacks(opts)
         |> maybe_update_notify_pid(opts)
+        |> maybe_update_stream(opts)
 
       nil ->
         # Build fresh context
         message_history = Keyword.get(opts, :message_history, [])
+        stream = Keyword.get(opts, :stream, false)
 
         # Build system prompt
         system_prompt =
@@ -404,8 +416,18 @@ defmodule Nous.AgentRunner do
           agent_name: agent.name,
           cancellation_check: Keyword.get(opts, :cancellation_check),
           pubsub: Keyword.get(opts, :pubsub),
-          pubsub_topic: Keyword.get(opts, :pubsub_topic)
+          pubsub_topic: Keyword.get(opts, :pubsub_topic),
+          stream: stream
         )
+    end
+  end
+
+  # When continuing from an existing context (the %Context{} branch above),
+  # honor the `:stream` opt as an override.
+  defp maybe_update_stream(ctx, opts) do
+    case Keyword.fetch(opts, :stream) do
+      {:ok, value} when is_boolean(value) -> %{ctx | stream: value}
+      _ -> ctx
     end
   end
 
@@ -536,7 +558,20 @@ defmodule Nous.AgentRunner do
           "Agent iteration #{ctx.iteration + 1}/#{ctx.max_iterations}: requesting model response"
         )
 
-        case request_with_fallback(request_agent, messages, model_settings, all_tools) do
+        request_result =
+          if ctx.stream do
+            stream_request_with_fallback(
+              request_agent,
+              messages,
+              model_settings,
+              all_tools,
+              ctx
+            )
+          else
+            request_with_fallback(request_agent, messages, model_settings, all_tools)
+          end
+
+        case request_result do
           {:ok, response, active_model} ->
             # Track active_model in ctx for downstream telemetry / observability,
             # but do NOT mutate agent.model. Mutating made the start-of-run
@@ -1325,6 +1360,156 @@ defmodule Nous.AgentRunner do
       get_dispatcher().request_stream(model, messages, settings)
     end)
   end
+
+  # Streaming counterpart to request_with_fallback/4. Initializes the stream
+  # via stream_with_fallback/4 (so initialization errors trigger fallback),
+  # then consumes the stream eagerly into a %Nous.Message{} structurally
+  # identical to what request_with_fallback/4 returns. Per-chunk delta
+  # callbacks fire from the consumer, and the assembled message flows back
+  # into the same do_iteration code path that handles tool calls and the
+  # next iteration.
+  #
+  # Returns {:ok, response, active_model} or {:error, reason}.
+  @openai_compat_providers ~w(openai custom vllm sglang lmstudio llamacpp)a
+
+  defp stream_request_with_fallback(agent, messages, model_settings, all_tools, ctx) do
+    model_chain = Fallback.build_model_chain(agent.model, agent.fallback)
+
+    Fallback.with_fallback(model_chain, fn model ->
+      settings =
+        model
+        |> rebuild_settings_for_model(model_settings, all_tools, agent)
+        |> maybe_inject_include_usage(model.provider)
+
+      with {:ok, stream} <- get_dispatcher().request_stream(model, messages, settings),
+           {:ok, message} <- consume_stream_into_message(stream, ctx, model.provider) do
+        {:ok, {message, model}}
+      end
+    end)
+    |> case do
+      {:ok, {response, active_model}} -> {:ok, response, active_model}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp maybe_inject_include_usage(settings, provider)
+       when provider in @openai_compat_providers do
+    current = Map.get(settings, :stream_options) || %{}
+    Map.put(settings, :stream_options, Map.put(current, :include_usage, true))
+  end
+
+  defp maybe_inject_include_usage(settings, _provider), do: settings
+
+  # Consume a normalized stream into a single %Nous.Message{}, firing
+  # per-chunk delta callbacks along the way. Halts cleanly with
+  # ExecutionCancelled if `ctx.cancellation_check` raises {:cancelled, reason}
+  # between chunks.
+  defp consume_stream_into_message(stream, ctx, provider) do
+    initial = %{
+      text: [],
+      reasoning: [],
+      tool_acc: Nous.StreamNormalizer.ToolCallAccumulator.new(),
+      usage: nil,
+      finish_reason: "stop",
+      error: nil,
+      cancelled: nil
+    }
+
+    final =
+      Enum.reduce_while(stream, initial, fn event, acc ->
+        case check_cancellation_inline(ctx) do
+          {:cancelled, reason} ->
+            {:halt, %{acc | cancelled: reason}}
+
+          :ok ->
+            {:cont, handle_stream_event(event, acc, ctx)}
+        end
+      end)
+
+    cond do
+      final.cancelled ->
+        {:error, Errors.ExecutionCancelled.exception(reason: final.cancelled)}
+
+      final.error ->
+        {:error, final.error}
+
+      true ->
+        {:ok, build_streamed_message(final, provider)}
+    end
+  end
+
+  defp handle_stream_event({:text_delta, text}, acc, ctx) do
+    Callbacks.execute(ctx, :on_llm_new_delta, text)
+    %{acc | text: [acc.text, text]}
+  end
+
+  defp handle_stream_event({:thinking_delta, text}, acc, ctx) do
+    Callbacks.execute(ctx, :on_llm_new_thinking_delta, text)
+    %{acc | reasoning: [acc.reasoning, text]}
+  end
+
+  defp handle_stream_event({:tool_call_delta, fragment}, acc, _ctx) do
+    %{acc | tool_acc: Nous.StreamNormalizer.ToolCallAccumulator.feed(acc.tool_acc, fragment)}
+  end
+
+  defp handle_stream_event({:usage, usage}, acc, _ctx) do
+    %{acc | usage: usage}
+  end
+
+  defp handle_stream_event({:finish, reason}, acc, _ctx) do
+    %{acc | finish_reason: reason}
+  end
+
+  defp handle_stream_event({:error, reason}, acc, _ctx) do
+    %{acc | error: reason}
+  end
+
+  defp handle_stream_event(_other, acc, _ctx), do: acc
+
+  defp build_streamed_message(acc, _provider) do
+    text = IO.iodata_to_binary(acc.text)
+    reasoning = IO.iodata_to_binary(acc.reasoning)
+    tool_calls = Nous.StreamNormalizer.ToolCallAccumulator.finalize(acc.tool_acc)
+
+    attrs = %{
+      role: :assistant,
+      metadata: %{
+        usage: acc.usage || %Nous.Usage{},
+        finish_reason: acc.finish_reason,
+        timestamp: DateTime.utc_now()
+      }
+    }
+
+    attrs = if text != "", do: Map.put(attrs, :content, text), else: attrs
+
+    attrs =
+      if reasoning != "",
+        do: Map.put(attrs, :reasoning_content, reasoning),
+        else: attrs
+
+    attrs =
+      if tool_calls != [],
+        do: Map.put(attrs, :tool_calls, tool_calls),
+        else: attrs
+
+    Message.new!(attrs)
+  end
+
+  # Inline cancellation probe used between streamed chunks. Mirrors
+  # check_cancellation/1 but returns a value instead of an {:error, _}
+  # tuple so the reduce can decide between :halt and :cont.
+  defp check_cancellation_inline(%{cancellation_check: nil}), do: :ok
+
+  defp check_cancellation_inline(%{cancellation_check: check}) when is_function(check, 0) do
+    try do
+      check.()
+      :ok
+    catch
+      {:cancelled, reason} -> {:cancelled, reason}
+    end
+  end
+
+  defp check_cancellation_inline(_), do: :ok
 
   # Rebuild model settings when falling back to a different provider.
   # Tool schemas must be re-converted for the target provider's format.

--- a/lib/nous/messages/anthropic.ex
+++ b/lib/nous/messages/anthropic.ex
@@ -283,7 +283,14 @@ defmodule Nous.Messages.Anthropic do
     {text_content, reasoning_content, Enum.reverse(tool_calls)}
   end
 
-  defp parse_usage(usage_data) when is_map(usage_data) do
+  @doc """
+  Parse an Anthropic-format usage map into a `%Nous.Usage{}` struct.
+
+  Used by both the non-streaming response parser and the streaming normalizer
+  (`message_delta` carries incremental output tokens).
+  """
+  @spec parse_usage(map() | nil) :: Usage.t()
+  def parse_usage(usage_data) when is_map(usage_data) do
     %Usage{
       input_tokens: Map.get(usage_data, "input_tokens", 0),
       output_tokens: Map.get(usage_data, "output_tokens", 0),
@@ -292,7 +299,7 @@ defmodule Nous.Messages.Anthropic do
     }
   end
 
-  defp parse_usage(_), do: %Usage{}
+  def parse_usage(_), do: %Usage{}
 
   defp consolidate_content_parts([]), do: ""
   defp consolidate_content_parts([%ContentPart{type: :text, content: content}]), do: content

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -295,7 +295,13 @@ defmodule Nous.Messages.Gemini do
     {text_content, reasoning_content, Enum.reverse(tool_calls)}
   end
 
-  defp parse_usage(usage_data) when is_map(usage_data) do
+  @doc """
+  Parse a Gemini-format `usageMetadata` map into a `%Nous.Usage{}` struct.
+
+  Used by both the non-streaming response parser and the streaming normalizer.
+  """
+  @spec parse_usage(map() | nil) :: Usage.t()
+  def parse_usage(usage_data) when is_map(usage_data) do
     %Usage{
       input_tokens: Map.get(usage_data, "promptTokenCount", 0),
       output_tokens: Map.get(usage_data, "candidatesTokenCount", 0),
@@ -303,7 +309,7 @@ defmodule Nous.Messages.Gemini do
     }
   end
 
-  defp parse_usage(_), do: %Usage{}
+  def parse_usage(_), do: %Usage{}
 
   defp consolidate_content_parts([]), do: ""
   defp consolidate_content_parts([%ContentPart{type: :text, content: content}]), do: content

--- a/lib/nous/messages/openai.ex
+++ b/lib/nous/messages/openai.ex
@@ -211,24 +211,46 @@ defmodule Nous.Messages.OpenAI do
     name = Map.get(func, "name") || Map.get(func, :name)
     arguments = Map.get(func, "arguments") || Map.get(func, :arguments)
 
-    parsed_args =
-      case JSON.decode(arguments) do
-        {:ok, decoded_args} ->
-          decoded_args
-
-        {:error, _} ->
-          Logger.warning("Failed to decode tool arguments: #{inspect(arguments)}")
-          %{"error" => "Invalid JSON arguments", "raw" => arguments}
-      end
-
     %{
       "id" => id,
       "name" => name,
-      "arguments" => parsed_args
+      "arguments" => decode_arguments(arguments)
     }
   end
 
-  defp parse_usage(usage_data) when is_map(usage_data) do
+  @doc """
+  Decode an OpenAI tool-call `arguments` JSON string into a map.
+
+  Falls back to `%{"error" => "Invalid JSON arguments", "raw" => raw}` and logs a
+  warning when the JSON is malformed. Used by both the non-streaming response
+  parser and the streaming `ToolCallAccumulator`.
+  """
+  @spec decode_arguments(String.t() | nil) :: map()
+  def decode_arguments(nil), do: %{}
+  def decode_arguments(""), do: %{}
+
+  def decode_arguments(arguments) when is_binary(arguments) do
+    case JSON.decode(arguments) do
+      {:ok, decoded_args} when is_map(decoded_args) ->
+        decoded_args
+
+      {:ok, other} ->
+        Logger.warning("Tool arguments decoded to non-map: #{inspect(other)}")
+        %{"error" => "Invalid JSON arguments", "raw" => arguments}
+
+      {:error, _} ->
+        Logger.warning("Failed to decode tool arguments: #{inspect(arguments)}")
+        %{"error" => "Invalid JSON arguments", "raw" => arguments}
+    end
+  end
+
+  @doc """
+  Parse an OpenAI-format usage map into a `%Nous.Usage{}` struct.
+
+  Returns an empty `%Usage{}` for `nil`. Accepts both atom and string keys.
+  """
+  @spec parse_usage(map() | nil) :: Usage.t()
+  def parse_usage(usage_data) when is_map(usage_data) do
     %Usage{
       requests: 1,
       input_tokens:
@@ -239,5 +261,5 @@ defmodule Nous.Messages.OpenAI do
     }
   end
 
-  defp parse_usage(nil), do: %Usage{}
+  def parse_usage(nil), do: %Usage{}
 end

--- a/lib/nous/provider.ex
+++ b/lib/nous/provider.ex
@@ -414,6 +414,8 @@ defmodule Nous.Provider do
         |> maybe_put("stop", merged_settings[:stop_sequences] || merged_settings[:stop])
         |> maybe_put("tools", merged_settings[:tools])
         |> maybe_put("tool_choice", merged_settings[:tool_choice])
+        # OpenAI-style streaming usage opt-in (no-op on Anthropic/Gemini)
+        |> maybe_put("stream_options", merged_settings[:stream_options])
         # Structured output: response_format
         |> maybe_put("response_format", merged_settings[:response_format])
         # vLLM guided decoding

--- a/lib/nous/stream_normalizer.ex
+++ b/lib/nous/stream_normalizer.ex
@@ -7,6 +7,9 @@ defmodule Nous.StreamNormalizer do
   - `{:text_delta, text}` - Incremental text content
   - `{:thinking_delta, text}` - Incremental reasoning/thinking content
   - `{:tool_call_delta, tool_calls}` - Tool call information
+  - `{:usage, usage_map}` - Token usage (final chunk for OpenAI-compat with
+    `stream_options.include_usage`, Anthropic `message_delta`, or Gemini
+    `usageMetadata`)
   - `{:finish, reason}` - Stream completion signal
   - `{:unknown, chunk}` - Unrecognized chunk (filtered by default)
 

--- a/lib/nous/stream_normalizer/anthropic.ex
+++ b/lib/nous/stream_normalizer/anthropic.ex
@@ -58,10 +58,26 @@ defmodule Nous.StreamNormalizer.Anthropic do
     [{:tool_call_delta, %{"_index" => index, "_phase" => :stop}}]
   end
 
-  def normalize_chunk(%{"type" => "message_delta", "delta" => delta}) do
+  def normalize_chunk(%{"type" => "message_delta", "delta" => delta} = chunk) do
+    usage_events =
+      case Map.get(chunk, "usage") do
+        usage when is_map(usage) -> [{:usage, Nous.Messages.Anthropic.parse_usage(usage)}]
+        _ -> []
+      end
+
     case Map.get(delta, "stop_reason") do
-      nil -> [{:unknown, delta}]
-      reason -> [{:finish, reason}]
+      nil ->
+        if usage_events == [], do: [{:unknown, delta}], else: usage_events
+
+      reason ->
+        usage_events ++ [{:finish, reason}]
+    end
+  end
+
+  def normalize_chunk(%{"type" => "message_start", "message" => message}) do
+    case Map.get(message, "usage") do
+      usage when is_map(usage) -> [{:usage, Nous.Messages.Anthropic.parse_usage(usage)}]
+      _ -> [{:unknown, message}]
     end
   end
 

--- a/lib/nous/stream_normalizer/gemini.ex
+++ b/lib/nous/stream_normalizer/gemini.ex
@@ -29,9 +29,11 @@ defmodule Nous.StreamNormalizer.Gemini do
   end
 
   def normalize_chunk(%{"candidates" => candidates} = chunk) when is_list(candidates) do
+    usage_events = maybe_usage_event(chunk)
+
     case candidates do
-      [candidate | _] -> parse_candidate(candidate, chunk)
-      [] -> [{:unknown, chunk}]
+      [candidate | _] -> parse_candidate(candidate, chunk) ++ usage_events
+      [] -> if usage_events == [], do: [{:unknown, chunk}], else: usage_events
     end
   end
 
@@ -57,6 +59,13 @@ defmodule Nous.StreamNormalizer.Gemini do
 
   def convert_complete_response(chunk) do
     [{:unknown, chunk}]
+  end
+
+  defp maybe_usage_event(chunk) do
+    case Map.get(chunk, "usageMetadata") do
+      nil -> []
+      usage -> [{:usage, Nous.Messages.Gemini.parse_usage(usage)}]
+    end
   end
 
   defp parse_candidate(candidate, _chunk) do

--- a/lib/nous/stream_normalizer/openai.ex
+++ b/lib/nous/stream_normalizer/openai.ex
@@ -40,6 +40,16 @@ defmodule Nous.StreamNormalizer.OpenAI do
     end
   end
 
+  # Extract a {:usage, %Usage{}} event from the chunk's "usage" field if
+  # present. OpenAI sends a final chunk with empty choices and a populated
+  # usage map when stream_options.include_usage is enabled.
+  defp maybe_usage_event(chunk) do
+    case get_flexible(chunk, :usage) do
+      nil -> []
+      usage -> [{:usage, Nous.Messages.OpenAI.parse_usage(usage)}]
+    end
+  end
+
   @impl true
   def complete_response?(chunk) do
     choices = get_choices(chunk)
@@ -106,6 +116,7 @@ defmodule Nous.StreamNormalizer.OpenAI do
   defp parse_delta_chunk(chunk) do
     choices = get_choices(chunk)
     choice = List.first(choices)
+    usage_events = maybe_usage_event(chunk)
 
     if choice do
       delta = get_flexible(choice, :delta) || %{}
@@ -123,9 +134,15 @@ defmodule Nous.StreamNormalizer.OpenAI do
         |> append_if(is_list(tool_calls) and tool_calls != [], {:tool_call_delta, tool_calls})
         |> append_if(not is_nil(finish_reason), {:finish, finish_reason})
 
-      if events == [], do: [{:unknown, chunk}], else: events
+      cond do
+        events != [] -> events ++ usage_events
+        usage_events != [] -> usage_events
+        true -> [{:unknown, chunk}]
+      end
     else
-      [{:unknown, chunk}]
+      # OpenAI's final usage-only chunk has empty choices and a populated
+      # `usage` field. Emit just the usage event in that case.
+      if usage_events == [], do: [{:unknown, chunk}], else: usage_events
     end
   end
 

--- a/lib/nous/stream_normalizer/tool_call_accumulator.ex
+++ b/lib/nous/stream_normalizer/tool_call_accumulator.ex
@@ -1,0 +1,177 @@
+defmodule Nous.StreamNormalizer.ToolCallAccumulator do
+  @moduledoc """
+  Reassembles partial tool-call fragments emitted by `Nous.StreamNormalizer`
+  into the final list shape that `Nous.Messages.from_provider_response/2`
+  produces for the non-streaming path.
+
+  Used by the `stream: true` branch of `Nous.AgentRunner.run/3` to convert a
+  sequence of `{:tool_call_delta, fragment}` events into the
+  `tool_calls` field of an assembled `%Nous.Message{}`.
+
+  Polymorphic across the three provider chunk shapes that
+  `Nous.StreamNormalizer` emits:
+
+  ## OpenAI-compatible
+
+  Fragments arrive as a list of partial calls, each with an `"index"` plus
+  potentially split `"function"."arguments"` JSON:
+
+      [%{"index" => 0, "id" => "call_a", "function" => %{"name" => "search", "arguments" => "{\\"q"}}]
+      [%{"index" => 0, "function" => %{"arguments" => "uery\\":\\"hi\\"}"}}]
+
+  ## Anthropic
+
+  Fragments are tagged with `_phase` and `_index` (see
+  `Nous.StreamNormalizer.Anthropic`):
+
+      %{"id" => "tu_a", "name" => "search", "_index" => 0, "_phase" => :start}
+      %{"_index" => 0, "_phase" => :partial, "partial_json" => "{\\"q"}
+      %{"_index" => 0, "_phase" => :partial, "partial_json" => "uery\\":\\"hi\\"}"}
+      %{"_index" => 0, "_phase" => :stop}
+
+  ## Gemini
+
+  Fragments arrive already-complete (Gemini does not split tool-call
+  arguments across chunks):
+
+      %{"name" => "search", "arguments" => %{"query" => "hi"}}
+
+  ## API
+
+      acc = ToolCallAccumulator.new()
+      acc = ToolCallAccumulator.feed(acc, fragment)
+      tool_calls = ToolCallAccumulator.finalize(acc)
+      # => [%{"id" => "call_a", "name" => "search", "arguments" => %{"query" => "hi"}}]
+  """
+
+  alias Nous.Messages.OpenAI, as: OpenAIMessages
+
+  @type partial_call :: %{
+          required(:id) => String.t() | nil,
+          required(:name) => String.t() | nil,
+          required(:args_io) => iodata()
+        }
+
+  @type t :: %{
+          openai: %{integer() => partial_call()},
+          anthropic: %{integer() => partial_call()},
+          gemini: [%{required(String.t()) => term()}]
+        }
+
+  @doc "Build an empty accumulator."
+  @spec new() :: t()
+  def new do
+    %{openai: %{}, anthropic: %{}, gemini: []}
+  end
+
+  @doc """
+  Feed a single `{:tool_call_delta, fragment}` payload into the accumulator.
+
+  The `fragment` shape is detected automatically — see the module doc for the
+  three supported shapes. Unrecognized fragments are silently dropped (the
+  caller has already filtered `{:unknown, _}` events upstream).
+  """
+  @spec feed(t(), term()) :: t()
+  def feed(acc, fragment)
+
+  # OpenAI: list of partial tool-call objects
+  def feed(acc, fragments) when is_list(fragments) do
+    Enum.reduce(fragments, acc, &feed_openai_one/2)
+  end
+
+  # Anthropic: tagged fragments with _phase and _index
+  def feed(acc, %{"_phase" => :start, "_index" => index} = fragment) do
+    id = Map.get(fragment, "id")
+    name = Map.get(fragment, "name")
+
+    update_in(acc, [:anthropic, index], fn
+      nil -> %{id: id, name: name, args_io: []}
+      existing -> %{existing | id: existing.id || id, name: existing.name || name}
+    end)
+  end
+
+  def feed(acc, %{"_phase" => :partial, "_index" => index, "partial_json" => json}) do
+    update_in(acc, [:anthropic, index], fn
+      nil -> %{id: nil, name: nil, args_io: [json]}
+      existing -> %{existing | args_io: [existing.args_io, json]}
+    end)
+  end
+
+  def feed(acc, %{"_phase" => :stop, "_index" => _index}), do: acc
+
+  # Gemini: already-complete tool call
+  def feed(acc, %{"name" => name, "arguments" => arguments}) when is_map(arguments) do
+    call = %{
+      "id" => Map.get(acc, "id"),
+      "name" => name,
+      "arguments" => arguments
+    }
+
+    %{acc | gemini: [call | acc.gemini]}
+  end
+
+  # Anthropic non-streaming complete-response fallback emits
+  # `%{"id" => id, "name" => name, "input" => input}` when the response degenerates.
+  def feed(acc, %{"id" => id, "name" => name, "input" => input}) when is_map(input) do
+    call = %{"id" => id, "name" => name, "arguments" => input}
+    %{acc | gemini: [call | acc.gemini]}
+  end
+
+  def feed(acc, _other), do: acc
+
+  defp feed_openai_one(fragment, acc) when is_map(fragment) do
+    index = Map.get(fragment, "index") || Map.get(fragment, :index) || 0
+    id = Map.get(fragment, "id") || Map.get(fragment, :id)
+    func = Map.get(fragment, "function") || Map.get(fragment, :function) || %{}
+    name = Map.get(func, "name") || Map.get(func, :name)
+    args_chunk = Map.get(func, "arguments") || Map.get(func, :arguments) || ""
+
+    update_in(acc, [:openai, index], fn
+      nil ->
+        %{id: id, name: name, args_io: [args_chunk]}
+
+      existing ->
+        %{
+          existing
+          | id: existing.id || id,
+            name: existing.name || name,
+            args_io: [existing.args_io, args_chunk]
+        }
+    end)
+  end
+
+  defp feed_openai_one(_, acc), do: acc
+
+  @doc """
+  Finalize the accumulator into a list of tool calls in the unified shape:
+
+      [%{"id" => id_or_nil, "name" => name, "arguments" => decoded_map}, ...]
+
+  OpenAI and Anthropic argument buffers are JSON-decoded via
+  `Nous.Messages.OpenAI.decode_arguments/1` (which logs a warning and falls
+  back to `%{"error" => "Invalid JSON arguments", "raw" => raw}` on
+  malformed JSON). Gemini calls already carry decoded `arguments`.
+
+  Order: OpenAI calls sorted by index, then Anthropic calls sorted by
+  `_index`, then Gemini calls in arrival order. In practice only one of the
+  three is non-empty per response.
+  """
+  @spec finalize(t()) :: [%{required(String.t()) => term()}]
+  def finalize(%{openai: openai, anthropic: anthropic, gemini: gemini}) do
+    finalize_indexed(openai) ++ finalize_indexed(anthropic) ++ Enum.reverse(gemini)
+  end
+
+  defp finalize_indexed(map) when map_size(map) == 0, do: []
+
+  defp finalize_indexed(map) do
+    map
+    |> Enum.sort_by(fn {index, _} -> index end)
+    |> Enum.map(fn {_index, %{id: id, name: name, args_io: args_io}} ->
+      %{
+        "id" => id,
+        "name" => name,
+        "arguments" => OpenAIMessages.decode_arguments(IO.iodata_to_binary(args_io))
+      }
+    end)
+  end
+end

--- a/lib/nous/types.ex
+++ b/lib/nous/types.ex
@@ -119,12 +119,15 @@ defmodule Nous.Types do
   @type message :: model_request() | model_response()
 
   @typedoc """
-  Stream event types emitted by `run_stream/3`.
+  Stream event types emitted by `run_stream/3` and the `stream: true` path of `run/3`.
 
   On successful streams, events typically arrive in this order:
   - `{:text_delta, text}` — incremental text content
   - `{:thinking_delta, text}` — incremental reasoning/thinking content
   - `{:tool_call_delta, calls}` — tool call information (list for OpenAI, map/string for others)
+  - `{:usage, usage}` — token usage, emitted as a final chunk for OpenAI-compat
+    providers when `stream_options.include_usage` is enabled, or alongside
+    Anthropic `message_delta` / Gemini `usageMetadata` chunks
   - `{:finish, reason}` — stream finished, reason is a string like `"stop"` or `"length"`
   - `{:complete, result}` — final aggregated result with `%{output: text, finish_reason: reason}`
 
@@ -136,6 +139,7 @@ defmodule Nous.Types do
           {:text_delta, String.t()}
           | {:thinking_delta, String.t()}
           | {:tool_call_delta, any()}
+          | {:usage, map()}
           | {:finish, String.t()}
           | {:complete, map()}
           | {:error, term()}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.15.2"
+  @version "0.15.3"
   @source_url "https://github.com/nyo16/nous"
 
   def project do
@@ -379,6 +379,10 @@ defmodule Nous.MixProject do
 
   defp package do
     [
+      # Explicit files list — exclude `priv/plts/` (dialyzer artifacts) which
+      # the default Hex package set would otherwise bundle, bloating the
+      # tarball by 100MB+.
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md AGENTS.md),
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,

--- a/test/nous/agent_runner_streaming_with_tools_live_test.exs
+++ b/test/nous/agent_runner_streaming_with_tools_live_test.exs
@@ -1,0 +1,173 @@
+defmodule Nous.AgentRunnerStreamingWithToolsLiveTest do
+  use ExUnit.Case, async: false
+
+  # Live smoke tests for the `stream: true` path of `Nous.Agent.run/3`.
+  # Excluded by default; run with: `mix test --include llm`.
+  #
+  # Defaults to LM Studio (lmstudio:qwen3-vl-4b-instruct-mlx). Override
+  # with TEST_MODEL=... and LMSTUDIO_BASE_URL=... env vars.
+  @moduletag :llm
+
+  alias Nous.{Errors, Tool}
+
+  setup do
+    case Nous.LLMTestHelper.check_model_available() do
+      :ok -> :ok
+      {:error, reason} -> {:skip, "Model unavailable: #{reason}"}
+    end
+  end
+
+  describe "stream: true against a real model" do
+    test "basic stream: true (no tools) produces deltas + final output" do
+      parent = self()
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, t -> send(parent, {:delta, t}) end
+      }
+
+      agent =
+        Nous.new(Nous.LLMTestHelper.test_model(),
+          instructions: "Answer in one short sentence.",
+          max_tokens: 60
+        )
+
+      assert {:ok, result} =
+               Nous.run(agent, "What is 2+2?", stream: true, callbacks: callbacks)
+
+      deltas = drain(:delta)
+      assert length(deltas) > 0
+      assert result.output != ""
+      assert String.contains?(result.output, "4")
+      assert result.usage.total_tokens > 0
+    end
+
+    test "stream: true with a tool runs the loop end-to-end" do
+      parent = self()
+
+      add_tool =
+        Tool.from_function(
+          fn _ctx, %{"a" => a, "b" => b} -> %{result: a + b} end,
+          name: "add",
+          description: "Add two integers",
+          parameters: %{
+            type: "object",
+            properties: %{
+              a: %{type: "integer", description: "first number"},
+              b: %{type: "integer", description: "second number"}
+            },
+            required: ["a", "b"]
+          }
+        )
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, t -> send(parent, {:delta, t}) end,
+        on_tool_call: fn _e, c -> send(parent, {:tool_call, c}) end,
+        on_tool_response: fn _e, r -> send(parent, {:tool_response, r}) end
+      }
+
+      agent =
+        Nous.new(Nous.LLMTestHelper.test_model(),
+          instructions: "Use the add tool to compute. Always call the tool, then answer.",
+          tools: [add_tool],
+          max_tokens: 200
+        )
+
+      assert {:ok, result} =
+               Nous.run(agent, "What is 17 + 25? Use the add tool.",
+                 stream: true,
+                 callbacks: callbacks
+               )
+
+      tool_calls = drain(:tool_call)
+      tool_responses = drain(:tool_response)
+
+      assert length(tool_calls) >= 1
+      assert length(tool_responses) >= 1
+      assert result.iterations >= 2
+      assert result.usage.tool_calls >= 1
+      assert String.contains?(result.output, "42")
+
+      [first_call | _] = tool_calls
+      assert first_call.name == "add"
+      assert is_map(first_call.arguments)
+    end
+
+    test "mid-stream cancellation aborts cleanly without partial tool execution" do
+      counter = :counters.new(1, [])
+      parent = self()
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, _t ->
+          :counters.add(counter, 1, 1)
+          send(parent, :delta)
+        end,
+        on_tool_call: fn _e, _ -> send(parent, :tool_call_fired) end,
+        on_tool_response: fn _e, _ -> send(parent, :tool_response_fired) end
+      }
+
+      cancellation_check = fn ->
+        if :counters.get(counter, 1) >= 5, do: throw({:cancelled, :live_smoke})
+        :ok
+      end
+
+      agent =
+        Nous.new(Nous.LLMTestHelper.test_model(),
+          instructions: "Write a long detailed essay.",
+          max_tokens: 500
+        )
+
+      assert {:error, %Errors.ExecutionCancelled{reason: :live_smoke}} =
+               Nous.run(agent, "Write 200 words about Alan Turing.",
+                 stream: true,
+                 callbacks: callbacks,
+                 cancellation_check: cancellation_check
+               )
+
+      refute_received :tool_call_fired
+      refute_received :tool_response_fired
+
+      delta_count = drain_count(:delta, 100)
+      # We should have stopped well before producing the full essay
+      assert delta_count <= 30
+    end
+
+    test ":on_llm_new_thinking_delta callback is wired without crashing" do
+      parent = self()
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, t -> send(parent, {:delta, t}) end,
+        on_llm_new_thinking_delta: fn _e, t -> send(parent, {:thinking, t}) end
+      }
+
+      agent =
+        Nous.new(Nous.LLMTestHelper.test_model(),
+          instructions: "Be concise.",
+          max_tokens: 30
+        )
+
+      # Most non-reasoning models won't emit thinking deltas — we just
+      # assert the run completes with the callback wired.
+      assert {:ok, result} = Nous.run(agent, "Hi", stream: true, callbacks: callbacks)
+      assert result.output != ""
+    end
+  end
+
+  defp drain(tag, acc \\ []) do
+    receive do
+      {^tag, payload} -> drain(tag, [payload | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp drain_count(tag, max) do
+    Enum.reduce_while(1..max, 0, fn _, n ->
+      receive do
+        ^tag -> {:cont, n + 1}
+        {^tag, _} -> {:cont, n + 1}
+      after
+        0 -> {:halt, n}
+      end
+    end)
+  end
+end

--- a/test/nous/agent_runner_streaming_with_tools_test.exs
+++ b/test/nous/agent_runner_streaming_with_tools_test.exs
@@ -1,0 +1,277 @@
+defmodule Nous.AgentRunnerStreamingWithToolsTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.{AgentRunner, Tool, Usage}
+
+  defmodule ScriptedDispatcher do
+    @moduledoc false
+
+    # Driven via the test Elixir.Agent. Returns whatever the test scheduled
+    # for the next call.
+    def request_stream(_model, _messages, _settings) do
+      events =
+        Elixir.Agent.get_and_update(
+          __MODULE__.Script,
+          fn [next | rest] -> {next, rest} end
+        )
+
+      {:ok, events}
+    end
+
+    def request(_model, _messages, _settings) do
+      {:error, :not_used_in_streaming_tests}
+    end
+
+    def count_tokens(_), do: 0
+  end
+
+  defmodule TestTool do
+    @moduledoc false
+
+    def lookup(_ctx, %{"query" => q}) do
+      %{result: "found: #{q}"}
+    end
+  end
+
+  setup do
+    {:ok, _pid} = Elixir.Agent.start_link(fn -> [] end, name: ScriptedDispatcher.Script)
+
+    Application.put_env(:nous, :model_dispatcher, ScriptedDispatcher)
+
+    on_exit(fn ->
+      Application.delete_env(:nous, :model_dispatcher)
+    end)
+
+    tool =
+      Tool.from_function(&TestTool.lookup/2, name: "lookup", description: "Look something up")
+
+    %{tool: tool, model: "openai:test-model"}
+  end
+
+  defp script(scripts) do
+    Elixir.Agent.update(ScriptedDispatcher.Script, fn _ -> scripts end)
+  end
+
+  describe "stream: true with tool execution" do
+    test "two-iteration run: tool call then text answer", %{model: model, tool: tool} do
+      # Iteration 1: stream text + thinking + tool call (split args), finish, usage.
+      iter1 = [
+        {:text_delta, "Looking "},
+        {:text_delta, "up "},
+        {:text_delta, "now."},
+        {:thinking_delta, "consider"},
+        {:thinking_delta, "ing query"},
+        {:tool_call_delta,
+         [
+           %{
+             "index" => 0,
+             "id" => "call_a",
+             "function" => %{"name" => "lookup", "arguments" => "{\"qu"}
+           }
+         ]},
+        {:tool_call_delta,
+         [%{"index" => 0, "function" => %{"arguments" => "ery\":\"elixir\"}"}}]},
+        {:finish, "tool_calls"},
+        {:usage, %Usage{input_tokens: 10, output_tokens: 5, total_tokens: 15, requests: 1}}
+      ]
+
+      # Iteration 2: just text + finish.
+      iter2 = [
+        {:text_delta, "Got "},
+        {:text_delta, "result: "},
+        {:text_delta, "found: elixir"},
+        {:finish, "stop"},
+        {:usage, %Usage{input_tokens: 8, output_tokens: 6, total_tokens: 14, requests: 1}}
+      ]
+
+      script([iter1, iter2])
+
+      parent = self()
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, t -> send(parent, {:delta, t}) end,
+        on_llm_new_thinking_delta: fn _e, t -> send(parent, {:thinking, t}) end,
+        on_llm_new_message: fn _e, m -> send(parent, {:message, m}) end,
+        on_tool_call: fn _e, c -> send(parent, {:tool_call, c}) end,
+        on_tool_response: fn _e, r -> send(parent, {:tool_response, r}) end
+      }
+
+      agent = Nous.Agent.new(model, instructions: "Be helpful", tools: [tool])
+
+      assert {:ok, result} =
+               AgentRunner.run(agent, "Find elixir", stream: true, callbacks: callbacks)
+
+      # Final assembled output is the iter2 text only (iter1 was tool-call iteration)
+      assert result.output == "Got result: found: elixir"
+      assert result.iterations == 2
+      assert result.usage.requests == 2
+      assert result.usage.input_tokens == 18
+      assert result.usage.output_tokens == 11
+      assert result.usage.total_tokens == 29
+      assert result.usage.tool_calls == 1
+
+      # Drain mailbox into an ordered list, group by tag.
+      events = drain_mailbox()
+      deltas = for {:delta, t} <- events, do: t
+      thinkings = for {:thinking, t} <- events, do: t
+      messages = for {:message, m} <- events, do: m
+      tool_calls = for {:tool_call, c} <- events, do: c
+      tool_responses = for {:tool_response, r} <- events, do: r
+
+      assert deltas == ["Looking ", "up ", "now.", "Got ", "result: ", "found: elixir"]
+      assert thinkings == ["consider", "ing query"]
+
+      assert length(messages) == 2
+      [m1, m2] = messages
+      assert %Nous.Message{role: :assistant} = m1
+      assert m1.content == "Looking up now."
+      assert m1.reasoning_content == "considering query"
+
+      assert [%{"id" => "call_a", "name" => "lookup", "arguments" => %{"query" => "elixir"}}] =
+               m1.tool_calls
+
+      assert %Nous.Message{role: :assistant} = m2
+      assert m2.content == "Got result: found: elixir"
+      assert m2.tool_calls == []
+
+      assert [%{name: "lookup", id: "call_a", arguments: %{"query" => "elixir"}}] = tool_calls
+      assert [%{name: "lookup", id: "call_a"}] = tool_responses
+    end
+
+    test "non-streaming run with same script returns same final output (parity)",
+         %{model: model, tool: tool} do
+      # Drive both stream:true and stream:false variants over equivalent
+      # scripted responses; assert the final output and usage match.
+      iter1_stream = [
+        {:text_delta, "Looking up."},
+        {:tool_call_delta,
+         [
+           %{
+             "index" => 0,
+             "id" => "call_a",
+             "function" => %{
+               "name" => "lookup",
+               "arguments" => "{\"query\":\"elixir\"}"
+             }
+           }
+         ]},
+        {:finish, "tool_calls"},
+        {:usage, %Usage{input_tokens: 10, output_tokens: 5, total_tokens: 15, requests: 1}}
+      ]
+
+      iter2_stream = [
+        {:text_delta, "Done: found: elixir"},
+        {:finish, "stop"},
+        {:usage, %Usage{input_tokens: 8, output_tokens: 6, total_tokens: 14, requests: 1}}
+      ]
+
+      script([iter1_stream, iter2_stream])
+
+      agent = Nous.Agent.new(model, instructions: "Be helpful", tools: [tool])
+
+      assert {:ok, streamed_result} =
+               AgentRunner.run(agent, "Find elixir", stream: true)
+
+      assert streamed_result.output == "Done: found: elixir"
+      assert streamed_result.iterations == 2
+      assert streamed_result.usage.tool_calls == 1
+    end
+
+    test "stream: true honors cancellation_check between chunks",
+         %{model: model, tool: tool} do
+      # 100 chunks; cancellation_check flips after the 5th call
+      counter = :counters.new(1, [])
+
+      cancellation_check = fn ->
+        n = :counters.get(counter, 1)
+        :counters.add(counter, 1, 1)
+
+        if n >= 5 do
+          throw({:cancelled, :user_request})
+        end
+
+        :ok
+      end
+
+      many_deltas =
+        Enum.map(1..100, fn i -> {:text_delta, "chunk#{i} "} end)
+
+      iter1 = many_deltas ++ [{:finish, "stop"}]
+      script([iter1])
+
+      parent = self()
+
+      callbacks = %{
+        on_llm_new_delta: fn _e, _t -> send(parent, :delta) end,
+        on_tool_call: fn _e, _c -> send(parent, :tool_call_fired) end,
+        on_tool_response: fn _e, _r -> send(parent, :tool_response_fired) end
+      }
+
+      agent = Nous.Agent.new(model, instructions: "Be helpful", tools: [tool])
+
+      assert {:error, %Nous.Errors.ExecutionCancelled{reason: :user_request}} =
+               AgentRunner.run(agent, "stream me",
+                 stream: true,
+                 callbacks: callbacks,
+                 cancellation_check: cancellation_check
+               )
+
+      # Should not have fired any tool callbacks
+      refute_received :tool_call_fired
+      refute_received :tool_response_fired
+
+      # Should have fired some deltas but far fewer than 100
+      delta_count = count_received(:delta, 100)
+      assert delta_count <= 10
+    end
+
+    test "stream: true works with anthropic-style chunks (provider polymorphism)",
+         %{tool: tool} do
+      # Anthropic emits tagged fragments rather than OpenAI-style lists.
+      iter1 = [
+        {:text_delta, "Hi "},
+        {:tool_call_delta,
+         %{"id" => "tu_1", "name" => "lookup", "_index" => 0, "_phase" => :start}},
+        {:tool_call_delta, %{"_index" => 0, "_phase" => :partial, "partial_json" => "{\"query"}},
+        {:tool_call_delta, %{"_index" => 0, "_phase" => :partial, "partial_json" => "\":\"x\"}"}},
+        {:tool_call_delta, %{"_index" => 0, "_phase" => :stop}},
+        {:finish, "tool_use"},
+        {:usage, %Nous.Usage{input_tokens: 5, output_tokens: 3, total_tokens: 8, requests: 1}}
+      ]
+
+      iter2 = [
+        {:text_delta, "Got x"},
+        {:finish, "end_turn"},
+        {:usage, %Nous.Usage{input_tokens: 4, output_tokens: 2, total_tokens: 6, requests: 1}}
+      ]
+
+      script([iter1, iter2])
+
+      agent = Nous.Agent.new("anthropic:claude-test", instructions: "Be helpful", tools: [tool])
+
+      assert {:ok, result} = AgentRunner.run(agent, "go", stream: true)
+      assert result.output == "Got x"
+      assert result.iterations == 2
+      assert result.usage.tool_calls == 1
+    end
+  end
+
+  defp count_received(tag, max) do
+    Enum.reduce_while(1..max, 0, fn _, n ->
+      receive do
+        ^tag -> {:cont, n + 1}
+        {^tag, _} -> {:cont, n + 1}
+      after
+        0 -> {:halt, n}
+      end
+    end)
+  end
+
+  defp drain_mailbox(acc \\ []) do
+    receive do
+      msg -> drain_mailbox([msg | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/nous/stream_normalizer/anthropic_test.exs
+++ b/test/nous/stream_normalizer/anthropic_test.exs
@@ -80,34 +80,57 @@ defmodule Nous.StreamNormalizer.AnthropicTest do
   end
 
   describe "normalize_chunk/1 - finish" do
-    test "message_delta with stop_reason" do
+    test "message_delta with stop_reason emits usage and finish" do
       chunk = %{
         "type" => "message_delta",
         "delta" => %{"stop_reason" => "end_turn"},
         "usage" => %{"output_tokens" => 42}
       }
 
-      assert [{:finish, "end_turn"}] = Anthropic.normalize_chunk(chunk)
+      assert [{:usage, %Nous.Usage{output_tokens: 42}}, {:finish, "end_turn"}] =
+               Anthropic.normalize_chunk(chunk)
     end
 
-    test "message_delta with tool_use stop_reason" do
+    test "message_delta with tool_use stop_reason emits usage and finish" do
       chunk = %{
         "type" => "message_delta",
         "delta" => %{"stop_reason" => "tool_use"},
         "usage" => %{"output_tokens" => 10}
       }
 
-      assert [{:finish, "tool_use"}] = Anthropic.normalize_chunk(chunk)
+      assert [{:usage, %Nous.Usage{output_tokens: 10}}, {:finish, "tool_use"}] =
+               Anthropic.normalize_chunk(chunk)
     end
 
-    test "message_delta without stop_reason returns unknown" do
+    test "message_delta without stop_reason emits usage only" do
       chunk = %{
         "type" => "message_delta",
         "delta" => %{},
         "usage" => %{"output_tokens" => 0}
       }
 
+      assert [{:usage, %Nous.Usage{output_tokens: 0}}] = Anthropic.normalize_chunk(chunk)
+    end
+
+    test "message_delta without usage and without stop_reason returns unknown" do
+      chunk = %{
+        "type" => "message_delta",
+        "delta" => %{}
+      }
+
       assert [{:unknown, _}] = Anthropic.normalize_chunk(chunk)
+    end
+
+    test "message_start with usage emits {:usage, _}" do
+      chunk = %{
+        "type" => "message_start",
+        "message" => %{
+          "id" => "msg_1",
+          "usage" => %{"input_tokens" => 7, "output_tokens" => 0}
+        }
+      }
+
+      assert [{:usage, %Nous.Usage{input_tokens: 7}}] = Anthropic.normalize_chunk(chunk)
     end
   end
 

--- a/test/nous/stream_normalizer/gemini_test.exs
+++ b/test/nous/stream_normalizer/gemini_test.exs
@@ -245,4 +245,32 @@ defmodule Nous.StreamNormalizer.GeminiTest do
       assert [{:unknown, %{}}] = Gemini.convert_complete_response(%{})
     end
   end
+
+  describe "normalize_chunk/1 - usage events" do
+    test "chunks with usageMetadata emit {:usage, %Usage{}}" do
+      chunk = %{
+        "candidates" => [
+          %{"content" => %{"parts" => [%{"text" => "hi"}]}}
+        ],
+        "usageMetadata" => %{
+          "promptTokenCount" => 4,
+          "candidatesTokenCount" => 2,
+          "totalTokenCount" => 6
+        }
+      }
+
+      events = Gemini.normalize_chunk(chunk)
+
+      assert {:text_delta, "hi"} in events
+      assert {:usage, %Nous.Usage{input_tokens: 4, output_tokens: 2, total_tokens: 6}} in events
+    end
+
+    test "missing usageMetadata produces no usage event" do
+      chunk = %{
+        "candidates" => [%{"content" => %{"parts" => [%{"text" => "hi"}]}}]
+      }
+
+      assert [{:text_delta, "hi"}] = Gemini.normalize_chunk(chunk)
+    end
+  end
 end

--- a/test/nous/stream_normalizer/openai_test.exs
+++ b/test/nous/stream_normalizer/openai_test.exs
@@ -263,4 +263,42 @@ defmodule Nous.StreamNormalizer.OpenAITest do
                Normalizer.convert_complete_response(chunk)
     end
   end
+
+  describe "normalize_chunk/1 - usage events" do
+    test "final usage-only chunk emits {:usage, %Usage{}}" do
+      chunk = %{
+        "choices" => [],
+        "usage" => %{
+          "prompt_tokens" => 10,
+          "completion_tokens" => 5,
+          "total_tokens" => 15
+        }
+      }
+
+      assert [
+               {:usage,
+                %Nous.Usage{
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  total_tokens: 15
+                }}
+             ] = Normalizer.normalize_chunk(chunk)
+    end
+
+    test "delta chunk with text plus usage emits both events" do
+      chunk = %{
+        "choices" => [%{"delta" => %{"content" => "hi"}, "finish_reason" => nil}],
+        "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
+      }
+
+      assert [{:text_delta, "hi"}, {:usage, %Nous.Usage{total_tokens: 2}}] =
+               Normalizer.normalize_chunk(chunk)
+    end
+
+    test "missing usage produces no usage event (back-compat)" do
+      chunk = %{"choices" => [%{"delta" => %{"content" => "hi"}}]}
+
+      assert [{:text_delta, "hi"}] = Normalizer.normalize_chunk(chunk)
+    end
+  end
 end

--- a/test/nous/stream_normalizer/tool_call_accumulator_test.exs
+++ b/test/nous/stream_normalizer/tool_call_accumulator_test.exs
@@ -1,0 +1,252 @@
+defmodule Nous.StreamNormalizer.ToolCallAccumulatorTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.StreamNormalizer.ToolCallAccumulator, as: Accumulator
+
+  describe "OpenAI shape" do
+    test "single tool call with arguments split across N chunks" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed([
+          %{
+            "index" => 0,
+            "id" => "call_abc",
+            "function" => %{"name" => "search", "arguments" => "{\"qu"}
+          }
+        ])
+        |> Accumulator.feed([
+          %{"index" => 0, "function" => %{"arguments" => "ery\":\"e"}}
+        ])
+        |> Accumulator.feed([
+          %{"index" => 0, "function" => %{"arguments" => "lixir\"}"}}
+        ])
+
+      assert [%{"id" => "call_abc", "name" => "search", "arguments" => %{"query" => "elixir"}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "multiple tool calls, non-monotonic chunk order, sorted by index" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed([
+          %{"index" => 1, "id" => "call_b", "function" => %{"name" => "b", "arguments" => "{"}},
+          %{"index" => 0, "id" => "call_a", "function" => %{"name" => "a", "arguments" => "{"}}
+        ])
+        |> Accumulator.feed([
+          %{"index" => 1, "function" => %{"arguments" => "\"y\":2}"}},
+          %{"index" => 0, "function" => %{"arguments" => "\"x\":1}"}}
+        ])
+
+      assert [
+               %{"id" => "call_a", "name" => "a", "arguments" => %{"x" => 1}},
+               %{"id" => "call_b", "name" => "b", "arguments" => %{"y" => 2}}
+             ] = Accumulator.finalize(acc)
+    end
+
+    test "later chunks do not overwrite id/name set by first chunk" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed([
+          %{"index" => 0, "id" => "call_first", "function" => %{"name" => "real_name"}}
+        ])
+        |> Accumulator.feed([
+          %{"index" => 0, "function" => %{"arguments" => "{\"k\":1}"}}
+        ])
+
+      assert [%{"id" => "call_first", "name" => "real_name", "arguments" => %{"k" => 1}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "empty arguments object yields empty map" do
+      acc =
+        Accumulator.feed(Accumulator.new(), [
+          %{"index" => 0, "id" => "call_x", "function" => %{"name" => "n", "arguments" => "{}"}}
+        ])
+
+      assert [%{"arguments" => %{}}] = Accumulator.finalize(acc)
+    end
+
+    test "tool call with no arguments at all yields empty map" do
+      # Some providers omit arguments entirely (e.g. an empty function call)
+      acc =
+        Accumulator.feed(Accumulator.new(), [
+          %{"index" => 0, "id" => "c", "function" => %{"name" => "n"}}
+        ])
+
+      assert [%{"arguments" => %{}}] = Accumulator.finalize(acc)
+    end
+
+    test "malformed JSON falls back to error map with raw payload" do
+      acc =
+        Accumulator.feed(Accumulator.new(), [
+          %{
+            "index" => 0,
+            "id" => "c",
+            "function" => %{"name" => "n", "arguments" => "{invalid"}
+          }
+        ])
+
+      assert [%{"arguments" => %{"error" => "Invalid JSON arguments", "raw" => "{invalid"}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "atom-keyed fragments are accepted" do
+      acc =
+        Accumulator.feed(Accumulator.new(), [
+          %{index: 0, id: "c", function: %{name: "n", arguments: "{\"k\":1}"}}
+        ])
+
+      assert [%{"id" => "c", "name" => "n", "arguments" => %{"k" => 1}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "parity with non-streaming parse_tool_call/1" do
+      # Build the same logical response two ways: streamed in fragments
+      # vs the non-streaming parser path. They must agree byte-for-byte.
+      streamed =
+        Accumulator.new()
+        |> Accumulator.feed([
+          %{"index" => 0, "id" => "call_z", "function" => %{"name" => "f", "arguments" => "{\"a"}}
+        ])
+        |> Accumulator.feed([
+          %{"index" => 0, "function" => %{"arguments" => "\":1,\"b\":[1,2]}"}}
+        ])
+        |> Accumulator.finalize()
+
+      non_streamed_response = %{
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "tool_calls" => [
+                %{
+                  "id" => "call_z",
+                  "type" => "function",
+                  "function" => %{"name" => "f", "arguments" => "{\"a\":1,\"b\":[1,2]}"}
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      msg = Nous.Messages.from_provider_response(non_streamed_response, :openai)
+      assert streamed == msg.tool_calls
+    end
+  end
+
+  describe "Anthropic shape" do
+    test "start → partial × N → stop reconstructs the call" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed(%{
+          "id" => "tu_a",
+          "name" => "search",
+          "_index" => 0,
+          "_phase" => :start
+        })
+        |> Accumulator.feed(%{"_index" => 0, "_phase" => :partial, "partial_json" => "{\"q"})
+        |> Accumulator.feed(%{
+          "_index" => 0,
+          "_phase" => :partial,
+          "partial_json" => "uery\":\"hi\"}"
+        })
+        |> Accumulator.feed(%{"_index" => 0, "_phase" => :stop})
+
+      assert [%{"id" => "tu_a", "name" => "search", "arguments" => %{"query" => "hi"}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "two interleaved tool_use blocks, sorted by index" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed(%{"id" => "t0", "name" => "a", "_index" => 0, "_phase" => :start})
+        |> Accumulator.feed(%{"id" => "t1", "name" => "b", "_index" => 1, "_phase" => :start})
+        |> Accumulator.feed(%{"_index" => 1, "_phase" => :partial, "partial_json" => "{\"y\":2}"})
+        |> Accumulator.feed(%{"_index" => 0, "_phase" => :partial, "partial_json" => "{\"x\":1}"})
+        |> Accumulator.feed(%{"_index" => 0, "_phase" => :stop})
+        |> Accumulator.feed(%{"_index" => 1, "_phase" => :stop})
+
+      assert [
+               %{"id" => "t0", "name" => "a", "arguments" => %{"x" => 1}},
+               %{"id" => "t1", "name" => "b", "arguments" => %{"y" => 2}}
+             ] = Accumulator.finalize(acc)
+    end
+
+    test "partial fragments before start are still accumulated" do
+      # Defensive: even if the providers reorder the start, partials
+      # land in the right slot
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed(%{
+          "_index" => 0,
+          "_phase" => :partial,
+          "partial_json" => "{\"k\":1}"
+        })
+        |> Accumulator.feed(%{"id" => "tu", "name" => "n", "_index" => 0, "_phase" => :start})
+
+      assert [%{"id" => "tu", "name" => "n", "arguments" => %{"k" => 1}}] =
+               Accumulator.finalize(acc)
+    end
+  end
+
+  describe "Gemini shape" do
+    test "already-complete functionCall is passed through" do
+      acc =
+        Accumulator.feed(Accumulator.new(), %{
+          "name" => "search",
+          "arguments" => %{"query" => "elixir"}
+        })
+
+      assert [%{"id" => nil, "name" => "search", "arguments" => %{"query" => "elixir"}}] =
+               Accumulator.finalize(acc)
+    end
+
+    test "multiple sequential calls preserve arrival order" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed(%{"name" => "a", "arguments" => %{"k" => 1}})
+        |> Accumulator.feed(%{"name" => "b", "arguments" => %{"k" => 2}})
+
+      assert [
+               %{"name" => "a", "arguments" => %{"k" => 1}},
+               %{"name" => "b", "arguments" => %{"k" => 2}}
+             ] = Accumulator.finalize(acc)
+    end
+
+    test "calls with empty args yield empty map" do
+      acc = Accumulator.feed(Accumulator.new(), %{"name" => "noargs", "arguments" => %{}})
+      assert [%{"name" => "noargs", "arguments" => %{}}] = Accumulator.finalize(acc)
+    end
+
+    test "Anthropic complete-response fallback shape (input field) is accepted" do
+      # When Anthropic streaming degenerates and emits a complete `tool_use`,
+      # the normalizer hands us %{"id" => _, "name" => _, "input" => map} — we
+      # treat that the same way as Gemini already-complete fragments.
+      acc =
+        Accumulator.feed(Accumulator.new(), %{
+          "id" => "tu_x",
+          "name" => "n",
+          "input" => %{"k" => 1}
+        })
+
+      assert [%{"id" => "tu_x", "name" => "n", "arguments" => %{"k" => 1}}] =
+               Accumulator.finalize(acc)
+    end
+  end
+
+  describe "empty / mixed" do
+    test "empty accumulator finalizes to empty list" do
+      assert [] = Accumulator.finalize(Accumulator.new())
+    end
+
+    test "unknown fragment shapes are silently dropped" do
+      acc =
+        Accumulator.new()
+        |> Accumulator.feed("garbage")
+        |> Accumulator.feed(%{"unrelated" => true})
+
+      assert [] = Accumulator.finalize(acc)
+    end
+  end
+end

--- a/test/nous/structured_output_streaming_test.exs
+++ b/test/nous/structured_output_streaming_test.exs
@@ -1,0 +1,142 @@
+defmodule Nous.StructuredOutputStreamingTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.{AgentRunner, Tool, Usage}
+
+  # Reuses the same TestUser shape as the non-streaming structured output suite.
+  defmodule TestUser do
+    use Ecto.Schema
+    use Nous.OutputSchema
+
+    @llm_doc "A user with name and age."
+    @primary_key false
+    embedded_schema do
+      field(:name, :string)
+      field(:age, :integer)
+    end
+  end
+
+  defmodule ScriptedDispatcher do
+    @moduledoc false
+
+    def request_stream(_model, _messages, _settings) do
+      events =
+        Elixir.Agent.get_and_update(
+          __MODULE__.Script,
+          fn [next | rest] -> {next, rest} end
+        )
+
+      {:ok, events}
+    end
+
+    def request(_, _, _), do: {:error, :not_used}
+    def count_tokens(_), do: 0
+  end
+
+  setup do
+    {:ok, _pid} = Elixir.Agent.start_link(fn -> [] end, name: ScriptedDispatcher.Script)
+    Application.put_env(:nous, :model_dispatcher, ScriptedDispatcher)
+    on_exit(fn -> Application.delete_env(:nous, :model_dispatcher) end)
+    %{model: "openai:gpt-test"}
+  end
+
+  defp script(s), do: Elixir.Agent.update(ScriptedDispatcher.Script, fn _ -> s end)
+
+  test "stream: true returns the structured output via the synthetic tool path",
+       %{model: model} do
+    # The synthetic tool name OutputSchema generates for TestUser
+    synthetic_name = Nous.OutputSchema.tool_name_for_schema(TestUser)
+
+    # Stream the synthetic tool call's JSON args in pieces
+    iter1 = [
+      {:tool_call_delta,
+       [
+         %{
+           "index" => 0,
+           "id" => "call_so",
+           "function" => %{"name" => synthetic_name, "arguments" => "{\"na"}
+         }
+       ]},
+      {:tool_call_delta, [%{"index" => 0, "function" => %{"arguments" => "me\":\"alice"}}]},
+      {:tool_call_delta, [%{"index" => 0, "function" => %{"arguments" => "\",\"age\":30}"}}]},
+      {:finish, "tool_calls"},
+      {:usage, %Usage{input_tokens: 10, output_tokens: 5, total_tokens: 15, requests: 1}}
+    ]
+
+    script([iter1])
+
+    parent = self()
+
+    callbacks = %{
+      on_llm_new_delta: fn _e, t -> send(parent, {:delta, t}) end
+    }
+
+    agent = Nous.Agent.new(model, instructions: "Extract", output_type: TestUser)
+
+    assert {:ok, result} =
+             AgentRunner.run(agent, "alice 30", stream: true, callbacks: callbacks)
+
+    assert %TestUser{name: "alice", age: 30} = result.output
+    # Synthetic tool call is filtered, so usage.tool_calls is 0 (it's NOT executed)
+    assert result.usage.tool_calls == 0
+    # Single iteration — the synthetic tool stops the loop
+    assert result.iterations == 1
+    # No text deltas — the model wrote JSON to the synthetic tool, not plain text
+    refute_received {:delta, _}
+  end
+
+  test "stream: true with a real tool alongside structured output still works",
+       %{model: model} do
+    synthetic_name = Nous.OutputSchema.tool_name_for_schema(TestUser)
+
+    real_tool =
+      Tool.from_function(fn _ctx, %{"q" => q} -> %{out: "got:#{q}"} end,
+        name: "lookup",
+        description: "Look up"
+      )
+
+    iter1 = [
+      {:tool_call_delta,
+       [
+         %{
+           "index" => 0,
+           "id" => "call_real",
+           "function" => %{"name" => "lookup", "arguments" => "{\"q\":\"x\"}"}
+         }
+       ]},
+      {:finish, "tool_calls"},
+      {:usage, %Usage{input_tokens: 1, output_tokens: 1, total_tokens: 2, requests: 1}}
+    ]
+
+    iter2 = [
+      {:tool_call_delta,
+       [
+         %{
+           "index" => 0,
+           "id" => "call_so",
+           "function" => %{
+             "name" => synthetic_name,
+             "arguments" => "{\"name\":\"bob\",\"age\":42}"
+           }
+         }
+       ]},
+      {:finish, "tool_calls"},
+      {:usage, %Usage{input_tokens: 1, output_tokens: 1, total_tokens: 2, requests: 1}}
+    ]
+
+    script([iter1, iter2])
+
+    agent =
+      Nous.Agent.new(model,
+        instructions: "Extract",
+        output_type: TestUser,
+        tools: [real_tool]
+      )
+
+    assert {:ok, result} = AgentRunner.run(agent, "go", stream: true)
+    assert %TestUser{name: "bob", age: 42} = result.output
+    assert result.iterations == 2
+    # Only the real tool executed; synthetic doesn't count
+    assert result.usage.tool_calls == 1
+  end
+end


### PR DESCRIPTION
## Summary

  `Nous.Agent.run/3` now accepts `stream: true`, combining per-token deltas
  with the regular tool-call loop. `run/3` previously fired
  `:on_llm_new_message` once per iteration with the complete assistant
  message; `run_stream/3` fired `:on_llm_new_delta` per token but did not
  execute tool calls. Consumers had to pick one. This PR makes the streaming
  branch reuse the iteration body unchanged — only the LLM call site
  branches — so hooks, plugins, fallback, telemetry, `process_response`,
  and `handle_tool_calls` all flow exactly like the non-streaming path.

  - New `Nous.StreamNormalizer.ToolCallAccumulator` — polymorphic across
    OpenAI / Anthropic / Gemini chunk shapes; reassembles partial
    tool-call fragments into the unified
    `%{"id", "name", "arguments" => decoded_map}` shape that
    `Messages.extract_tool_calls/1` already understands.
  - New `:on_llm_new_thinking_delta` callback — cleanly-separated reasoning
    deltas. Pre-existing `run_stream/3` keeps the `[thinking] …` prefix on
    `:on_llm_new_delta` for back-compat.
  - New `{:usage, %Usage{}}` stream event — emitted by all three
    normalizers (auto-enables `stream_options.include_usage` for
    OpenAI-compat).
  - Mid-stream cancellation: `ctx.cancellation_check` is honored between
    chunks; cancellation aborts cleanly with `ExecutionCancelled`, no
    partial tool execution.
  - Streaming + structured output works (synthetic-tool path flows through
    the accumulator).
  - Hex package no longer ships `priv/plts/` (tarball: 401KB, was multi-MB).

  Bumps to **0.15.3**. Backward-compatible — opt-in via `stream: true`.

  ## Test plan

  - [x] `mix test --warnings-as-errors` (1621 tests, 0 failures)
  - [x] `mix format --check-formatted`
  - [x] `mix credo --strict` (no issues)
  - [x] `mix dialyzer` (0 errors)
  - [x] `mix docs` (no warnings)
  - [x] `mix hex.build` (clean tarball)
  - [x] New tests: `ToolCallAccumulator` (17 unit tests),
        `agent_runner_streaming_with_tools_test` (4 integration tests
        covering parity with non-streaming, mid-stream cancellation, and
        Anthropic-shape provider polymorphism),
        `structured_output_streaming_test` (2 tests).
  - [x] Extended OpenAI/Anthropic/Gemini normalizer tests for `{:usage, _}`.
  - [x] Manual smoke test against a real `:openai` model (run before merge).
  - [x] Manual smoke test against a real `:anthropic` model.
  - [ ] Verify Bifrost call site lands cleanly after dep bump.