### PR TITLE
fix: join multi-part Gemini/Vertex text responses (0.15.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.6] - 2026-05-05
+
+### Fixed
+
+- **Gemini / Vertex AI multi-part responses no longer crash
+  `Message.new!/1`.** When a Gemini candidate contained more than one
+  `text` (or `thought`) part — common on long `gemini-2.5-pro` outputs
+  such as multi-thousand-token translations — `from_response/1` passed
+  the raw list of `ContentPart` structs to `Nous.Message`, whose
+  `:content` field is `:string`. Ecto then raised
+  `%Ecto.InvalidChangesetError{errors: [content: {"is invalid",
+  [type: :string, validation: :cast]}]}`. `consolidate_content_parts/1`
+  now joins homogeneous lists of `:text` or `:thinking` parts into a
+  single string. Vertex AI is fixed implicitly via the existing
+  `:vertex_ai → from_gemini_response/1` delegation in
+  `Nous.Messages.from_provider_response/2`.
+
 ## [0.15.5] - 2026-05-01
 
 ### Fixed

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -314,5 +314,19 @@ defmodule Nous.Messages.Gemini do
   defp consolidate_content_parts([]), do: ""
   defp consolidate_content_parts([%ContentPart{type: :text, content: content}]), do: content
   defp consolidate_content_parts([%ContentPart{type: :thinking, content: content}]), do: content
-  defp consolidate_content_parts(parts) when is_list(parts), do: parts
+
+  defp consolidate_content_parts(parts) when is_list(parts) do
+    # Gemini may split a single response into multiple text (or thought) parts.
+    # Join homogeneous lists into a single string so they fit Message.content.
+    cond do
+      Enum.all?(parts, &match?(%ContentPart{type: :text}, &1)) ->
+        Enum.map_join(parts, "", & &1.content)
+
+      Enum.all?(parts, &match?(%ContentPart{type: :thinking}, &1)) ->
+        Enum.map_join(parts, "", & &1.content)
+
+      true ->
+        parts
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.15.5"
+  @version "0.15.6"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/messages_gemini_test.exs
+++ b/test/nous/messages_gemini_test.exs
@@ -147,6 +147,49 @@ defmodule Nous.MessagesGeminiTest do
       assert msg.role == :assistant
       assert msg.content == "" or msg.content == nil
     end
+
+    test "joins multiple text parts in a single candidate" do
+      # Long Gemini responses are sometimes split across multiple `text`
+      # parts. Without consolidation, Message.new!/1 raises because content
+      # is :string, not a list of ContentParts.
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{"text" => "First chunk. "},
+                %{"text" => "Second chunk. "},
+                %{"text" => "Third chunk."}
+              ]
+            }
+          }
+        ]
+      }
+
+      msg = Gemini.from_response(response)
+      assert msg.role == :assistant
+      assert msg.content == "First chunk. Second chunk. Third chunk."
+    end
+
+    test "joins multiple thought parts into reasoning_content" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{"text" => "Thinking step 1. ", "thought" => true},
+                %{"text" => "Thinking step 2.", "thought" => true},
+                %{"text" => "Final answer."}
+              ]
+            }
+          }
+        ]
+      }
+
+      msg = Gemini.from_response(response)
+      assert msg.content == "Final answer."
+      assert msg.reasoning_content == "Thinking step 1. Thinking step 2."
+    end
   end
 
   describe "to_format/1" do


### PR DESCRIPTION
When a Gemini candidate contains more than one text (or thought) part, consolidate_content_parts/1 used to return the raw list of ContentPart structs, which then failed Nous.Message's :string cast on :content with %Ecto.InvalidChangesetError{errors: [content: {"is invalid", ...}]}.

Common trigger: long gemini-2.5-pro outputs (e.g. multi-thousand-token translations) the model splits across multiple parts. Vertex AI is hit through the same path via the :vertex_ai -> from_gemini_response/1 delegation in Nous.Messages.from_provider_response/2.

Now homogeneous lists of :text or :thinking parts are joined into a single string; heterogeneous lists fall through unchanged.