### PR TITLE
feat: expand Vertex/Gemini support — thinking, structured output, tools, caching (0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-05-10
+
+A significant Gemini-on-Vertex upgrade. Most of the new surface lands as
+`Nous.Messages.Gemini` helpers + small `build_request_params/3` wiring on
+both `Nous.Providers.VertexAI` and `Nous.Providers.Gemini`, so anything new
+works against either entry point.
+
+### Added
+
+- **Thinking config (request-side).** New `:thinking_config` setting maps to
+  `generationConfig.thinkingConfig`, letting callers set `thinking_budget`
+  and `include_thoughts` on Gemini 2.5/3.x. Both Elixir shape
+  (`%{thinking_budget: 1024, include_thoughts: true}`) and native Vertex
+  shape (`%{"thinkingBudget" => 1024, "includeThoughts" => true}`) are
+  accepted.
+- **`thoughtSignature` round-trip on tool calls.** `Nous.Messages.Gemini`
+  now preserves Vertex's `thoughtSignature` on parsed tool calls (under
+  `tool_call["metadata"]["thought_signature"]`) and echoes it back when
+  serializing assistant turns. Without this, multi-turn thinking + tool
+  loops on Gemini 2.5/3.x degrade or fail because the next turn lacks the
+  required signature. The streaming normalizer also propagates the
+  signature on `{:tool_call_delta, ...}` events.
+- **Structured output (JSON schema).** New `:json_response` and
+  `:json_schema` settings wire to `responseMimeType` /  `responseSchema`
+  in `generationConfig`. The cross-provider `:response_format` shape
+  (`%{type: :json_schema, schema: ...}` and `%{type: :json_object}`) maps
+  through too.
+- **Safety settings.** `:safety_settings` flows to top-level
+  `safetySettings`, with atom-keyed entries auto-stringified.
+- **Tool config / tool choice.** `:tool_config` (raw map) and `:tool_choice`
+  (friendly form) both flow to top-level `toolConfig`. Friendly forms:
+  `:auto`, `:any` / `:required`, `:none`, and `{:any, ["fn_a", ...]}` for
+  `allowedFunctionNames`.
+- **Function calling on Vertex/Gemini actually works.** Function
+  declarations are now serialized in Vertex's `tools[].functionDeclarations`
+  format via `Nous.ToolSchema.to_gemini/1` (which strips OpenAI's `strict`
+  field and unsupported `additionalProperties` from the parameters
+  schema). Previously the high-level `Nous.LLM` path silently dropped
+  tools for these providers.
+- **Native Vertex tools.** New `:native_tools` setting accepts
+  `:google_search`, `:url_context`, `:code_execution` atoms (or
+  `{tool, config}` tuples / raw maps) and adds them as additional entries
+  in the Vertex `tools` array, alongside any function declarations.
+- **Context caching.** `:cached_content` setting maps to top-level
+  `cachedContent`. Pass-through only — create caches via the Vertex REST
+  API for now.
+- **Streaming + tools.** `Nous.LLM.stream_text/3` now honors `:tools`.
+  Tool-call deltas are aggregated per turn (preserving any
+  `thoughtSignature`), tools execute between turns, and the conversation
+  continues until the model stops calling tools or hits
+  `@max_tool_iterations`. Text deltas are still yielded to the caller as
+  they were produced.
+- **More `generationConfig` fields:** `topK` ← `:top_k`, `seed` ← `:seed`,
+  `candidateCount` ← `:candidate_count`, `presencePenalty` ←
+  `:presence_penalty`, `frequencyPenalty` ← `:frequency_penalty`,
+  `responseModalities` ← `:response_modalities`.
+
+### Changed
+
+- **Single timeout source of truth.** Removed the separate
+  `@streaming_timeout` constants from `Nous.Providers.VertexAI` (300s) and
+  `Nous.Providers.Gemini` (120s). Streaming and non-streaming now share
+  the same provider default; the actual timeout used at request time is
+  always `model.receive_timeout`, which flows through
+  `build_provider_opts/1` as `:timeout`. Override via
+  `Model.parse(..., receive_timeout: ms)`.
+
 ## [0.15.8] - 2026-05-06
 
 ### Fixed

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -182,30 +182,130 @@ defmodule Nous.LLM do
 
   def stream_text(%Model{} = model, prompt, opts) do
     messages = build_messages(prompt, opts)
-    # Note: streaming with tools is not supported yet
-    settings = build_settings(opts, [], model.provider)
+    tools = parse_tools(Keyword.get(opts, :tools, []))
+    settings = build_settings(opts, tools, model.provider)
+    deps = Keyword.get(opts, :deps, %{})
+    ctx = RunContext.new(deps)
     fallback_models = Fallback.parse_fallback_models(Keyword.get(opts, :fallback, []))
     model_chain = Fallback.build_model_chain(model, fallback_models)
 
+    if tools == [] do
+      stream_text_simple(model_chain, model, settings, messages)
+    else
+      {:ok, stream_text_with_tools(model_chain, model, settings, messages, tools, ctx)}
+    end
+  end
+
+  defp stream_text_simple(model_chain, original_model, settings, messages) do
     case Fallback.with_fallback(model_chain, fn target_model ->
-           target_settings = rebuild_llm_settings(target_model, model, settings, [])
+           target_settings = rebuild_llm_settings(target_model, original_model, settings, [])
            get_dispatcher().request_stream(target_model, messages, target_settings)
          end) do
       {:ok, stream} ->
-        # Transform stream to only yield text deltas as strings
-        text_stream =
-          stream
-          |> Stream.filter(fn
-            {:text_delta, _} -> true
-            _ -> false
-          end)
-          |> Stream.map(fn {:text_delta, text} -> text end)
-
-        {:ok, text_stream}
+        {:ok, text_only_stream(stream)}
 
       {:error, _} = error ->
         error
     end
+  end
+
+  defp text_only_stream(stream) do
+    stream
+    |> Stream.filter(fn
+      {:text_delta, _} -> true
+      _ -> false
+    end)
+    |> Stream.map(fn {:text_delta, text} -> text end)
+  end
+
+  # Multi-turn streaming with tool execution. Each turn is consumed eagerly to
+  # extract aggregated tool calls and content; text deltas are still yielded
+  # to the caller as they were produced. After a turn finishes, if any tool
+  # calls were made, they're executed and a follow-up stream is started.
+  defp stream_text_with_tools(model_chain, original_model, settings, initial_messages, tools, ctx) do
+    Stream.resource(
+      fn -> {initial_messages, 0} end,
+      fn
+        :done ->
+          {:halt, :done}
+
+        {_messages, iteration} when iteration >= @max_tool_iterations ->
+          Logger.warning("LLM stream hit max tool iterations (#{@max_tool_iterations}); halting")
+
+          {:halt, :done}
+
+        {messages, iteration} ->
+          case Fallback.with_fallback(model_chain, fn target_model ->
+                 target_settings =
+                   rebuild_llm_settings(target_model, original_model, settings, tools)
+
+                 get_dispatcher().request_stream(target_model, messages, target_settings)
+               end) do
+            {:ok, raw_stream} ->
+              {chunks, tool_calls, content} = aggregate_stream_turn(raw_stream)
+
+              if tool_calls == [] do
+                {chunks, :done}
+              else
+                Logger.debug(
+                  "LLM stream produced #{length(tool_calls)} tool call(s), executing..."
+                )
+
+                assistant_msg = build_streamed_assistant_message(content, tool_calls)
+                tool_results = execute_tool_calls(tool_calls, tools, ctx)
+                new_messages = messages ++ [assistant_msg] ++ tool_results
+                {chunks, {new_messages, iteration + 1}}
+              end
+
+            {:error, _} ->
+              {:halt, :done}
+          end
+      end,
+      fn _ -> :ok end
+    )
+  end
+
+  defp aggregate_stream_turn(stream) do
+    initial = %{chunks: [], tool_calls: [], content: ""}
+
+    result =
+      Enum.reduce(stream, initial, fn
+        {:text_delta, text}, acc ->
+          %{acc | chunks: [text | acc.chunks], content: acc.content <> text}
+
+        {:tool_call_delta, call}, acc ->
+          %{acc | tool_calls: [ensure_tool_call_id(call) | acc.tool_calls]}
+
+        _other, acc ->
+          acc
+      end)
+
+    {Enum.reverse(result.chunks), Enum.reverse(result.tool_calls), result.content}
+  end
+
+  defp ensure_tool_call_id(call) do
+    cond do
+      call["id"] -> call
+      call[:id] -> call
+      true -> Map.put(call, "id", "stream_" <> random_id())
+    end
+  end
+
+  defp random_id do
+    :crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false)
+  end
+
+  defp build_streamed_assistant_message(content, tool_calls) do
+    attrs = %{role: :assistant, tool_calls: tool_calls}
+
+    attrs =
+      case content do
+        "" -> attrs
+        nil -> attrs
+        text -> Map.put(attrs, :content, text)
+      end
+
+    Message.new!(attrs)
   end
 
   # Private helpers
@@ -313,6 +413,10 @@ defmodule Nous.LLM do
 
   defp convert_tools_for_provider(:anthropic, tools) do
     Enum.map(tools, &Nous.ToolSchema.to_anthropic/1)
+  end
+
+  defp convert_tools_for_provider(provider, tools) when provider in [:vertex_ai, :gemini] do
+    Enum.map(tools, &Nous.ToolSchema.to_gemini/1)
   end
 
   defp convert_tools_for_provider(_, tools) do

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -164,6 +164,7 @@ defmodule Nous.Messages.Gemini do
                 "args" => Map.get(call, "arguments") || Map.get(call, :arguments, %{})
               }
             }
+            |> maybe_put_signature_on_part(extract_thought_signature(call))
           end)
 
         tool_parts ++ parts
@@ -263,11 +264,13 @@ defmodule Nous.Messages.Gemini do
             end
 
           %{"functionCall" => %{"name" => name} = function_call} when is_binary(name) ->
-            tool_call = %{
-              "id" => generate_tool_call_id(),
-              "name" => name,
-              "arguments" => Map.get(function_call, "args", %{})
-            }
+            tool_call =
+              %{
+                "id" => generate_tool_call_id(),
+                "name" => name,
+                "arguments" => Map.get(function_call, "args", %{})
+              }
+              |> maybe_put_thought_signature(Map.get(item, "thoughtSignature"))
 
             {parts, reasoning, [tool_call | tools]}
 
@@ -295,11 +298,13 @@ defmodule Nous.Messages.Gemini do
           Map.has_key?(part, "functionCall") ->
             function_call = Map.get(part, "functionCall")
 
-            tool_call = %{
-              "id" => generate_tool_call_id(),
-              "name" => Map.get(function_call, "name"),
-              "arguments" => Map.get(function_call, "args", %{})
-            }
+            tool_call =
+              %{
+                "id" => generate_tool_call_id(),
+                "name" => Map.get(function_call, "name"),
+                "arguments" => Map.get(function_call, "args", %{})
+              }
+              |> maybe_put_thought_signature(Map.get(part, "thoughtSignature"))
 
             {texts, reasoning, [tool_call | tools]}
 
@@ -319,6 +324,186 @@ defmodule Nous.Messages.Gemini do
       end
 
     {text_content, reasoning_content, Enum.reverse(tool_calls)}
+  end
+
+  @doc """
+  Derive Gemini's `responseMimeType`/`responseSchema` pair from generic settings.
+
+  Honors three settings keys, in priority order:
+
+  - `:json_schema` (map) — forces JSON mime type and sets the schema.
+  - `:response_format` (map) — accepts `%{type: :json_schema, schema: schema}` or
+    `%{type: :json_object}` for cross-provider consistency.
+  - `:json_response` (boolean) — forces JSON mime type without a schema.
+
+  Returns a map with `"responseMimeType"` and (optionally) `"responseSchema"`,
+  or `%{}` when none apply.
+  """
+  @spec json_config_for_settings(map() | keyword()) :: map()
+  def json_config_for_settings(settings) do
+    schema = get_setting(settings, :json_schema)
+    response_format = get_setting(settings, :response_format)
+    json_response = get_setting(settings, :json_response)
+
+    cond do
+      is_map(schema) ->
+        %{"responseMimeType" => "application/json", "responseSchema" => schema}
+
+      response_format_schema(response_format) ->
+        %{
+          "responseMimeType" => "application/json",
+          "responseSchema" => response_format_schema(response_format)
+        }
+
+      json_object_response_format?(response_format) ->
+        %{"responseMimeType" => "application/json"}
+
+      json_response == true ->
+        %{"responseMimeType" => "application/json"}
+
+      true ->
+        %{}
+    end
+  end
+
+  defp get_setting(settings, key) when is_map(settings),
+    do: Map.get(settings, key) || Map.get(settings, Atom.to_string(key))
+
+  defp get_setting(settings, key) when is_list(settings), do: Keyword.get(settings, key)
+  defp get_setting(_, _), do: nil
+
+  defp response_format_schema(%{type: :json_schema, schema: %{} = schema}), do: schema
+  defp response_format_schema(%{"type" => "json_schema", "schema" => %{} = schema}), do: schema
+  defp response_format_schema(_), do: nil
+
+  defp json_object_response_format?(%{type: :json_object}), do: true
+  defp json_object_response_format?(%{"type" => "json_object"}), do: true
+  defp json_object_response_format?(_), do: false
+
+  @doc """
+  Build Vertex's `tools` array from function declarations and native tools.
+
+  - `function_declarations` — list of Gemini-shaped function declarations
+    (already converted via `Nous.ToolSchema.to_gemini/1`). May be empty.
+  - `native_tools` — list of native Vertex tools, each one of:
+      * `:google_search`
+      * `:url_context`
+      * `:code_execution`
+      * `{atom_or_string, %{config}}` — for tools that take configuration
+      * a raw map — passed through (e.g. `%{"googleSearch" => %{}}`)
+
+  Returns `nil` when both lists are empty so callers can `maybe_put`.
+  """
+  @spec build_tools([map()], [atom() | tuple() | map()] | nil) :: [map()] | nil
+  def build_tools(function_declarations, native_tools)
+
+  def build_tools([], native_tools) when native_tools in [nil, []], do: nil
+
+  def build_tools(function_declarations, native_tools) do
+    declarations_entry =
+      case function_declarations do
+        [] -> []
+        list -> [%{"functionDeclarations" => list}]
+      end
+
+    native_entries = native_tools |> List.wrap() |> Enum.map(&native_tool_entry/1)
+
+    declarations_entry ++ native_entries
+  end
+
+  defp native_tool_entry(:google_search), do: %{"googleSearch" => %{}}
+  defp native_tool_entry(:url_context), do: %{"urlContext" => %{}}
+  defp native_tool_entry(:code_execution), do: %{"codeExecution" => %{}}
+
+  defp native_tool_entry({name, config}) when is_atom(name) and is_map(config),
+    do: %{atom_to_camel(name) => config}
+
+  defp native_tool_entry({name, config}) when is_binary(name) and is_map(config),
+    do: %{name => config}
+
+  defp native_tool_entry(map) when is_map(map), do: map
+
+  defp atom_to_camel(:google_search), do: "googleSearch"
+  defp atom_to_camel(:url_context), do: "urlContext"
+  defp atom_to_camel(:code_execution), do: "codeExecution"
+  defp atom_to_camel(atom), do: atom |> Atom.to_string() |> camelize()
+
+  defp camelize(string) do
+    [head | rest] = String.split(string, "_")
+    [head | Enum.map(rest, &String.capitalize/1)] |> Enum.join()
+  end
+
+  @doc """
+  Normalize a list of safety settings into Vertex's `safetySettings` shape.
+
+  Accepts atom-keyed (`%{category: ..., threshold: ...}`) or string-keyed
+  (`%{"category" => ..., "threshold" => ...}`) entries. Passes unknown keys
+  through so newer Vertex fields (e.g. `"method"`) work without a library
+  bump. Returns `nil` for nil input.
+  """
+  @spec normalize_safety_settings([map()] | nil) :: [map()] | nil
+  def normalize_safety_settings(nil), do: nil
+
+  def normalize_safety_settings(settings) when is_list(settings) do
+    Enum.map(settings, fn entry ->
+      Map.new(entry, fn
+        {k, v} when is_atom(k) -> {Atom.to_string(k), v}
+        {k, v} -> {k, v}
+      end)
+    end)
+  end
+
+  @doc """
+  Normalize a `:tool_choice` setting into Vertex's `toolConfig` shape.
+
+  Accepts:
+
+    * `:auto` → mode `AUTO`
+    * `:any` / `:required` → mode `ANY` (model must call a function)
+    * `:none` → mode `NONE`
+    * `{:any, ["name_a", ...]}` → mode `ANY` with `allowedFunctionNames`
+    * a raw map (passed through as-is)
+    * `nil` (returns nil)
+  """
+  @spec normalize_tool_choice(atom() | tuple() | map() | nil) :: map() | nil
+  def normalize_tool_choice(nil), do: nil
+  def normalize_tool_choice(:auto), do: function_calling_mode("AUTO")
+  def normalize_tool_choice(:any), do: function_calling_mode("ANY")
+  def normalize_tool_choice(:required), do: function_calling_mode("ANY")
+  def normalize_tool_choice(:none), do: function_calling_mode("NONE")
+
+  def normalize_tool_choice({:any, names}) when is_list(names) do
+    %{
+      "functionCallingConfig" => %{"mode" => "ANY", "allowedFunctionNames" => names}
+    }
+  end
+
+  def normalize_tool_choice(map) when is_map(map), do: map
+
+  defp function_calling_mode(mode) do
+    %{"functionCallingConfig" => %{"mode" => mode}}
+  end
+
+  @doc """
+  Normalize a Nous-shaped `thinking_config` into Gemini's `thinkingConfig`.
+
+  Accepts either the Elixir shape (`%{thinking_budget: 1024, include_thoughts:
+  true}`) or the native Vertex shape (`%{"thinkingBudget" => 1024,
+  "includeThoughts" => true}`). Returns `nil` when the input is nil.
+
+  Unrecognized keys are passed through unchanged so newer Vertex fields work
+  without a library bump.
+  """
+  @spec normalize_thinking_config(map() | nil) :: map() | nil
+  def normalize_thinking_config(nil), do: nil
+
+  def normalize_thinking_config(config) when is_map(config) do
+    Map.new(config, fn
+      {:thinking_budget, v} -> {"thinkingBudget", v}
+      {:include_thoughts, v} -> {"includeThoughts", v}
+      {k, v} when is_atom(k) -> {Atom.to_string(k), v}
+      {k, v} -> {k, v}
+    end)
   end
 
   @doc """
@@ -345,6 +530,37 @@ defmodule Nous.Messages.Gemini do
 
   defp maybe_put_metadata(metadata, _key, nil), do: metadata
   defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
+
+  # Parse path: store Vertex's thoughtSignature inside the tool_call's
+  # internal metadata bag so it survives until the next turn.
+  defp maybe_put_thought_signature(tool_call, nil), do: tool_call
+  defp maybe_put_thought_signature(tool_call, ""), do: tool_call
+
+  defp maybe_put_thought_signature(tool_call, signature) when is_binary(signature) do
+    metadata =
+      tool_call
+      |> Map.get("metadata", %{})
+      |> Map.put("thought_signature", signature)
+
+    Map.put(tool_call, "metadata", metadata)
+  end
+
+  # Encode path: emit thoughtSignature at the top level of the Gemini part,
+  # as required by the Vertex API shape.
+  defp maybe_put_signature_on_part(part, nil), do: part
+  defp maybe_put_signature_on_part(part, ""), do: part
+
+  defp maybe_put_signature_on_part(part, signature) when is_binary(signature),
+    do: Map.put(part, "thoughtSignature", signature)
+
+  # Read the signature back from a tool_call's metadata, supporting both
+  # string-keyed and atom-keyed metadata bags so callers building tool_calls
+  # by hand don't have to think about it.
+  defp extract_thought_signature(call) do
+    metadata = Map.get(call, "metadata") || Map.get(call, :metadata) || %{}
+
+    Map.get(metadata, "thought_signature") || Map.get(metadata, :thought_signature)
+  end
 
   # Surface non-STOP finish reasons (SAFETY, RECITATION, MAX_TOKENS, etc.)
   # and prompt blocks so they don't manifest as silent empty responses.

--- a/lib/nous/providers/gemini.ex
+++ b/lib/nous/providers/gemini.ex
@@ -35,6 +35,37 @@ defmodule Nous.Providers.Gemini do
 
   Unlike OpenAI/Anthropic which use headers, Gemini uses query parameter auth:
   `?key=API_KEY`
+
+  ## Thinking (Gemini 2.5/3.x)
+
+  For models that support extended thinking, pass `:thinking_config` in
+  `default_settings`. Both the Elixir shape (snake_case atoms) and the native
+  Vertex shape (camelCase strings) are accepted:
+
+      # Elixir shape (recommended)
+      Nous.new("gemini:gemini-2.5-pro",
+        default_settings: %{
+          thinking_config: %{thinking_budget: 1024, include_thoughts: true}
+        }
+      )
+
+      # Native Vertex shape
+      Nous.new("gemini:gemini-2.5-pro",
+        default_settings: %{
+          thinking_config: %{"thinkingBudget" => 1024, "includeThoughts" => true}
+        }
+      )
+
+  When `include_thoughts: true`, thought summaries arrive as
+  `Message.reasoning_content`. For tool-using thinking models, Vertex emits a
+  `thoughtSignature` on each tool call; Nous preserves it in
+  `tool_call["metadata"]["thought_signature"]` and echoes it back on the next
+  turn automatically — required for multi-turn thinking + tool loops to keep
+  working.
+
+  See https://ai.google.dev/gemini-api/docs/thinking for the Gemini-side docs
+  and https://cloud.google.com/vertex-ai/generative-ai/docs/thinking for the
+  Vertex equivalent.
   """
 
   use Nous.Provider,
@@ -44,8 +75,13 @@ defmodule Nous.Providers.Gemini do
 
   alias Nous.Providers.HTTP
 
-  @default_timeout 60_000
-  @streaming_timeout 120_000
+  # Single source of truth for the provider's HTTP receive timeout. The actual
+  # timeout used at request time is `model.receive_timeout` (set via
+  # `Model.parse(..., receive_timeout: ms)`), which flows through
+  # `build_provider_opts/1` as the `:timeout` option. This constant is only the
+  # safety-net default when `chat/2` or `chat_stream/2` is called directly
+  # without a model-level value.
+  @default_timeout 120_000
 
   # Override to convert from generic format to Gemini's format
   defp build_request_params(model, messages, settings) do
@@ -69,7 +105,18 @@ defmodule Nous.Providers.Gemini do
       |> maybe_put("temperature", merged_settings[:temperature])
       |> maybe_put("maxOutputTokens", merged_settings[:max_tokens])
       |> maybe_put("topP", merged_settings[:top_p])
+      |> maybe_put("topK", merged_settings[:top_k])
+      |> maybe_put("seed", merged_settings[:seed])
+      |> maybe_put("candidateCount", merged_settings[:candidate_count])
+      |> maybe_put("presencePenalty", merged_settings[:presence_penalty])
+      |> maybe_put("frequencyPenalty", merged_settings[:frequency_penalty])
+      |> maybe_put("responseModalities", merged_settings[:response_modalities])
       |> maybe_put("stopSequences", merged_settings[:stop_sequences] || merged_settings[:stop])
+      |> maybe_put(
+        "thinkingConfig",
+        Nous.Messages.Gemini.normalize_thinking_config(merged_settings[:thinking_config])
+      )
+      |> Map.merge(Nous.Messages.Gemini.json_config_for_settings(merged_settings))
 
     # Merge any explicit generationConfig from settings
     generation_config =
@@ -82,7 +129,28 @@ defmodule Nous.Providers.Gemini do
         params
       end
 
+    params =
+      params
+      |> maybe_put(
+        "tools",
+        Nous.Messages.Gemini.build_tools(
+          merged_settings[:tools] || [],
+          merged_settings[:native_tools]
+        )
+      )
+      |> maybe_put(
+        "safetySettings",
+        Nous.Messages.Gemini.normalize_safety_settings(merged_settings[:safety_settings])
+      )
+      |> maybe_put("toolConfig", resolve_tool_config(merged_settings))
+      |> maybe_put("cachedContent", merged_settings[:cached_content])
+
     maybe_merge_extra_body(params, merged_settings[:extra_body])
+  end
+
+  defp resolve_tool_config(settings) do
+    settings[:tool_config] ||
+      Nous.Messages.Gemini.normalize_tool_choice(settings[:tool_choice])
   end
 
   @impl Nous.Provider
@@ -107,7 +175,7 @@ defmodule Nous.Providers.Gemini do
 
     url = build_url(base_url(opts), model, api_key, :stream)
     headers = build_headers()
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
     finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
 
     # Remove model from params (it's in the URL)

--- a/lib/nous/providers/vertex_ai.ex
+++ b/lib/nous/providers/vertex_ai.ex
@@ -128,6 +128,28 @@ defmodule Nous.Providers.VertexAI do
         goth: MyApp.Goth,
         base_url: "https://aiplatform.googleapis.com/v1beta1/projects/my-project/locations/global"
 
+  ## Thinking (Gemini 2.5/3.x)
+
+  For models that support extended thinking, pass `:thinking_config` in
+  `default_settings`. Both the Elixir shape (snake_case atoms) and the native
+  Vertex shape (camelCase strings) are accepted:
+
+      Nous.new("vertex_ai:gemini-2.5-pro",
+        default_settings: %{
+          thinking_config: %{thinking_budget: 1024, include_thoughts: true}
+        }
+      )
+
+  When `include_thoughts: true`, thought summaries arrive as
+  `Message.reasoning_content`. For tool-using thinking models, Vertex emits a
+  `thoughtSignature` on each tool call; Nous preserves it in
+  `tool_call["metadata"]["thought_signature"]` and echoes it back on the next
+  turn automatically — required for multi-turn thinking + tool loops to keep
+  working.
+
+  See https://cloud.google.com/vertex-ai/generative-ai/docs/thinking for the
+  Vertex thinking docs.
+
   ## Examples
 
       # Gemini 3.1 Pro on global endpoint (preview, v1beta1)
@@ -156,8 +178,13 @@ defmodule Nous.Providers.VertexAI do
 
   require Logger
 
+  # Single source of truth for the provider's HTTP receive timeout. The actual
+  # timeout used at request time is `model.receive_timeout` (set via
+  # `Model.parse(..., receive_timeout: ms)`), which flows through
+  # `build_provider_opts/1` as the `:timeout` option. This constant is only the
+  # safety-net default when `chat/2` or `chat_stream/2` is called directly
+  # without a model-level value.
   @default_timeout 180_000
-  @streaming_timeout 300_000
 
   # Override to convert from generic format to Gemini's format (same API format)
   defp build_request_params(model, messages, settings) do
@@ -181,7 +208,18 @@ defmodule Nous.Providers.VertexAI do
       |> maybe_put("temperature", merged_settings[:temperature])
       |> maybe_put("maxOutputTokens", merged_settings[:max_tokens])
       |> maybe_put("topP", merged_settings[:top_p])
+      |> maybe_put("topK", merged_settings[:top_k])
+      |> maybe_put("seed", merged_settings[:seed])
+      |> maybe_put("candidateCount", merged_settings[:candidate_count])
+      |> maybe_put("presencePenalty", merged_settings[:presence_penalty])
+      |> maybe_put("frequencyPenalty", merged_settings[:frequency_penalty])
+      |> maybe_put("responseModalities", merged_settings[:response_modalities])
       |> maybe_put("stopSequences", merged_settings[:stop_sequences] || merged_settings[:stop])
+      |> maybe_put(
+        "thinkingConfig",
+        Nous.Messages.Gemini.normalize_thinking_config(merged_settings[:thinking_config])
+      )
+      |> Map.merge(Nous.Messages.Gemini.json_config_for_settings(merged_settings))
 
     # Merge any explicit generationConfig from settings
     generation_config =
@@ -194,7 +232,28 @@ defmodule Nous.Providers.VertexAI do
         params
       end
 
+    params =
+      params
+      |> maybe_put(
+        "tools",
+        Nous.Messages.Gemini.build_tools(
+          merged_settings[:tools] || [],
+          merged_settings[:native_tools]
+        )
+      )
+      |> maybe_put(
+        "safetySettings",
+        Nous.Messages.Gemini.normalize_safety_settings(merged_settings[:safety_settings])
+      )
+      |> maybe_put("toolConfig", resolve_tool_config(merged_settings))
+      |> maybe_put("cachedContent", merged_settings[:cached_content])
+
     maybe_merge_extra_body(params, merged_settings[:extra_body])
+  end
+
+  defp resolve_tool_config(settings) do
+    settings[:tool_config] ||
+      Nous.Messages.Gemini.normalize_tool_choice(settings[:tool_choice])
   end
 
   # Use Gemini stream normalizer — same response format
@@ -227,7 +286,7 @@ defmodule Nous.Providers.VertexAI do
          {:ok, url_base} <- resolve_base_url(opts, model) do
       url = build_url(url_base, model, :stream)
       headers = build_headers(token)
-      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
       finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
 
       Logger.debug("Vertex AI stream request: url=#{url}, model=#{model}")

--- a/lib/nous/stream_normalizer/gemini.ex
+++ b/lib/nous/stream_normalizer/gemini.ex
@@ -92,15 +92,25 @@ defmodule Nous.StreamNormalizer.Gemini do
     end
   end
 
-  defp parse_part(%{"functionCall" => %{"name" => name, "args" => args}}) do
-    [{:tool_call_delta, %{"name" => name, "arguments" => args}}]
+  defp parse_part(%{"functionCall" => %{"name" => name, "args" => args}} = part) do
+    [{:tool_call_delta, attach_thought_signature(%{"name" => name, "arguments" => args}, part)}]
   end
 
-  defp parse_part(%{"functionCall" => %{"name" => name}}) do
-    [{:tool_call_delta, %{"name" => name, "arguments" => %{}}}]
+  defp parse_part(%{"functionCall" => %{"name" => name}} = part) do
+    [{:tool_call_delta, attach_thought_signature(%{"name" => name, "arguments" => %{}}, part)}]
   end
 
   defp parse_part(_), do: []
+
+  defp attach_thought_signature(delta, part) do
+    case Map.get(part, "thoughtSignature") do
+      sig when is_binary(sig) and sig != "" ->
+        Map.put(delta, "metadata", %{"thought_signature" => sig})
+
+      _ ->
+        delta
+    end
+  end
 
   defp normalize_finish_reason("STOP"), do: "stop"
   defp normalize_finish_reason("MAX_TOKENS"), do: "length"

--- a/lib/nous/tool_schema.ex
+++ b/lib/nous/tool_schema.ex
@@ -32,6 +32,43 @@ defmodule Nous.ToolSchema do
   end
 
   @doc """
+  Convert tool to Gemini/Vertex `functionDeclarations` schema (string keys).
+
+  Vertex/Gemini's function declaration is shaped like OpenAI's inner `function`
+  object, minus the `strict` field which is OpenAI-specific.
+
+  Returns:
+
+      %{
+        "name" => "...",
+        "description" => "...",
+        "parameters" => %{...}
+      }
+  """
+  @spec to_gemini(Tool.t()) :: map()
+  def to_gemini(tool) do
+    %{"function" => function} = Tool.to_openai_schema(tool)
+
+    function
+    |> Map.delete("strict")
+    |> Map.update("parameters", %{}, &strip_unsupported_schema_keys/1)
+  end
+
+  # Vertex's parameters schema rejects fields like `additionalProperties` /
+  # `$schema`. Drop the well-known unsupported ones so callers don't have to
+  # think about it.
+  defp strip_unsupported_schema_keys(schema) when is_map(schema) do
+    schema
+    |> Map.drop(["additionalProperties", "$schema"])
+    |> Map.new(fn {k, v} -> {k, strip_unsupported_schema_keys(v)} end)
+  end
+
+  defp strip_unsupported_schema_keys(list) when is_list(list),
+    do: Enum.map(list, &strip_unsupported_schema_keys/1)
+
+  defp strip_unsupported_schema_keys(value), do: value
+
+  @doc """
   Convert tool to Anthropic tool schema (atom keys).
 
   Anthropic uses a different format with atom keys:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.15.8"
+  @version "0.16.0"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/messages_gemini_test.exs
+++ b/test/nous/messages_gemini_test.exs
@@ -355,6 +355,250 @@ defmodule Nous.MessagesGeminiTest do
       assert system_prompt == "First instruction\n\nSecond instruction"
       assert length(contents) == 1
     end
+
+    test "echoes thoughtSignature on assistant tool call when present in metadata" do
+      tool_call = %{
+        "id" => "call_1",
+        "name" => "search",
+        "arguments" => %{"q" => "elixir"},
+        "metadata" => %{"thought_signature" => "EjQK...sig"}
+      }
+
+      msg = Message.new!(%{role: :assistant, content: nil, tool_calls: [tool_call]})
+
+      {_sys, [encoded]} = Gemini.to_format([msg])
+
+      assert [%{"functionCall" => %{"name" => "search"}, "thoughtSignature" => "EjQK...sig"}] =
+               encoded["parts"]
+    end
+
+    test "omits thoughtSignature when metadata absent" do
+      tool_call = %{"id" => "call_1", "name" => "search", "arguments" => %{}}
+      msg = Message.new!(%{role: :assistant, content: nil, tool_calls: [tool_call]})
+
+      {_sys, [encoded]} = Gemini.to_format([msg])
+
+      [part] = encoded["parts"]
+      refute Map.has_key?(part, "thoughtSignature")
+    end
+  end
+
+  describe "thoughtSignature round-trip" do
+    test "parse_content captures thoughtSignature on tool call" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{
+                  "functionCall" => %{"name" => "search", "args" => %{"q" => "elixir"}},
+                  "thoughtSignature" => "EjQK...sig"
+                }
+              ],
+              "role" => "model"
+            }
+          }
+        ]
+      }
+
+      msg = Gemini.from_response(response)
+
+      assert [%{"name" => "search", "metadata" => %{"thought_signature" => "EjQK...sig"}}] =
+               msg.tool_calls
+    end
+
+    test "from_response → to_format preserves the signature" do
+      response = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{
+                  "functionCall" => %{"name" => "search", "args" => %{"q" => "elixir"}},
+                  "thoughtSignature" => "EjQK...sig"
+                }
+              ],
+              "role" => "model"
+            }
+          }
+        ]
+      }
+
+      msg = Gemini.from_response(response)
+      {_sys, [encoded]} = Gemini.to_format([msg])
+
+      assert Enum.any?(encoded["parts"], fn part ->
+               part["thoughtSignature"] == "EjQK...sig" and
+                 get_in(part, ["functionCall", "name"]) == "search"
+             end)
+    end
+  end
+
+  describe "build_tools/2" do
+    test "returns nil when no function declarations and no native tools" do
+      assert Gemini.build_tools([], nil) == nil
+      assert Gemini.build_tools([], []) == nil
+    end
+
+    test "wraps function declarations in functionDeclarations entry" do
+      decls = [%{"name" => "search", "description" => "x", "parameters" => %{}}]
+
+      assert Gemini.build_tools(decls, nil) == [%{"functionDeclarations" => decls}]
+    end
+
+    test "emits native tools as separate entries" do
+      assert Gemini.build_tools([], [:google_search]) == [%{"googleSearch" => %{}}]
+      assert Gemini.build_tools([], [:url_context]) == [%{"urlContext" => %{}}]
+      assert Gemini.build_tools([], [:code_execution]) == [%{"codeExecution" => %{}}]
+    end
+
+    test "combines function declarations with native tools" do
+      decls = [%{"name" => "x"}]
+
+      assert Gemini.build_tools(decls, [:google_search]) == [
+               %{"functionDeclarations" => decls},
+               %{"googleSearch" => %{}}
+             ]
+    end
+
+    test "supports {tool, config} tuple form" do
+      assert Gemini.build_tools([], [{:google_search, %{"some" => "config"}}]) == [
+               %{"googleSearch" => %{"some" => "config"}}
+             ]
+    end
+
+    test "passes raw map entries through" do
+      assert Gemini.build_tools([], [%{"customTool" => %{}}]) == [%{"customTool" => %{}}]
+    end
+  end
+
+  describe "normalize_safety_settings/1" do
+    test "returns nil for nil" do
+      assert Gemini.normalize_safety_settings(nil) == nil
+    end
+
+    test "stringifies atom keys" do
+      assert Gemini.normalize_safety_settings([
+               %{category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_LOW_AND_ABOVE"}
+             ]) == [
+               %{
+                 "category" => "HARM_CATEGORY_DANGEROUS_CONTENT",
+                 "threshold" => "BLOCK_LOW_AND_ABOVE"
+               }
+             ]
+    end
+
+    test "passes string-keyed entries through" do
+      input = [%{"category" => "HARM_CATEGORY_HARASSMENT", "threshold" => "BLOCK_NONE"}]
+      assert Gemini.normalize_safety_settings(input) == input
+    end
+  end
+
+  describe "normalize_tool_choice/1" do
+    test ":auto produces AUTO mode" do
+      assert Gemini.normalize_tool_choice(:auto) == %{
+               "functionCallingConfig" => %{"mode" => "AUTO"}
+             }
+    end
+
+    test ":any and :required produce ANY mode" do
+      expected = %{"functionCallingConfig" => %{"mode" => "ANY"}}
+      assert Gemini.normalize_tool_choice(:any) == expected
+      assert Gemini.normalize_tool_choice(:required) == expected
+    end
+
+    test ":none produces NONE mode" do
+      assert Gemini.normalize_tool_choice(:none) == %{
+               "functionCallingConfig" => %{"mode" => "NONE"}
+             }
+    end
+
+    test "{:any, names} restricts to allowed function names" do
+      assert Gemini.normalize_tool_choice({:any, ["a", "b"]}) == %{
+               "functionCallingConfig" => %{
+                 "mode" => "ANY",
+                 "allowedFunctionNames" => ["a", "b"]
+               }
+             }
+    end
+
+    test "raw map passes through" do
+      raw = %{"functionCallingConfig" => %{"mode" => "AUTO"}}
+      assert Gemini.normalize_tool_choice(raw) == raw
+    end
+
+    test "nil returns nil" do
+      assert Gemini.normalize_tool_choice(nil) == nil
+    end
+  end
+
+  describe "json_config_for_settings/1" do
+    test "returns empty map when no JSON keys are set" do
+      assert Gemini.json_config_for_settings(%{}) == %{}
+    end
+
+    test ":json_response true forces application/json mime type" do
+      assert Gemini.json_config_for_settings(%{json_response: true}) == %{
+               "responseMimeType" => "application/json"
+             }
+    end
+
+    test ":json_schema sets schema and forces mime type" do
+      schema = %{"type" => "object", "properties" => %{"x" => %{"type" => "number"}}}
+
+      assert Gemini.json_config_for_settings(%{json_schema: schema}) == %{
+               "responseMimeType" => "application/json",
+               "responseSchema" => schema
+             }
+    end
+
+    test ":json_schema wins over :json_response" do
+      schema = %{"type" => "object"}
+
+      assert %{"responseSchema" => ^schema} =
+               Gemini.json_config_for_settings(%{json_schema: schema, json_response: true})
+    end
+
+    test ":response_format json_schema shape maps through" do
+      schema = %{"type" => "object"}
+
+      assert Gemini.json_config_for_settings(%{
+               response_format: %{type: :json_schema, schema: schema}
+             }) == %{
+               "responseMimeType" => "application/json",
+               "responseSchema" => schema
+             }
+    end
+
+    test ":response_format json_object shape forces mime type only" do
+      assert Gemini.json_config_for_settings(%{response_format: %{type: :json_object}}) == %{
+               "responseMimeType" => "application/json"
+             }
+    end
+  end
+
+  describe "normalize_thinking_config/1" do
+    test "converts Elixir snake_case keys to Vertex camelCase" do
+      assert Gemini.normalize_thinking_config(%{
+               thinking_budget: 1024,
+               include_thoughts: true
+             }) == %{"thinkingBudget" => 1024, "includeThoughts" => true}
+    end
+
+    test "passes through native Vertex shape unchanged" do
+      assert Gemini.normalize_thinking_config(%{
+               "thinkingBudget" => 2048,
+               "includeThoughts" => false
+             }) == %{"thinkingBudget" => 2048, "includeThoughts" => false}
+    end
+
+    test "passes through unknown atom keys as strings" do
+      assert Gemini.normalize_thinking_config(%{custom_field: "x"}) == %{"custom_field" => "x"}
+    end
+
+    test "returns nil for nil input" do
+      assert Gemini.normalize_thinking_config(nil) == nil
+    end
   end
 
   describe "from_messages/1" do

--- a/test/nous/stream_normalizer/gemini_test.exs
+++ b/test/nous/stream_normalizer/gemini_test.exs
@@ -59,6 +59,49 @@ defmodule Nous.StreamNormalizer.GeminiTest do
       assert [{:tool_call_delta, %{"name" => "get_time", "arguments" => %{}}}] =
                Gemini.normalize_chunk(chunk)
     end
+
+    test "functionCall with thoughtSignature carries metadata" do
+      chunk = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [
+                %{
+                  "functionCall" => %{"name" => "search", "args" => %{"q" => "elixir"}},
+                  "thoughtSignature" => "EjQK...sig"
+                }
+              ],
+              "role" => "model"
+            }
+          }
+        ]
+      }
+
+      assert [
+               {:tool_call_delta,
+                %{
+                  "name" => "search",
+                  "arguments" => %{"q" => "elixir"},
+                  "metadata" => %{"thought_signature" => "EjQK...sig"}
+                }}
+             ] = Gemini.normalize_chunk(chunk)
+    end
+
+    test "functionCall without thoughtSignature has no metadata key" do
+      chunk = %{
+        "candidates" => [
+          %{
+            "content" => %{
+              "parts" => [%{"functionCall" => %{"name" => "search", "args" => %{}}}],
+              "role" => "model"
+            }
+          }
+        ]
+      }
+
+      [{:tool_call_delta, delta}] = Gemini.normalize_chunk(chunk)
+      refute Map.has_key?(delta, "metadata")
+    end
   end
 
   describe "normalize_chunk/1 - finish" do

--- a/test/nous/tool_schema_test.exs
+++ b/test/nous/tool_schema_test.exs
@@ -1,0 +1,76 @@
+defmodule Nous.ToolSchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.{Tool, ToolSchema}
+
+  defp sample_tool do
+    %Tool{
+      name: "search",
+      description: "Search the index",
+      function: fn _, _ -> {:ok, "n/a"} end,
+      parameters: %{
+        "type" => "object",
+        "properties" => %{
+          "query" => %{"type" => "string"},
+          "limit" => %{"type" => "integer"}
+        },
+        "required" => ["query"],
+        "additionalProperties" => false
+      }
+    }
+  end
+
+  describe "to_gemini/1" do
+    test "produces a flat function declaration with name/description/parameters" do
+      schema = ToolSchema.to_gemini(sample_tool())
+
+      assert %{
+               "name" => "search",
+               "description" => "Search the index",
+               "parameters" => %{"type" => "object", "properties" => _, "required" => ["query"]}
+             } = schema
+    end
+
+    test "strips OpenAI-only `strict` field if present" do
+      tool = %Tool{
+        name: "x",
+        description: "y",
+        function: fn _, _ -> {:ok, nil} end,
+        parameters: %{"type" => "object", "properties" => %{}}
+      }
+
+      schema = ToolSchema.to_gemini(tool)
+      refute Map.has_key?(schema, "strict")
+      refute Map.has_key?(schema, "type")
+      refute Map.has_key?(schema, "function")
+    end
+
+    test "removes additionalProperties from parameters (Vertex doesn't accept it)" do
+      schema = ToolSchema.to_gemini(sample_tool())
+      refute Map.has_key?(schema["parameters"], "additionalProperties")
+    end
+
+    test "removes additionalProperties recursively from nested objects" do
+      tool = %Tool{
+        name: "x",
+        description: "y",
+        function: fn _, _ -> {:ok, nil} end,
+        parameters: %{
+          "type" => "object",
+          "properties" => %{
+            "nested" => %{
+              "type" => "object",
+              "properties" => %{"a" => %{"type" => "string"}},
+              "additionalProperties" => false
+            }
+          },
+          "additionalProperties" => false
+        }
+      }
+
+      schema = ToolSchema.to_gemini(tool)
+      refute Map.has_key?(schema["parameters"], "additionalProperties")
+      refute Map.has_key?(schema["parameters"]["properties"]["nested"], "additionalProperties")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

   Bundle of Gemini-on-Vertex improvements. Most of the new surface lands as helpers in `Nous.Messages.Gemini` wired into both `Nous.Providers.VertexAI` and `Nous.Providers.Gemini`, so anything new works
   against either entry point.

   ### Added

   - **Thinking config (request-side).** `:thinking_config` → `generationConfig.thinkingConfig`. Accepts Elixir shape (`%{thinking_budget: 1024, include_thoughts: true}`) or native Vertex shape.
   - **`thoughtSignature` round-trip on tool calls.** Required for multi-turn thinking + tool loops on Gemini 2.5/3.x. Preserved in `tool_call["metadata"]["thought_signature"]` and echoed back when serializing
    assistant turns. Stream normalizer also propagates it on `:tool_call_delta`.
   - **Structured output.** `:json_response` / `:json_schema` → `responseMimeType` / `responseSchema`. Cross-provider `:response_format` shapes (`%{type: :json_schema, schema: ...}` and `%{type:
   :json_object}`) map through.
   - **Safety settings.** `:safety_settings` → top-level `safetySettings`.
   - **Tool config / tool choice.** `:tool_config` (raw map) or `:tool_choice` (`:auto` / `:any` / `:required` / `:none` / `{:any, [\"name\"]}`) → top-level `toolConfig`.
   - **Function calling actually works on Vertex/Gemini.** New `Nous.ToolSchema.to_gemini/1` emits proper `functionDeclarations` shape (strips OpenAI's `strict` and unsupported `additionalProperties`).
   Previously the high-level `Nous.LLM` path silently dropped tools for these providers.
   - **Native Vertex tools.** `:native_tools` accepts `:google_search`, `:url_context`, `:code_execution`, plus `{tool, config}` tuples and raw maps. Combined with function declarations in the same `tools`
   array.
   - **Context caching.** `:cached_content` → top-level `cachedContent` (pass-through).
   - **Streaming + tools.** `Nous.LLM.stream_text/3` now honors `:tools`. Tool-call deltas (with `thoughtSignature`) aggregate per turn, tools execute between turns, conversation continues until the model
   stops calling tools or hits `@max_tool_iterations`. Text deltas are still yielded as produced.
   - **More generationConfig fields:** `topK`, `seed`, `candidateCount`, `presencePenalty`, `frequencyPenalty`, `responseModalities`.

   ### Changed

   - **Single timeout source of truth.** Removed `@streaming_timeout` (300s on Vertex, 120s on Gemini). Streaming and non-streaming share one provider default; the actual timeout is `model.receive_timeout`,
   flowing through `build_provider_opts/1`.

   ### Version

   - `mix.exs`: 0.15.8 → 0.16.0
   - CHANGELOG entry under `[0.16.0] - 2026-05-10`.

   ## Test plan

   - [x] `mix test` — 1709 tests, 0 failures (101 excluded `:llm` tag)
   - [x] `mix compile --warnings-as-errors` clean
   - [x] `mix format --check-formatted` clean
   - [ ] Manual smoke against real Vertex w/ service account: thinking + tool round-trip on `gemini-2.5-pro`
   - [ ] Manual smoke: JSON schema response on `gemini-2.0-flash`
   - [ ] Manual smoke: `:google_search` returns grounded citations
   - [ ] Manual smoke: streaming with tools fires both, completes loop
   - [ ] Manual smoke: `receive_timeout: 600_000` on a long thinking call

   ## Notes

   - `:tools` for Vertex/Gemini was effectively broken in `Nous.LLM` before this PR (the high-level path used the OpenAI tool schema and the providers never wrote a `tools` field). After this PR, tool calling
   on Gemini-on-Vertex works through the same `Nous.LLM.generate_text/3` and `stream_text/3` API as the other providers.
   - Helpers added on `Nous.Messages.Gemini` are public so users can consume them directly if they're calling `Nous.Providers.{VertexAI,Gemini}.chat/2` at the low level.