### PR TITLE
fix: make hackney an optional dependency (0.15.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.7] - 2026-05-05
+
+### Changed
+
+- **`hackney` is now an optional dependency.** Req (default for both
+  one-shot and streaming) is the primary HTTP backend; `hackney` is only
+  used when a consumer opts into `Nous.HTTP.Backend.Hackney` /
+  `Nous.HTTP.StreamBackend.Hackney` via `NOUS_HTTP_BACKEND=hackney`
+  (or the streaming variant) or app config. Forcing `hackney ~> 4.0` as
+  a hard dep (added in 0.15.x) broke downstream apps with any
+  transitive constraint of `hackney ~> 1.20` (e.g. `aws ~> 1.0`'s
+  optional dep), since the resolver activated the optional constraint
+  once hackney 4 entered the graph. Apps that use the hackney backend
+  now declare `{:hackney, "~> 4.0"}` in their own `mix.exs`.
+
 ## [0.15.6] - 2026-05-05
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.15.6"
+  @version "0.15.7"
   @source_url "https://github.com/nyo16/nous"
 
   def project do
@@ -46,15 +46,17 @@ defmodule Nous.MixProject do
       {:ecto, "~> 3.11"},
 
       # HTTP clients for all LLM providers.
-      # Finch/Req for non-streaming (one-shot requests, redirects, retries).
-      # Hackney for SSE/long-streaming bodies — its `:async, :once` mode is
-      # truly pull-based, so the consumer paces the producer and a slow
-      # consumer can't OOM us via mailbox accumulation. (Finch.stream/5's
-      # callback is push-based; a fast LLM + slow consumer = unbounded
-      # mailbox growth — see review M-12.)
+      # Finch/Req is the default backend for both one-shot and streaming.
+      # Hackney is an opt-in alternative for SSE/long-streaming bodies — its
+      # `:async, :once` mode is truly pull-based, so the consumer paces the
+      # producer and a slow consumer can't OOM us via mailbox accumulation.
+      # (Finch.stream/5's callback is push-based; a fast LLM + slow consumer =
+      # unbounded mailbox growth — see review M-12.) To use the hackney
+      # backend, declare `{:hackney, "~> 4.0"}` in your app's deps and select
+      # it via `NOUS_HTTP_BACKEND=hackney` (or the streaming variant).
       {:finch, "~> 0.19"},
       {:req, "~> 0.5"},
-      {:hackney, "~> 4.0"},
+      {:hackney, "~> 4.0", optional: true},
 
       # Google Cloud auth for Vertex AI (optional — add to your app's deps to unlock)
       {:goth, "~> 1.4", optional: true},


### PR DESCRIPTION
Req is the default backend for both one-shot and streaming HTTP. Hackney is only used when a consumer opts into Nous.HTTP.Backend.Hackney / Nous.HTTP.StreamBackend.Hackney via NOUS_HTTP_BACKEND or app config.

Forcing {:hackney, "~> 4.0"} as a hard dep in 0.15.x broke downstream apps that pulled in any transitive optional constraint of hackney ~> 1.x (e.g. aws ~> 1.0's optional hackney dep). Once hackney 4 entered the graph, Mix activated the optional ~> 1.20 constraint and version resolution failed:

  Because "the lock" depends on "aws 1.0.10" which depends on
  "hackney ~> 1.20", "the lock" requires "hackney ~> 1.20".
  And because "nous >= 0.15.0" depends on "hackney ~> 4.0",
  "the lock" is incompatible with "nous >= 0.15.0".

Apps using the hackney backend now declare {:hackney, "~> 4.0"} in their own mix.exs.