### PR TITLE
chore: code review fixes + README reorganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed (breaking)
+
+- **Provider error contracts.** `Nous.Providers.LMStudio`, `Nous.Providers.SGLang`,
+  `Nous.Providers.VLLM`, and `Nous.Providers.Custom` now return
+  `{:error, {:invalid_config, reason}}` instead of raising `ArgumentError`
+  when the resolved `base_url` is missing or fails `Nous.Tools.UrlGuard`
+  validation. `Nous.Providers.LlamaCpp` similarly returns
+  `{:error, %Nous.Errors.ProviderError{}}` instead of raising when the
+  `:llamacpp_model` option is missing.
+
+  Callers that wrapped these calls in `try/rescue ArgumentError` should
+  switch to pattern matching on `{:error, _}`. The high-level
+  `Nous.run/2`, `Nous.generate_text/3`, and `Nous.Agent.run/3` paths
+  already returned result tuples and are unaffected.
+
 ## [0.16.0] - 2026-05-10
 
 A significant Gemini-on-Vertex upgrade. Most of the new surface lands as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ All notable changes to this project will be documented in this file.
   `Nous.run/2`, `Nous.generate_text/3`, and `Nous.Agent.run/3` paths
   already returned result tuples and are unaffected.
 
+- **Vertex AI token resolution prefers Goth over `VERTEX_AI_ACCESS_TOKEN`.**
+  When a `:goth` instance is configured (in opts or app config),
+  `Nous.Providers.VertexAI` now uses Goth exclusively for that request,
+  and surfaces Goth failures as `{:error, %{reason: :goth_error, ...}}`.
+  Previously, a Goth failure would silently fall through to the env var,
+  producing confusing 401s when the env var was stale or missing.
+  If you relied on env-var fallback while Goth was misconfigured, you
+  will now see the Goth error directly — that's the intended behavior.
+
+### Fixed
+
+- **Tool args of the wrong type no longer crash `Nous.Tools.StringTools`.**
+  `replace_text`, `split_text`, `count_occurrences`, `contains` previously
+  chained `Map.get(args, "k1") || Map.get(args, "k2") || ""` to support
+  aliased keys. When the LLM handed back a non-string value (e.g.
+  `"pattern" => 123`), the value flowed straight into `String.replace/3`
+  and crashed the tool call. Args are now extracted via a typed helper
+  that falls back to the default when the value isn't a binary.
+
 ## [0.16.0] - 2026-05-10
 
 A significant Gemini-on-Vertex upgrade. Most of the new surface lands as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.16.1] - 2026-05-15
 
 ### Changed (breaking)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to Nous
+
+Thanks for your interest in contributing. This document covers everything
+you need to develop, test, and submit changes to Nous.
+
+## Prerequisites
+
+- **Elixir** 1.18+ (uses the built-in `JSON` module)
+- **OTP** 27+
+
+## Setup
+
+```bash
+git clone https://github.com/nyo16/nous.git
+cd nous
+mix deps.get
+mix compile
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+mix test
+
+# Run a specific test file
+mix test test/nous/decisions_test.exs
+
+# Run tests with verbose output
+mix test --trace
+```
+
+## Code Quality
+
+```bash
+# Check formatting
+mix format --check-formatted
+
+# Run credo linter
+mix credo --strict
+
+# Run dialyzer (first run builds PLT, takes a few minutes)
+mix dialyzer
+
+# All checks at once
+mix compile --warnings-as-errors && mix format --check-formatted && mix credo --strict && mix test
+```
+
+## Configuration
+
+API keys are configured via environment variables:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GROQ_API_KEY="gsk_..."
+# See config/config.exs for all supported providers
+```
+
+For local models (no API key needed):
+
+```bash
+# LM Studio — start the server, then:
+agent = Nous.new("lmstudio:qwen3")
+
+# Ollama — start the server, then:
+agent = Nous.new("ollama:llama2")
+
+# LlamaCpp — load a GGUF model directly (requires llama_cpp_ex dep):
+:ok = LlamaCppEx.init()
+{:ok, llm} = LlamaCppEx.load_model("model.gguf", n_gpu_layers: -1)
+agent = Nous.new("llamacpp:local", llamacpp_model: llm)
+
+# For thinking models (Qwen3, DeepSeek, etc.), disable <think> tags:
+agent = Nous.new("llamacpp:local",
+  llamacpp_model: llm,
+  model_settings: %{enable_thinking: false}
+)
+```
+
+## Running Examples
+
+```bash
+# Run any example script
+mix run examples/01_hello_world.exs
+
+# Run with a specific provider
+OPENAI_API_KEY=sk-... mix run examples/02_with_tools.exs
+```
+
+## Generating Docs
+
+```bash
+mix docs
+open doc/index.html
+```
+
+## Project Structure
+
+```
+lib/nous/
+├── agent.ex              # Agent struct and builder
+├── agent_runner.ex       # Core execution loop
+├── agent_server.ex       # GenServer wrapper for supervised agents
+├── fallback.ex           # Fallback model chain support
+├── decisions/            # Decision graph (goals, decisions, outcomes)
+│   ├── store/            # Store backends (ETS, DuckDB)
+│   ├── node.ex           # Node struct
+│   ├── edge.ex           # Edge struct
+│   ├── tools.ex          # LLM-callable decision tools
+│   └── context_builder.ex
+├── knowledge_base/       # LLM-compiled wiki knowledge base
+│   ├── store/            # Store backends (ETS)
+│   ├── tools.ex          # 9 KB agent tools
+│   ├── workflows.ex      # DAG pipelines (ingest, update, health, generate)
+│   └── prompts.ex        # LLM prompt templates
+├── memory/               # Persistent memory with hybrid search
+│   ├── store/            # Store backends (ETS, SQLite, DuckDB, etc.)
+│   ├── embedding/        # Embedding providers
+│   └── tools.ex          # LLM-callable memory tools
+├── plugins/              # Agent plugins
+│   ├── decisions.ex      # Decision graph plugin
+│   ├── memory.ex         # Memory plugin
+│   ├── team_tools.ex     # Team communication plugin
+│   ├── sub_agent.ex      # Sub-agent delegation
+│   └── human_in_the_loop.ex
+├── providers/            # LLM provider adapters
+├── teams/                # Multi-agent team orchestration
+│   ├── coordinator.ex    # Team lifecycle management
+│   ├── shared_state.ex   # Per-team shared state (ETS)
+│   ├── rate_limiter.ex   # Budget and rate limiting
+│   ├── role.ex           # Role-based tool scoping
+│   └── comms.ex          # PubSub topic helpers
+├── tool/                 # Tool system
+│   ├── behaviour.ex      # Tool behaviour
+│   ├── schema.ex         # Declarative tool DSL
+│   └── registry.ex       # Tool collection and filtering
+├── research/             # Deep research system
+└── eval/                 # Evaluation framework
+```
+
+## Submitting changes
+
+```bash
+# Fork, clone, then:
+mix deps.get
+mix test                     # Make sure tests pass
+mix format                   # Format your code
+mix credo --strict           # Check for issues
+# Open a PR against master
+```
+
+See [CHANGELOG.md](CHANGELOG.md) for recent changes.
+
+## Security
+
+Nous has project-wide security rules that are non-negotiable. Code that
+breaks these will be rejected on review:
+
+1. **Never `String.to_atom/1` on untrusted input.** Use
+   `String.to_existing_atom/1` with rescue, or pattern-match on a
+   whitelist of literal strings.
+2. **Tools requiring approval are rejected without an `:approval_handler`.**
+   `Bash`, `FileWrite`, `FileEdit` need one wired in `RunContext` or they
+   refuse to run.
+3. **File tools enforce a workspace root** via `PathGuard`. Don't bypass it.
+4. **HTTP from agents goes through `UrlGuard`.** Don't make raw `Req.get/1`
+   calls from a tool to a user-controlled URL.
+5. **`PromptTemplate` rejects `<% ... %>` blocks** — only `<%= @var %>`
+   substitution is allowed (RCE prevention).
+6. **Sub-agent deps don't auto-forward.** Declare which deps a sub-agent
+   sees with `:sub_agent_shared_deps, [:key1, :key2]`.
+
+The full text and rationale for each rule lives in
+[AGENTS.md](AGENTS.md#critical-rules-security--correctness).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:nous, "~> 0.16.0"}
+    {:nous, "~> 0.16.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ AI agent framework for Elixir with multi-provider LLM support.
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/nyo16/nous/blob/master/LICENSE)
 [![Status](https://img.shields.io/badge/status-active-brightgreen.svg)](#features)
 
+## What Nous is
+
+A production-grade AI agent framework for the BEAM. Three things you get:
+
+- **One string, 13 providers.** Swap OpenAI for Anthropic, Gemini, Vertex AI,
+  Groq, Mistral, OpenRouter, Together, Ollama, LM Studio, vLLM, SGLang,
+  LlamaCpp, or any custom OpenAI-compatible endpoint by changing
+  `"openai:gpt-4"` to `"anthropic:claude-sonnet-4-5-20250929"`.
+- **OTP-native.** Agents run as supervised processes with crash recovery,
+  streaming uses pull-based backpressure so a fast LLM can't OOM a slow
+  consumer, and fallback chains kick in on transport-layer errors without
+  application code.
+- **Batteries included.** Tool calling, structured output (Ecto schemas),
+  streaming with tool execution, skills, hooks, plugins (HITL, input
+  guards, sub-agent delegation), memory (hybrid keyword + vector),
+  workflows (DAGs), a knowledge base, deep research, evaluation, and a
+  first-class LiveView story.
+
+Think of it as Pydantic AI for Elixir — with first-class OTP supervision,
+streaming backpressure, and 13 LLM providers behind one `provider:model`
+string.
+
+> **Using Claude Code, Cursor, or Copilot to work on a Nous app?**
+> See [AGENTS.md](AGENTS.md) — it documents the public API, security
+> rules, and testing patterns specifically for AI coding agents.
+
 ## Requirements
 
 - **Elixir** 1.18+ (uses built-in `JSON` module)
@@ -23,7 +49,7 @@ Add to your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:nous, "~> 0.15.2"}
+    {:nous, "~> 0.16.0"}
   ]
 end
 ```
@@ -35,61 +61,78 @@ mix deps.get
 
 ## Quick Start
 
-### Simple Text Generation
-
-For quick LLM calls without agents:
+### One-shot text generation
 
 ```elixir
-# One-liner
-{:ok, text} = Nous.generate_text("lmstudio:qwen3", "What is Elixir?")
+{:ok, text} = Nous.generate_text("openai:gpt-4o", "What is Elixir?")
 IO.puts(text)
-
-# With options
-{:ok, text} = Nous.generate_text("openai:gpt-4", "Explain monads",
-  system: "You are a functional programming expert",
-  temperature: 0.7,
-  max_tokens: 500
-)
-
-# Streaming
-{:ok, stream} = Nous.stream_text("lmstudio:qwen3", "Write a haiku")
-stream |> Stream.each(&IO.write/1) |> Stream.run()
-
-# With prompt templates
-alias Nous.PromptTemplate
-
-template = PromptTemplate.from_template("""
-Summarize the following text in <%= @style %> style:
-
-<text>
-<%= @content %>
-</text>
-""")
-
-prompt = PromptTemplate.format(template, %{
-  style: "bullet points",
-  content: "Elixir is a dynamic, functional language for building scalable applications..."
-})
-
-{:ok, summary} = Nous.generate_text("openai:gpt-4", prompt)
 ```
 
-### With Agents
-
-For multi-turn conversations, tools, and complex workflows:
+### Streaming text
 
 ```elixir
-# Create an agent
-agent = Nous.new("lmstudio:qwen3",
-  instructions: "Be helpful and concise."
-)
+{:ok, stream} = Nous.stream_text("anthropic:claude-sonnet-4-5-20250929", "Write a haiku")
+stream |> Stream.each(&IO.write/1) |> Stream.run()
+```
 
-# Run it
-{:ok, result} = Nous.run(agent, "What is Elixir?")
+### An agent with a real tool
 
+Tools are plain functions. The LLM decides when to call them.
+
+```elixir
+get_weather = fn _ctx, %{"city" => city} ->
+  %{city: city, temperature: 72, conditions: "sunny"}
+end
+
+agent =
+  Nous.new("openai:gpt-4o",
+    instructions: "You can check the weather.",
+    tools: [get_weather]
+  )
+
+{:ok, result} = Nous.run(agent, "What's the weather in Tokyo?")
 IO.puts(result.output)
 IO.puts("Tokens: #{result.usage.total_tokens}")
 ```
+
+### Switch providers with one line
+
+```elixir
+agent = Nous.new("lmstudio:qwen3")                         # Local (free)
+agent = Nous.new("openai:gpt-4o")                          # OpenAI
+agent = Nous.new("anthropic:claude-sonnet-4-5-20250929")   # Anthropic
+agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")       # Google Vertex AI
+agent = Nous.new("llamacpp:local", llamacpp_model: llm)    # Local NIF
+
+# Or set a fallback chain:
+agent = Nous.new("openai:gpt-4o",
+  fallback: ["anthropic:claude-sonnet-4-5-20250929", "groq:llama-3.1-70b-versatile"]
+)
+```
+
+For a longer guided tour (multi-tool agents, error handling, persistence,
+observability) see [docs/getting-started.md](docs/getting-started.md).
+
+## Features
+
+One-line index of what's built in. Each item links to its deep dive below
+or out to a focused guide.
+
+- **[Tool calling](#tool-calling)** — Elixir functions or modules the LLM can invoke; concurrent execution, timeouts, validation
+- **[Streaming](#streaming)** — token deltas with optional tool execution, cancellation-safe between chunks
+- **[Structured output](#structured-output)** — return validated Ecto schemas, schemaless types, JSON schema, or `{:one_of, [...]}` choices ([guide](docs/guides/structured_output.md))
+- **[Skills](#skills)** — reusable domain knowledge as modules or markdown files; 21 built-in skills across 7 groups ([guide](docs/guides/skills.md))
+- **[Hooks](#hooks)** — intercept tool calls, requests, and lifecycle events at 6 points ([guide](docs/guides/hooks.md))
+- **[Plugins](#plugin-system)** — composable cross-cutting concerns
+- **[Human-in-the-loop](#human-in-the-loop)** — approval workflows for sensitive tools, sync or async via PubSub
+- **[Input guard](#input-guard)** — pluggable strategies for prompt-injection and jailbreak detection
+- **[Sub-agent delegation](#sub-agent-delegation)** — `delegate_task` / `spawn_agents` for sequential or parallel sub-agents
+- **[Memory](#agent-memory)** — persistent hybrid keyword + vector search; ETS, SQLite, DuckDB, Muninn, Zvec backends ([guide](docs/guides/memory.md))
+- **[Workflow](#workflow-engine)** — executable DAGs of agents, tools, and control flow with branching, cycles, parallelism, pause/resume ([guide](docs/guides/workflows.md))
+- **[Knowledge base](#knowledge-base)** — LLM-compiled wiki with summaries, backlinks, ingestion pipelines ([guide](docs/guides/knowledge_base.md))
+- **[Deep research](#deep-research)** — autonomous multi-step research with citations
+- **[Agent supervision](#agent-supervision--persistence)** — `AgentDynamicSupervisor`, persistence backends, crash recovery
+- **[LiveView integration](#liveview-integration)** — streaming, PubSub fan-out, async approvals ([guide](docs/guides/liveview-integration.md))
 
 ## Supported Providers
 
@@ -110,14 +153,6 @@ IO.puts("Tokens: #{result.usage.total_tokens}")
 | LlamaCpp | `llamacpp:local` + `:llamacpp_model` | ✅ |
 | **Custom** | `custom:model` + `:base_url` | ✅ |
 
-HTTP providers use a pluggable backend on both the non-streaming and
-streaming paths — `Req` (default, on top of Finch) or `hackney 4` —
-selected per-call, via `NOUS_HTTP_BACKEND` / `NOUS_HTTP_STREAM_BACKEND`,
-or via app config. The Hackney streaming backend uses `[{:async, :once}]`
-pull-based mode for strict backpressure (a slow consumer can't grow its
-mailbox under a fast LLM). LlamaCpp runs in-process via NIFs.
-See [HTTP Backend](#http-backend) below for details.
-
 > **Tip**: The named local providers (`lmstudio:`, `vllm:`, `sglang:`,
 > `ollama:`) are the recommended way to talk to local OpenAI-compatible
 > servers — they default to the right port, validate `*_BASE_URL` env vars
@@ -126,45 +161,8 @@ See [HTTP Backend](#http-backend) below for details.
 
 ### Custom Providers
 
-Use the `custom:` prefix to connect to any OpenAI-compatible API endpoint:
+Use the `custom:` prefix for any OpenAI-compatible endpoint:
 
-```elixir
-# Quick example with explicit options
-agent = Nous.new("custom:llama-3.1-70b",
-  base_url: "https://api.groq.com/openai/v1",
-  api_key: System.get_env("GROQ_API_KEY")
-)
-{:ok, result} = Nous.run(agent, "Hello!")
-```
-
-#### Configuration Methods
-
-Configuration is loaded in this precedence (higher overrides lower):
-
-1. **Direct options** (per-request):
-   ```elixir
-   Nous.new("custom:my-model",
-     base_url: "https://api.example.com/v1",
-     api_key: "sk-..."
-   )
-   ```
-
-2. **Environment variables**:
-   ```bash
-   export CUSTOM_BASE_URL="https://api.example.com/v1"
-   export CUSTOM_API_KEY="sk-..."
-   ```
-
-3. **Application config**:
-   ```elixir
-   config :nous, :custom,
-     base_url: "https://api.example.com/v1",
-     api_key: "sk-..."
-   ```
-
-#### Examples by Service
-
-**Groq** (fast inference):
 ```elixir
 agent = Nous.new("custom:llama-3.1-70b",
   base_url: "https://api.groq.com/openai/v1",
@@ -172,354 +170,58 @@ agent = Nous.new("custom:llama-3.1-70b",
 )
 ```
 
-**Together AI** (model variety):
-```elixir
-agent = Nous.new("custom:meta-llama/Llama-3-70b",
-  base_url: "https://api.together.xyz/v1",
-  api_key: System.get_env("TOGETHER_API_KEY")
-)
-```
+Configuration is loaded in this precedence: direct options → env vars
+(`CUSTOM_BASE_URL`, `CUSTOM_API_KEY`) → app config (`config :nous, :custom, ...`).
+Pass vendor-specific top-level body params (`top_k`, `chat_template_kwargs`,
+`repetition_penalty`, `min_p`, `best_of`, `ignore_eos`, etc.) through
+`:extra_body` — it mirrors the OpenAI Python SDK's `extra_body=` argument.
 
-**OpenRouter** (unified API):
-```elixir
-agent = Nous.new("custom:anthropic/claude-3.5-sonnet",
-  base_url: "https://openrouter.ai/api/v1",
-  api_key: System.get_env("OPENROUTER_API_KEY")
-)
-```
-
-**Local Servers** — prefer the named providers below; use `custom:` only when
-your local server isn't one of them.
-
-```elixir
-# Named providers — recommended. Each defaults to the standard port for
-# its server, and the *_BASE_URL env var is validated for SSRF safety.
-agent = Nous.new("lmstudio:qwen3")                          # localhost:1234
-agent = Nous.new("ollama:llama2")                           # localhost:11434
-agent = Nous.new("vllm:meta-llama/Llama-3-8B-Instruct")     # localhost:8000
-agent = Nous.new("sglang:meta-llama/Llama-3-8B-Instruct")   # localhost:30000
-
-# Per-provider overrides via env (or :base_url opt):
-# export LMSTUDIO_BASE_URL="http://10.0.0.5:1234/v1"
-# export VLLM_BASE_URL="http://gpu-host:8000/v1"
-# export SGLANG_BASE_URL="http://gpu-host:30000/v1"
-
-# Fall back to custom: only for non-OpenAI-compatible local servers,
-# or servers without a named provider.
-agent = Nous.new("custom:my-model", base_url: "http://localhost:9999/v1")
-```
-
-> **Note**: The legacy `openai_compatible:` prefix still works for backward compatibility
-> but `custom:` is the recommended approach going forward.
-
-#### Vendor-specific body params (`:extra_body`)
-
-Some OpenAI-compatible servers (vLLM, SGLang, LM Studio, llama.cpp) accept top-level
-JSON keys that aren't part of OpenAI's official schema — `top_k`, `chat_template_kwargs`,
-`repetition_penalty`, `min_p`, `best_of`, `ignore_eos`, etc. Pass them through `:extra_body`,
-which mirrors the OpenAI Python SDK's `extra_body=` argument:
-
-```elixir
-# Disable Qwen3 thinking + tune sampling
-agent = Nous.new("custom:qwen3-vl",
-  base_url: "http://localhost:8000/v1",
-  default_settings: %{
-    temperature: 0.7,
-    extra_body: %{
-      top_k: 20,
-      chat_template_kwargs: %{enable_thinking: false}
-    }
-  })
-
-# Interleaved thinking — preserve thinking blocks across turns
-agent = Nous.new("custom:qwen3-vl",
-  base_url: "http://localhost:8000/v1",
-  default_settings: %{
-    extra_body: %{
-      chat_template_kwargs: %{preserve_thinking: true}
-    }
-  })
-```
-
-Per-call override:
-
-```elixir
-Nous.LLM.complete(model, "hi", extra_body: %{top_k: 20})
-Agent.run(agent, prompt, model_settings: %{extra_body: %{top_k: 20}})
-```
-
-`extra_body` keys are merged at the top level of the request body and override any
-whitelisted keys on collision (escape-hatch semantics). Atom keys are stringified;
-nested map values pass through verbatim.
-
-```elixir
-# Switch providers with one line change
-agent = Nous.new("lmstudio:qwen3")                  # Local (free)
-agent = Nous.new("openai:gpt-4")                    # OpenAI
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929")   # Anthropic
-agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")  # Google Vertex AI
-agent = Nous.new("llamacpp:local", llamacpp_model: llm)  # Local NIF
-
-# With automatic fallback on provider failure
-agent = Nous.new("openai:gpt-4",
-  fallback: ["anthropic:claude-sonnet-4-20250514", "groq:llama-3.1-70b-versatile"]
-)
-```
+For full details (per-vendor examples, `extra_body` semantics,
+`openai_compatible:` legacy prefix), see
+[docs/guides/custom_providers.md](docs/guides/custom_providers.md).
 
 ### HTTP Backend
 
-Both the non-streaming and streaming HTTP paths go through pluggable
-backends. Defaults are `Nous.HTTP.Backend.Req` and
-`Nous.HTTP.StreamBackend.Req` (both on Req + Finch).
-`Nous.HTTP.Backend.Hackney` and `Nous.HTTP.StreamBackend.Hackney` are
-shipped as alternatives.
+HTTP providers use a pluggable backend on both the non-streaming and
+streaming paths — `Req` (default, on top of Finch) or `hackney 4` —
+selected per-call, via `NOUS_HTTP_BACKEND` / `NOUS_HTTP_STREAM_BACKEND`,
+or via app config. Hackney streaming uses pull-based `[{:async, :once}]`
+mode for strict backpressure.
 
-#### Non-streaming (`Nous.HTTP.Backend`)
+See [docs/guides/http_backends.md](docs/guides/http_backends.md) for
+configuration, the streaming-backend selection matrix, and pool tuning.
 
-Pick per-call, per-environment, or per-app:
+### Google Vertex AI
 
-```elixir
-# Per-call
-HTTP.post(url, body, headers, backend: Nous.HTTP.Backend.Hackney)
+Vertex AI provides enterprise access to Gemini models with VPC-SC,
+CMEK, IAM, regional/global endpoints, and the latest preview models
+(Gemini 3.1 Pro, 3 Flash, 3.1 Flash-Lite — global endpoint only).
 
-# Env (highest precedence after per-call):
-# NOUS_HTTP_BACKEND=hackney   # also accepts "req" or a fully-qualified
-#                             # custom module name like "MyApp.MyBackend"
-
-# App config
-config :nous, :http_backend, Nous.HTTP.Backend.Hackney
-```
-
-#### Streaming (`Nous.HTTP.StreamBackend`)
-
-Same resolution chain, separate config knob:
-
-```elixir
-# Per-call
-HTTP.stream(url, body, headers,
-  stream_backend: Nous.HTTP.StreamBackend.Hackney)
-
-# Env
-# NOUS_HTTP_STREAM_BACKEND=hackney
-
-# App config
-config :nous, :http_stream_backend, Nous.HTTP.StreamBackend.Hackney
-```
-
-When to pick which streaming backend:
-
-| Backend | Pick it when |
-|---------|--------------|
-| `Nous.HTTP.StreamBackend.Req` *(default)* | One HTTP stack across streaming + non-streaming. Right default for almost every app. Backpressure is bounded by parsing speed, not strict pull pacing — fine for typical LLM workloads where token rate is the bottleneck. |
-| `Nous.HTTP.StreamBackend.Hackney` | Strict pull-based backpressure via `[{:async, :once}]`. Pick this when downstream consumers can block per chunk (LiveView fan-out under load, persistence-on-every-chunk, slow IO). |
-
-Both emit identical normalized event streams (parsed JSON maps,
-`{:stream_done, _}`, `{:stream_error, _}`); switching backends needs no
-other code changes.
-
-#### Hackney pool
-
-Tune the shared hackney `:default` pool from app config (used by both
-the Hackney non-streaming and Hackney streaming backends):
-
-```elixir
-config :nous, :hackney_pool,
-  max_connections: 200,
-  timeout: 1_500   # idle keepalive ms (hackney 4 caps at 2_000)
-```
-
-See [the HTTP backend benchmark report](https://github.com/nyo16/nous/blob/master/docs/benchmarks/http_backend.md)
-for localhost + real-endpoint benchmark numbers and guidance on when
-to switch backends. Headline: stick with the Req defaults unless you
-have a specific reason (strict backpressure, HTTP/3 upgrade, single-HTTP-stack consolidation).
+See [docs/guides/vertex_ai_setup.md](docs/guides/vertex_ai_setup.md) for
+service-account setup, Goth integration, and endpoint selection.
 
 ### Timeouts
 
-Each provider has sensible default timeouts (60s for cloud APIs, 120s for local models). Override per-model with `receive_timeout`:
+Each provider has sensible default timeouts (60s for cloud APIs, 120s
+for local models). Override per-model with `receive_timeout`:
 
 ```elixir
-# Increase timeout for slow models or large responses
-agent = Nous.new("lmstudio:qwen3",
-  receive_timeout: 300_000  # 5 minutes
-)
-
-# Works with any provider
-agent = Nous.new("openai:gpt-4",
-  receive_timeout: 180_000  # 3 minutes
-)
+agent = Nous.new("lmstudio:qwen3", receive_timeout: 300_000)  # 5 minutes
+agent = Nous.new("openai:gpt-4o", receive_timeout: 180_000)   # 3 minutes
 ```
-
-Default timeouts by provider:
 
 | Provider | Default |
 |----------|---------|
 | OpenAI, Anthropic, Gemini, Groq, Mistral, OpenRouter, Together | 60s |
 | LM Studio, Ollama, vLLM, SGLang, LlamaCpp, Custom | 120s |
 
-### Google Vertex AI Setup
-
-Vertex AI provides enterprise access to Gemini models via Google Cloud. It supports
-VPC-SC, CMEK, IAM, regional/global endpoints, and all the latest Gemini models.
-
-#### Supported Models
-
-| Model | Model ID | Endpoint | API Version |
-|-------|----------|----------|-------------|
-| Gemini 3.1 Pro (preview) | `gemini-3.1-pro-preview` | global only | v1beta1 |
-| Gemini 3 Flash (preview) | `gemini-3-flash-preview` | global only | v1beta1 |
-| Gemini 3.1 Flash-Lite (preview) | `gemini-3.1-flash-lite-preview` | global only | v1beta1 |
-| Gemini 2.5 Pro | `gemini-2.5-pro` | regional + global | v1 |
-| Gemini 2.5 Flash | `gemini-2.5-flash` | regional + global | v1 |
-| Gemini 2.0 Flash | `gemini-2.0-flash` | regional + global | v1 |
-
-> **Note:** Preview and experimental models automatically use the `v1beta1` API version.
-> The Gemini 3.x preview models are **global endpoint only** — set `GOOGLE_CLOUD_LOCATION=global`.
-
-#### Regional vs Global Endpoints
-
-Vertex AI offers two endpoint types:
-
-- **Regional** (e.g., `us-central1`, `europe-west1`): Low-latency, data residency guarantees
-  ```
-  https://us-central1-aiplatform.googleapis.com/v1/projects/{project}/locations/us-central1
-  ```
-- **Global**: Higher availability, required for Gemini 3.x preview models
-  ```
-  https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global
-  ```
-
-The provider automatically selects the correct hostname and API version based on the
-region and model name. Set `GOOGLE_CLOUD_LOCATION=global` for Gemini 3.x preview models.
-
-#### Step 1: Create a Service Account
-
-```bash
-export PROJECT_ID="your-project-id"
-
-# Enable Vertex AI API
-gcloud services enable aiplatform.googleapis.com --project=$PROJECT_ID
-
-# Create service account
-gcloud iam service-accounts create nous-vertex-ai \
-  --display-name="Nous Vertex AI" \
-  --project=$PROJECT_ID
-
-# Grant the Vertex AI User role
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member="serviceAccount:nous-vertex-ai@${PROJECT_ID}.iam.gserviceaccount.com" \
-  --role="roles/aiplatform.user"
-
-# Download the key file
-gcloud iam service-accounts keys create /tmp/sa-key.json \
-  --iam-account="nous-vertex-ai@${PROJECT_ID}.iam.gserviceaccount.com"
-```
-
-#### Step 2: Set Environment Variables
-
-```bash
-# Load the service account JSON into an env var (recommended — no file path dependency)
-export GOOGLE_CREDENTIALS="$(cat /tmp/sa-key.json)"
-
-# Required: your GCP project ID
-export GOOGLE_CLOUD_PROJECT="your-project-id"
-
-# Required for Gemini 3.x preview models (global endpoint only)
-export GOOGLE_CLOUD_LOCATION="global"
-
-# Or use a regional endpoint for stable models:
-# export GOOGLE_CLOUD_LOCATION="us-central1"
-# export GOOGLE_CLOUD_LOCATION="europe-west1"
-```
-
-Both `GOOGLE_CLOUD_REGION` and `GOOGLE_CLOUD_LOCATION` are supported (consistent with
-other Google Cloud libraries). `GOOGLE_CLOUD_REGION` takes precedence if both are set.
-Defaults to `us-central1` if neither is set.
-
-#### Step 3: Add Goth to Your Application
-
-Goth handles OAuth2 token fetching and auto-refresh from the service account credentials.
-
-```elixir
-# mix.exs
-{:goth, "~> 1.4"}
-```
-
-```elixir
-# application.ex — start Goth in your supervision tree
-credentials = System.get_env("GOOGLE_CREDENTIALS") |> JSON.decode!()
-
-children = [
-  {Goth, name: MyApp.Goth, source: {:service_account, credentials}}
-]
-```
-
-#### Step 4: Configure and Use
-
-```elixir
-# Option A: App config (recommended for production)
-# config/config.exs
-config :nous, :vertex_ai, goth: MyApp.Goth
-
-# Then use it — Goth handles token refresh automatically:
-agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")
-{:ok, result} = Nous.run(agent, "Hello from Vertex AI!")
-```
-
-```elixir
-# Option B: Per-model Goth (useful for multiple projects)
-agent = Nous.new("vertex_ai:gemini-3-flash-preview",
-  default_settings: %{goth: MyApp.Goth}
-)
-```
-
-```elixir
-# Option C: Explicit base_url (for custom endpoint or specific region)
-alias Nous.Providers.VertexAI
-
-agent = Nous.new("vertex_ai:gemini-3.1-pro-preview",
-  base_url: VertexAI.endpoint("my-project", "global", "gemini-3.1-pro-preview"),
-  default_settings: %{goth: MyApp.Goth}
-)
-```
-
-```elixir
-# Option D: Quick testing with gcloud CLI (no Goth needed)
-# export VERTEX_AI_ACCESS_TOKEN="$(gcloud auth print-access-token)"
-agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")
-```
-
-#### Input Validation
-
-The provider validates `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` at request time
-and returns helpful error messages for invalid values instead of opaque DNS or HTTP errors.
-
-#### Examples
-
-- [`examples/providers/vertex_ai.exs`](examples/providers/vertex_ai.exs) — Basic usage with access token
-- [`examples/providers/vertex_ai_goth_test.exs`](examples/providers/vertex_ai_goth_test.exs) — Service account with Goth
-- [`examples/providers/vertex_ai_multi_region.exs`](examples/providers/vertex_ai_multi_region.exs) — Multi-region + v1/v1beta1 demo
-- [`examples/providers/vertex_ai_integration_test.exs`](examples/providers/vertex_ai_integration_test.exs) — Full integration test (Flash + Pro, streaming + non-streaming)
-
-## Features
+## Feature deep dives
 
 ### Tool Calling
 
-Define Elixir functions as tools. The AI calls them automatically when needed.
+Quick Start showed the minimal shape. Beyond that:
 
-```elixir
-get_weather = fn _ctx, %{"city" => city} ->
-  %{city: city, temperature: 72, conditions: "sunny"}
-end
-
-agent = Nous.new("openai:gpt-4",
-  instructions: "You can check the weather.",
-  tools: [get_weather]
-)
-
-{:ok, result} = Nous.run(agent, "What's the weather in Tokyo?")
-```
-
-### Tools with Context
+#### Tools with context
 
 Pass dependencies (user, database, API keys) via context:
 
@@ -536,15 +238,18 @@ agent = Nous.new("openai:gpt-4", tools: [get_balance])
 )
 ```
 
-### Context Continuation
+#### Module-based tools
 
-Continue conversations with full context preservation:
+For better organization and testability, implement `Nous.Tool.Behaviour`
+(returning `metadata/0` and `execute/2`) and pass via
+`Nous.Tool.from_module/1`. See
+[examples/07_module_tools.exs](examples/07_module_tools.exs) for the full
+pattern, and [docs/guides/tool_development.md](docs/guides/tool_development.md)
+for declarative schemas, registries, and testing helpers.
 
-```elixir
-{:ok, result1} = Nous.run(agent, "My name is Alice")
-{:ok, result2} = Nous.run(agent, "What's my name?", context: result1.context)
-# => "Your name is Alice"
-```
+Tools can also update context state for subsequent calls via
+`Nous.Tool.ContextUpdate`. Continue conversations with full context by
+passing `context: result.context` to the next `Nous.run/3`.
 
 ### Streaming
 
@@ -559,12 +264,9 @@ stream
 end)
 ```
 
-### Streaming with Tool Execution
-
 `Nous.run_stream/3` streams text but does **not** execute tools. To get
 per-token deltas *and* tool execution in the same call, pass `stream: true`
-to `Nous.run/3`. The agent loop runs as usual; deltas fire as the model
-produces them.
+to `Nous.run/3`:
 
 ```elixir
 agent = Nous.new("openai:gpt-4", tools: [&MyTools.search/2])
@@ -581,36 +283,35 @@ agent = Nous.new("openai:gpt-4", tools: [&MyTools.search/2])
 ```
 
 Works across providers (OpenAI-compatible, Anthropic, Gemini). Compatible
-with `output_type` for structured output. `cancellation_check` is honored
-between chunks — a flipped flag aborts the run cleanly without partial
-tool execution. See `docs/guides/liveview-integration.md` for the LiveView
-pattern.
+with `output_type`. `cancellation_check` is honored between chunks — a
+flipped flag aborts the run cleanly without partial tool execution. See
+[docs/guides/liveview-integration.md](docs/guides/liveview-integration.md)
+for the LiveView pattern.
 
 ### Fallback Models
 
-Automatically try alternative models when the primary fails (rate limit, server error, timeout):
+Automatically try alternative models when the primary fails (rate limit,
+server error, timeout):
 
 ```elixir
-# Agent with fallback chain
 agent = Nous.new("openai:gpt-4",
-  fallback: ["anthropic:claude-sonnet-4-20250514", "groq:llama-3.1-70b-versatile"],
-  instructions: "Be helpful"
+  fallback: ["anthropic:claude-sonnet-4-20250514", "groq:llama-3.1-70b-versatile"]
 )
 
-{:ok, result} = Nous.run(agent, "Hello")
-
-# Simple LLM API with fallback
+# Also works on the simple LLM API:
 {:ok, text} = Nous.generate_text("openai:gpt-4", "Hello",
   fallback: ["anthropic:claude-sonnet-4-20250514"]
 )
 
-# Also works with streaming
+# And on streaming:
 {:ok, stream} = Nous.stream_text("openai:gpt-4", "Write a haiku",
   fallback: ["groq:llama-3.1-70b-versatile"]
 )
 ```
 
-Fallback triggers on `ProviderError` and `ModelError` only. Application-level errors (validation, max iterations, tool errors) are returned immediately since a different model wouldn't help.
+Fallback triggers on `ProviderError` and `ModelError` only. Application-level
+errors (validation, max iterations, tool errors) return immediately since a
+different model wouldn't help.
 
 ### Callbacks
 
@@ -628,54 +329,6 @@ Monitor execution with callbacks or process messages:
 # Process messages (for LiveView)
 {:ok, result} = Nous.run(agent, "Hello", notify_pid: self())
 # Receives: {:agent_delta, text}, {:tool_call, call}, {:agent_complete, result}
-```
-
-### Module-Based Tools
-
-Define tools as modules for better organization and testability:
-
-```elixir
-defmodule MyTools.Search do
-  @behaviour Nous.Tool.Behaviour
-
-  @impl true
-  def metadata do
-    %{
-      name: "search",
-      description: "Search the web",
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "query" => %{"type" => "string"}
-        },
-        "required" => ["query"]
-      }
-    }
-  end
-
-  @impl true
-  def execute(ctx, %{"query" => query}) do
-    http = ctx.deps[:http_client] || MyApp.HTTP
-    {:ok, http.search(query)}
-  end
-end
-
-agent = Nous.new("openai:gpt-4",
-  tools: [Nous.Tool.from_module(MyTools.Search)]
-)
-```
-
-### Tool Context Updates
-
-Tools can modify context state for subsequent calls:
-
-```elixir
-alias Nous.Tool.ContextUpdate
-
-add_item = fn ctx, %{"item" => item} ->
-  items = ctx.deps[:cart] || []
-  {:ok, %{added: item}, ContextUpdate.set(ContextUpdate.new(), :cart, items ++ [item])}
-end
 ```
 
 ### Structured Output
@@ -703,51 +356,12 @@ agent = Nous.new("openai:gpt-4",
 result.output  #=> %UserInfo{name: "Alice", age: 30}
 ```
 
-Also supports schemaless types (`%{name: :string}`), raw JSON schema, choice constraints,
-and multi-schema selection where the LLM picks the format:
+Also supports schemaless types (`%{name: :string}`), raw JSON schema,
+choice constraints, and multi-schema selection (`{:one_of, [...]}`) where
+the LLM picks the format. Override per-run with `output_type:`.
 
-```elixir
-agent = Nous.new("openai:gpt-4",
-  output_type: {:one_of, [SentimentResult, EntityResult]}
-)
-
-{:ok, result} = Nous.run(agent, "Analyze: 'Great product!'")
-# result.output is a %SentimentResult{} or %EntityResult{} — LLM decides
-```
-
-Override per-run: `Nous.run(agent, prompt, output_type: MySchema)`.
-
-See [Structured Output Guide](docs/guides/structured_output.md) for full documentation.
-
-### Prompt Templates
-
-Build prompts with EEx variable substitution:
-
-```elixir
-alias Nous.PromptTemplate
-
-template = PromptTemplate.from_template(
-  "You are a <%= @role %> who speaks <%= @language %>.",
-  role: :system
-)
-
-message = PromptTemplate.to_message(template, %{role: "teacher", language: "Spanish"})
-{:ok, result} = Nous.run(agent, messages: [message, Message.user("Hello")])
-```
-
-### ReActAgent
-
-For complex multi-step reasoning with planning:
-
-```elixir
-agent = Nous.ReActAgent.new("openai:gpt-4",
-  tools: [&search/2, &calculate/2]
-)
-
-{:ok, result} = Nous.run(agent,
-  "Research the population of Tokyo and calculate its density"
-)
-```
+See [docs/guides/structured_output.md](docs/guides/structured_output.md)
+for full documentation.
 
 ### Skills
 
@@ -762,62 +376,16 @@ agent = Nous.new("openai:gpt-4",
 # Mix module skills, file-based skills, and groups
 agent = Nous.new("openai:gpt-4",
   skills: [MyApp.Skills.Custom, {:group, :testing}],
-  skill_dirs: ["priv/skills/"]  # Scan directories for .md skill files
+  skill_dirs: ["priv/skills/"]
 )
 ```
 
-#### File-Based Skills
+File-based skills are markdown with YAML frontmatter — no Elixir code
+needed. **21 built-in skills** across 7 groups: `:coding`, `:review`,
+`:testing`, `:debug`, `:git`, `:docs`, `:planning`.
 
-Define skills as markdown files with YAML frontmatter — no Elixir code needed:
-
-```markdown
-<!-- priv/skills/api_design.md -->
----
-name: api_design
-description: RESTful API design best practices
-tags: [api, rest, design]
-group: planning
-activation: auto
-priority: 50
----
-
-When designing APIs:
-1. Use nouns for resources, verbs for actions
-2. Version your API (v1, v2)
-3. Use proper HTTP status codes
-4. Paginate list endpoints
-```
-
-Load from files, directories, or parse inline:
-
-```elixir
-alias Nous.Skill.Loader
-
-# Load a single file
-{:ok, skill} = Loader.load_file("priv/skills/api_design.md")
-
-# Load all .md files from a directory (recursive)
-skills = Loader.load_directory("priv/skills/")
-
-# Or let the agent scan directories automatically
-agent = Nous.new("openai:gpt-4",
-  skill_dirs: ["priv/skills/", "~/.nous/skills/"]
-)
-```
-
-**21 built-in skills** across 7 groups:
-
-| Group | Skills |
-|-------|--------|
-| `:coding` | Refactor, ExplainCode, ElixirIdioms, EctoPatterns, OtpPatterns, PhoenixLiveView, PythonFastAPI, PythonTyping, PythonDataScience, PythonUv |
-| `:review` | CodeReview, SecurityScan, PythonSecurity |
-| `:testing` | TestGen, ElixirTesting, PythonTesting |
-| `:debug` | Debug |
-| `:git` | CommitMessage |
-| `:docs` | DocGen |
-| `:planning` | Architect, TaskBreakdown |
-
-Create custom skills as modules or markdown files — see the [Skills Guide](docs/guides/skills.md).
+See [docs/guides/skills.md](docs/guides/skills.md) for built-in skill
+listings, frontmatter spec, custom-skill patterns, and loader usage.
 
 ### Hooks
 
@@ -839,7 +407,10 @@ agent = Nous.new("openai:gpt-4",
 )
 ```
 
-6 lifecycle events: `pre_tool_use`, `post_tool_use`, `pre_request`, `post_response`, `session_start`, `session_end`. Three handler types: function, module, command (via NetRunner). See the [Hooks Guide](docs/guides/hooks.md).
+6 lifecycle events: `pre_tool_use`, `post_tool_use`, `pre_request`,
+`post_response`, `session_start`, `session_end`. Three handler types:
+function, module, command (via NetRunner). See
+[docs/guides/hooks.md](docs/guides/hooks.md).
 
 ### Plugin System
 
@@ -851,8 +422,6 @@ agent = Nous.new("openai:gpt-4",
   plugins: [Nous.Plugins.Summarization, Nous.Plugins.HumanInTheLoop],
   tools: [&MyTools.send_email/2]
 )
-
-{:ok, result} = Nous.run(agent, "Send a welcome email to alice@example.com")
 ```
 
 ### Human-in-the-Loop
@@ -873,27 +442,15 @@ agent = Nous.new("openai:gpt-4",
 )
 ```
 
-#### Async Approval via PubSub
-
-For LiveView or other async approval workflows:
-
-```elixir
-# Configure PubSub once in config/config.exs
-config :nous, pubsub: MyApp.PubSub
-
-# Use async approval handler
-deps = %{hitl_config: %{
-  tools: ["send_email"],
-  handler: Nous.PubSub.Approval.handler(session_id: session_id, timeout: :timer.minutes(5))
-}}
-
-# In LiveView: handle {:approval_required, info} and call
-# Nous.PubSub.Approval.respond(MyApp.PubSub, session_id, tool_call_id, :approve)
-```
+For LiveView or other async approval workflows, configure
+`config :nous, pubsub: MyApp.PubSub` and use
+`Nous.PubSub.Approval.handler/1` — see
+[examples/11_human_in_the_loop.exs](examples/11_human_in_the_loop.exs).
 
 ### Input Guard
 
-Detect and block prompt injection, jailbreak attempts, and other malicious inputs:
+Detect and block prompt injection, jailbreak attempts, and other
+malicious inputs:
 
 ```elixir
 agent = Nous.new("openai:gpt-4",
@@ -909,44 +466,12 @@ agent = Nous.new("openai:gpt-4",
     }
   }
 )
-# => Blocked instantly: "I can't process this request. Pattern matched: instruction override"
 ```
 
-Combine multiple strategies with configurable aggregation:
-
-```elixir
-deps: %{
-  input_guard_config: %{
-    strategies: [
-      {Nous.Plugins.InputGuard.Strategies.Pattern, []},                      # Regex patterns
-      {Nous.Plugins.InputGuard.Strategies.LLMJudge, model: "openai:gpt-4o-mini"},  # LLM classifier
-      {MyApp.InputGuard.Blocklist, words: ["hack", "exploit"]}               # Custom strategy
-    ],
-    aggregation: :any,            # :any | :majority | :all
-    policy: %{suspicious: :warn, blocked: :block},
-    on_violation: &MyApp.log_violation/1
-  }
-}
-```
-
-Create custom strategies by implementing the `Nous.Plugins.InputGuard.Strategy` behaviour:
-
-```elixir
-defmodule MyApp.InputGuard.Blocklist do
-  @behaviour Nous.Plugins.InputGuard.Strategy
-  alias Nous.Plugins.InputGuard.Result
-
-  @impl true
-  def check(input, config, _ctx) do
-    words = Keyword.get(config, :words, [])
-    downcased = String.downcase(input)
-    case Enum.find(words, &String.contains?(downcased, &1)) do
-      nil  -> {:ok, %Result{severity: :safe}}
-      word -> {:ok, %Result{severity: :blocked, reason: "Blocklisted: #{word}", strategy: __MODULE__}}
-    end
-  end
-end
-```
+Combine multiple strategies (`Pattern`, `LLMJudge`, or your own) with
+aggregation (`:any | :majority | :all`) and a policy map. Create custom
+strategies by implementing `Nous.Plugins.InputGuard.Strategy`. See
+[examples/15_input_guard.exs](examples/15_input_guard.exs).
 
 ### Sub-Agent Delegation
 
@@ -974,23 +499,11 @@ agent = Nous.new("openai:gpt-4",
 )
 ```
 
-The `SubAgent` plugin provides two tools:
-- `delegate_task` — run a single sub-agent for sequential delegation
-- `spawn_agents` — run multiple sub-agents concurrently via `Task.Supervisor`
-
-Each sub-agent runs in its own context but inherits parent deps automatically
-(excluding plugin-internal keys). Configure concurrency, timeouts, and
-optionally restrict which deps are shared:
-
-```elixir
-deps: %{
-  sub_agent_templates: templates,
-  database: MyApp.Repo,              # shared with sub-agents automatically
-  parallel_max_concurrency: 3,       # max concurrent sub-agents (default: 5)
-  parallel_timeout: 60_000,          # per-task timeout in ms (default: 120_000)
-  sub_agent_shared_deps: [:database] # optional: restrict to specific keys
-}
-```
+Sub-agents run in their own context but inherit parent deps automatically
+(excluding plugin-internal keys). Configure `parallel_max_concurrency`,
+`parallel_timeout`, and restrict shared deps with
+`sub_agent_shared_deps: [:key1, :key2]` (default `[]` is correct for
+security).
 
 ### Agent Memory
 
@@ -1003,35 +516,19 @@ agent = Nous.new("openai:gpt-4",
   deps: %{memory_config: %{store: Nous.Memory.Store.ETS}}
 )
 
-# Agent can now use remember/recall/forget tools
 {:ok, r1} = Nous.run(agent, "Remember that my favorite color is blue")
 {:ok, r2} = Nous.run(agent, "What is my favorite color?", context: r1.context)
-# => Recalls "blue" from memory
 ```
 
-Add semantic search with embeddings:
+**Store backends:** ETS (zero deps), SQLite (FTS5), DuckDB (FTS + vector),
+Muninn (Tantivy BM25), Zvec (HNSW), Hybrid (Muninn + Zvec).
+**Embedding providers:** Bumblebee (local, offline), OpenAI, Local
+(Ollama/vLLM). **Features:** Memory scoping (agent/user/session/global),
+temporal decay, importance weighting, RRF scoring, configurable
+auto-injection.
 
-```elixir
-agent = Nous.new("openai:gpt-4",
-  plugins: [Nous.Plugins.Memory],
-  deps: %{
-    memory_config: %{
-      store: Nous.Memory.Store.ETS,
-      embedding: Nous.Memory.Embedding.OpenAI,
-      embedding_opts: %{api_key: System.get_env("OPENAI_API_KEY")},
-      auto_inject: true  # Auto-retrieves relevant memories before each request
-    }
-  }
-)
-```
-
-**Store backends:** ETS (zero deps), SQLite (FTS5), DuckDB (FTS + vector), Muninn (Tantivy BM25), Zvec (HNSW), Hybrid (Muninn + Zvec).
-
-**Embedding providers:** Bumblebee (local, offline), OpenAI, Local (Ollama/vLLM).
-
-**Features:** Memory scoping (agent/user/session/global), temporal decay, importance weighting, RRF scoring, configurable auto-injection.
-
-See the [Memory Examples](#memory-examples) section below for complete examples.
+See [docs/guides/memory.md](docs/guides/memory.md) for full configuration
+and the [Memory Examples](#memory-examples) below for runnable scripts.
 
 ### Workflow Engine
 
@@ -1040,7 +537,6 @@ Compose agents, tools, and control flow as executable DAGs:
 ```elixir
 alias Nous.Workflow
 
-# Build a workflow graph
 graph =
   Workflow.new("research_pipeline")
   |> Workflow.add_node(:plan, :agent_step, %{agent: planner, prompt: "Plan research on: ..."})
@@ -1054,59 +550,43 @@ graph =
   |> Workflow.add_node(:review, :human_checkpoint, %{prompt: "Approve report?"})
   |> Workflow.chain([:plan, :search, :synthesize, :review])
 
-# Run it
 {:ok, state} = Workflow.run(graph, %{topic: "AI agents"}, trace: true)
-
-# Visualize
 IO.puts(Workflow.to_mermaid(graph))
 ```
 
-**Supports:** branching, cycles with max-iteration guards, static + dynamic parallelism, pause/resume, hooks, subworkflows, error strategies (retry/skip/fallback), telemetry, tracing, checkpointing. See [examples/18_workflow.exs](examples/18_workflow.exs).
+Supports branching, cycles with max-iteration guards, static and dynamic
+parallelism, pause/resume, hooks, subworkflows, error strategies
+(retry/skip/fallback), telemetry, tracing, and checkpointing. See
+[examples/18_workflow.exs](examples/18_workflow.exs).
 
 ### Knowledge Base
 
-LLM-compiled personal knowledge base — raw documents get ingested, compiled by an LLM into a structured markdown wiki with summaries, backlinks, and cross-references:
+LLM-compiled personal knowledge base — raw documents get ingested,
+compiled by an LLM into a structured markdown wiki with summaries,
+backlinks, and cross-references:
 
 ```elixir
 # Plugin mode — add KB tools to any agent
 agent = Nous.new("openai:gpt-4",
   plugins: [Nous.Plugins.KnowledgeBase],
   deps: %{
-    kb_config: %{
-      store: Nous.KnowledgeBase.Store.ETS,
-      kb_id: "my_kb"
-    }
+    kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}
   }
 )
 
 {:ok, r1} = Nous.run(agent, "Ingest this article about GenServers: ...")
 {:ok, r2} = Nous.run(agent, "What do we know about OTP?", context: r1.context)
-```
 
-For KB-specialized agents with reasoning tools:
-
-```elixir
-agent = Nous.new("openai:gpt-4",
-  behaviour_module: Nous.Agents.KnowledgeBaseAgent,
-  plugins: [Nous.Plugins.KnowledgeBase],
-  deps: %{kb_config: %{store: Nous.KnowledgeBase.Store.ETS, kb_id: "my_kb"}}
-)
-```
-
-For batch operations, use the workflow API:
-
-```elixir
-# Batch ingest documents
+# Batch operations via the workflow API:
 {:ok, state} = Nous.KnowledgeBase.ingest(
-  [%{title: "Article 1", content: "..."}],
-  kb_config: config
+  [%{title: "Article 1", content: "..."}], kb_config: config
 )
-
-# Run a health check
-{:ok, state} = Nous.KnowledgeBase.health_check(kb_config: config)
 ```
 
-**9 tools:** `kb_search`, `kb_read`, `kb_list`, `kb_ingest`, `kb_add_entry`, `kb_link`, `kb_backlinks`, `kb_health_check`, `kb_generate`. Composes with the Memory plugin. See the [Knowledge Base Guide](docs/guides/knowledge_base.md).
+**9 tools:** `kb_search`, `kb_read`, `kb_list`, `kb_ingest`,
+`kb_add_entry`, `kb_link`, `kb_backlinks`, `kb_health_check`,
+`kb_generate`. Composes with the Memory plugin. See
+[docs/guides/knowledge_base.md](docs/guides/knowledge_base.md).
 
 ### Deep Research
 
@@ -1127,7 +607,6 @@ IO.puts(report.content)  # Markdown report with inline citations
 Production lifecycle management with state persistence:
 
 ```elixir
-# Start a supervised agent with persistence
 {:ok, pid} = Nous.AgentDynamicSupervisor.start_agent(
   agent, session_id: "user-123",
   persistence: Nous.Persistence.ETS,
@@ -1168,13 +647,16 @@ defmodule MyAppWeb.ChatLive do
 end
 ```
 
-See [examples/advanced/liveview_integration.exs](examples/advanced/liveview_integration.exs) for complete patterns.
+See [docs/guides/liveview-integration.md](docs/guides/liveview-integration.md)
+and [examples/advanced/liveview_integration.exs](examples/advanced/liveview_integration.exs)
+for complete patterns including PubSub fan-out, async approvals, and
+hackney backpressure tuning.
 
 ## Examples
 
-**[Full Examples Collection](examples/README.md)** - Focused examples from basics to production.
+**[Full Examples Collection](examples/README.md)** — focused examples from basics to production.
 
-### Core Examples (01-10)
+### Core Examples (01-19)
 
 | Example | Description |
 |---------|-------------|
@@ -1240,7 +722,6 @@ Nous.Telemetry.attach_default_handler()
 Test, benchmark, and optimize your agents:
 
 ```elixir
-# Define tests
 suite = Nous.Eval.Suite.new(
   name: "my_tests",
   default_model: "lmstudio:qwen3",
@@ -1254,25 +735,19 @@ suite = Nous.Eval.Suite.new(
   ]
 )
 
-# Run evaluation
 {:ok, result} = Nous.Eval.run(suite)
 Nous.Eval.Reporter.print(result)
 ```
 
-**Features:**
-- Six built-in evaluators (exact_match, fuzzy_match, contains, tool_usage, schema, llm_judge)
-- Metrics collection (latency, tokens, cost)
-- A/B testing with `Nous.Eval.run_ab/2`
-- Parameter optimization with Bayesian, grid, or random search
-- YAML test suite definitions
+Six built-in evaluators (exact_match, fuzzy_match, contains, tool_usage,
+schema, llm_judge), metrics (latency, tokens, cost), A/B testing via
+`Nous.Eval.run_ab/2`, parameter optimization (Bayesian, grid, random
+search), and YAML test-suite definitions. CLI:
+`mix nous.eval --suite test/eval/suites/basic.yaml`,
+`mix nous.optimize --suite suite.yaml --strategy bayesian --trials 20`.
 
-**CLI:**
-```bash
-mix nous.eval --suite test/eval/suites/basic.yaml
-mix nous.optimize --suite suite.yaml --strategy bayesian --trials 20
-```
-
-See [Evaluation Guide](docs/guides/evaluation.md) for complete documentation.
+See [docs/guides/evaluation.md](docs/guides/evaluation.md) for complete
+documentation.
 
 ## Architecture
 
@@ -1293,156 +768,16 @@ Nous.run/3 → AgentRunner
 └─→ Research (Planner → Searcher → Synthesizer → Reporter)
 ```
 
-## Development
+## Troubleshooting
 
-### Prerequisites
-
-- Erlang/OTP 26+
-- Elixir 1.15+
-
-### Setup
-
-```bash
-git clone https://github.com/nyo16/nous.git
-cd nous
-mix deps.get
-mix compile
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-mix test
-
-# Run a specific test file
-mix test test/nous/decisions_test.exs
-
-# Run tests with verbose output
-mix test --trace
-```
-
-### Code Quality
-
-```bash
-# Check formatting
-mix format --check-formatted
-
-# Run credo linter
-mix credo --strict
-
-# Run dialyzer (first run builds PLT, takes a few minutes)
-mix dialyzer
-
-# All checks at once
-mix compile --warnings-as-errors && mix format --check-formatted && mix credo --strict && mix test
-```
-
-### Configuration
-
-API keys are configured via environment variables:
-
-```bash
-export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_API_KEY="sk-ant-..."
-export GROQ_API_KEY="gsk_..."
-# See config/config.exs for all supported providers
-```
-
-For local models (no API key needed):
-
-```bash
-# LM Studio — start the server, then:
-agent = Nous.new("lmstudio:qwen3")
-
-# Ollama — start the server, then:
-agent = Nous.new("ollama:llama2")
-
-# LlamaCpp — load a GGUF model directly (requires llama_cpp_ex dep):
-:ok = LlamaCppEx.init()
-{:ok, llm} = LlamaCppEx.load_model("model.gguf", n_gpu_layers: -1)
-agent = Nous.new("llamacpp:local", llamacpp_model: llm)
-
-# For thinking models (Qwen3, DeepSeek, etc.), disable <think> tags:
-agent = Nous.new("llamacpp:local",
-  llamacpp_model: llm,
-  model_settings: %{enable_thinking: false}
-)
-```
-
-### Running Examples
-
-```bash
-# Run any example script
-mix run examples/01_hello_world.exs
-
-# Run with a specific provider
-OPENAI_API_KEY=sk-... mix run examples/02_with_tools.exs
-```
-
-### Generating Docs
-
-```bash
-mix docs
-open doc/index.html
-```
-
-### Project Structure
-
-```
-lib/nous/
-├── agent.ex              # Agent struct and builder
-├── agent_runner.ex       # Core execution loop
-├── agent_server.ex       # GenServer wrapper for supervised agents
-├── fallback.ex           # Fallback model chain support
-├── decisions/            # Decision graph (goals, decisions, outcomes)
-│   ├── store/            # Store backends (ETS, DuckDB)
-│   ├── node.ex           # Node struct
-│   ├── edge.ex           # Edge struct
-│   ├── tools.ex          # LLM-callable decision tools
-│   └── context_builder.ex
-├── knowledge_base/       # LLM-compiled wiki knowledge base
-│   ├── store/            # Store backends (ETS)
-│   ├── tools.ex          # 9 KB agent tools
-│   ├── workflows.ex      # DAG pipelines (ingest, update, health, generate)
-│   └── prompts.ex        # LLM prompt templates
-├── memory/               # Persistent memory with hybrid search
-│   ├── store/            # Store backends (ETS, SQLite, DuckDB, etc.)
-│   ├── embedding/        # Embedding providers
-│   └── tools.ex          # LLM-callable memory tools
-├── plugins/              # Agent plugins
-│   ├── decisions.ex      # Decision graph plugin
-│   ├── memory.ex         # Memory plugin
-│   ├── team_tools.ex     # Team communication plugin
-│   ├── sub_agent.ex      # Sub-agent delegation
-│   └── human_in_the_loop.ex
-├── providers/            # LLM provider adapters
-├── teams/                # Multi-agent team orchestration
-│   ├── coordinator.ex    # Team lifecycle management
-│   ├── shared_state.ex   # Per-team shared state (ETS)
-│   ├── rate_limiter.ex   # Budget and rate limiting
-│   ├── role.ex           # Role-based tool scoping
-│   └── comms.ex          # PubSub topic helpers
-├── tool/                 # Tool system
-│   ├── behaviour.ex      # Tool behaviour
-│   ├── schema.ex         # Declarative tool DSL
-│   └── registry.ex       # Tool collection and filtering
-├── research/             # Deep research system
-└── eval/                 # Evaluation framework
-```
+Hit a wall? See [docs/guides/troubleshooting.md](docs/guides/troubleshooting.md)
+for common errors, debug logging, and provider-specific gotchas.
 
 ## Contributing
 
-Contributions welcome! See [CHANGELOG.md](CHANGELOG.md) for recent changes.
-
-```bash
-# Fork, clone, then:
-mix deps.get
-mix test                     # Make sure tests pass
-mix format                   # Format your code
-mix credo --strict           # Check for issues
-# Open a PR against master
-```
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
+test commands, code-quality checks, project layout, and the security
+rules that apply to all code in the repo.
 
 ## License
 
@@ -1450,5 +785,7 @@ Apache 2.0 - see [LICENSE](https://github.com/nyo16/nous/blob/master/LICENSE)
 
 ## Credits
 
-- Inspired by [Pydantic AI](https://ai.pydantic.dev/)
+- Inspired by [Pydantic AI](https://ai.pydantic.dev/) — Nous brings the
+  same agent-shaped API to Elixir, layered on OTP for supervision and
+  Phoenix for the UI story.
 - HTTP: [Req](https://github.com/wojtekmach/req) + [Finch](https://github.com/sneako/finch)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,20 +4,19 @@ Complete documentation for the Nous AI framework.
 
 ## 🚀 Quick Start
 - **[Getting Started](getting-started.md)** - Setup and first steps
-- **[Examples Quickstart](../examples/quickstart/)** - 5-minute examples
+- **[Hello World](../examples/01_hello_world.exs)** - Minimal example to verify your install
 
 ## 📚 Learning Resources
-- **[Examples](../examples/)** - Working code examples
-- **[Tutorials](../examples/tutorials/)** - Structured learning path
+- **[Examples](../examples/)** - Working code examples (numbered 01–19, plus `providers/`, `memory/`, `advanced/`, `workflow/`)
 - **[API Documentation](../doc/)** - Generated API docs
 
 ## 📖 Guides
 - **[LiveView Integration](guides/liveview-integration.md)** - Complete Phoenix LiveView integration guide
-- **[Tool Development](guides/tool-development.md)** - Building custom tools
+- **[Tool Development](guides/tool_development.md)** - Building custom tools
 - **[Structured Output](guides/structured_output.md)** - Return validated, typed data from agents
-- **[Best Practices](guides/best-practices.md)** - Production patterns
+- **[Best Practices](guides/best_practices.md)** - Production patterns
 - **[Troubleshooting](guides/troubleshooting.md)** - Common issues and solutions
-- **[Migration Guide](guides/migration.md)** - Version upgrade guide
+- **[Migration Guide](guides/migration_guide.md)** - Version upgrade guide
 
 ## 🔧 Architecture & Design
 - **[Design Documents](design/)** - Architecture decisions and patterns
@@ -28,19 +27,19 @@ Complete documentation for the Nous AI framework.
 
 ### For New Users
 1. Start with **[Getting Started](getting-started.md)** - basic setup
-2. Try **[Quickstart Examples](../examples/quickstart/)** - immediate hands-on
-3. Follow **[Tutorials](../examples/tutorials/)** - structured learning
+2. Try the [numbered examples](../examples/) - 01 through 19, hands-on
+3. Pick a focused guide from [guides/](guides/) for the feature you need
 
 ### For Specific Needs
 - **Need examples?** → Browse [Examples](../examples/) by feature
-- **Building tools?** → Read [Tool Development Guide](guides/tool-development.md)
-- **Production deployment?** → Check [Best Practices](guides/best-practices.md)
+- **Building tools?** → Read [Tool Development Guide](guides/tool_development.md)
+- **Production deployment?** → Check [Best Practices](guides/best_practices.md)
 - **Troubleshooting?** → See [Troubleshooting Guide](guides/troubleshooting.md)
 
 ### For Contributors
 - **API Reference** → [Generated docs](../doc/)
 - **Design decisions** → [Design documents](design/)
-- **Migration notes** → [Migration guide](guides/migration.md)
+- **Migration notes** → [Migration guide](guides/migration_guide.md)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,210 +1,188 @@
-# Getting Started with Nous AI
+# Getting Started with Nous
 
-Complete setup guide for the Nous AI framework.
+This guide picks up where the [README Quick Start](../README.md#quick-start)
+leaves off. It assumes you already have Nous installed (`{:nous, "~> 0.16.0"}`)
+and a provider configured (API key set, or a local LM Studio / Ollama / vLLM
+server running).
 
-## Installation
+It covers four real-world building blocks:
 
-Add to your `mix.exs`:
+1. [Building your first multi-tool agent](#building-your-first-multi-tool-agent)
+2. [Handling errors in production](#handling-errors-in-production)
+3. [Persisting agent state](#persisting-agent-state)
+4. [Wiring up callbacks for observability](#wiring-up-callbacks-for-observability)
 
-```elixir
-def deps do
-  [
-    {:nous, "~> 0.9.0"}
-  ]
-end
-```
+Plus two reference patterns at the end:
 
-Then run:
-```bash
-mix deps.get
-```
+- [Error handling](#error-handling)
+- [Conversation state as a GenServer](#conversation-state-as-a-genserver)
 
-## Quick Setup
+## Building your first multi-tool agent
 
-### Option 1: Local AI (Free)
-Perfect for development and testing.
+Most useful agents call more than one tool. The pattern: define each tool
+as a plain function (or a module implementing `Nous.Tool.Behaviour`), then
+pass them into `Nous.new/2`. The LLM picks which to call.
 
-1. **Download LM Studio** from [lmstudio.ai](https://lmstudio.ai/)
-2. **Download a model** (recommended: qwen3-vl-4b-thinking-mlx)
-3. **Start server** in LM Studio (runs on http://localhost:1234)
-4. **Test it works**:
-   ```bash
-   mix run -e "
-   agent = Nous.new(\"lmstudio:qwen3-vl-4b-thinking-mlx")
-   {:ok, result} = Nous.run(agent, \"Hello!\")
-   IO.puts(result.output)
-   "
-   ```
-
-### Option 2: Cloud AI
-Perfect for production and advanced models.
-
-**Anthropic (Recommended):**
-```bash
-export ANTHROPIC_API_KEY="sk-ant-your-key"
-```
-
-**OpenAI:**
-```bash
-export OPENAI_API_KEY="sk-your-key"
-```
-
-**Google Vertex AI:**
-```bash
-export GOOGLE_CLOUD_PROJECT="your-project-id"
-export GOOGLE_CLOUD_REGION="us-central1"  # optional, defaults to us-central1
-# Option A: Use gcloud access token
-export VERTEX_AI_ACCESS_TOKEN="$(gcloud auth print-access-token)"
-# Option B: Use Goth with service account (recommended for production)
-export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
-```
-
-**Test cloud setup:**
-```bash
-mix run -e "
-agent = Nous.new(\"anthropic:claude-sonnet-4-5-20250929\")
-{:ok, result} = Nous.run(agent, \"Hello!\")
-IO.puts(result.output)
-"
-```
-
-## Basic Usage
-
-### Simple Chat Agent
-```elixir
-# Create an agent
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929",
-  instructions: "You are a helpful assistant"
-)
-
-# Ask questions
-{:ok, result} = Nous.run(agent, "What is Elixir?")
-IO.puts(result.output)
-
-# Check usage
-IO.puts("Tokens used: #{result.usage.total_tokens}")
-```
-
-### Agent with Tools
 ```elixir
 defmodule MyTools do
-  @doc "Get the current weather for a location"
-  def get_weather(_ctx, %{"location" => location}) do
-    "The weather in #{location} is sunny and 72°F"
+  def get_weather(_ctx, %{"city" => city}) do
+    %{city: city, temperature: 72, conditions: "sunny"}
+  end
+
+  def get_forecast(_ctx, %{"city" => city, "days" => days}) do
+    %{city: city, days: days, summary: "mild and dry"}
+  end
+
+  def list_cities(_ctx, _args) do
+    ["Tokyo", "Lisbon", "Berlin", "Buenos Aires"]
   end
 end
 
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929",
-  instructions: "Use the get_weather tool when asked about weather",
-  tools: [&MyTools.get_weather/2]
-)
+agent =
+  Nous.new("openai:gpt-4o",
+    instructions: """
+    You are a travel assistant. Use the available tools to answer
+    questions about cities. Always cite which tool you used.
+    """,
+    tools: [
+      &MyTools.get_weather/2,
+      &MyTools.get_forecast/2,
+      &MyTools.list_cities/2
+    ]
+  )
 
-{:ok, result} = Nous.run(agent, "What's the weather in Paris?")
-IO.puts(result.output)  # AI automatically calls the weather tool
+{:ok, result} = Nous.run(agent, "What's the weather in Tokyo, and what's the 3-day forecast?")
+IO.puts(result.output)
 ```
 
-### Structured Output
+The agent loop will:
+
+1. Receive your prompt
+2. Decide which tool(s) to call (it can chain multiple in one turn)
+3. Execute them concurrently where safe
+4. Feed the results back to the model
+5. Generate the final answer
+
+For a working version of this pattern see
+[`examples/02_with_tools.exs`](../examples/02_with_tools.exs) and
+[`examples/07_module_tools.exs`](../examples/07_module_tools.exs).
+
+## Handling errors in production
+
+`Nous.run/3` returns `{:ok, result}` or `{:error, reason}`. In production you
+typically want three things on top of that: retries on transient errors,
+provider fallback, and structured logging.
+
+### Provider fallback
+
 ```elixir
-defmodule UserInfo do
-  use Ecto.Schema
-  @primary_key false
-  embedded_schema do
-    field :name, :string
-    field :age, :integer
+agent =
+  Nous.new("openai:gpt-4o",
+    fallback: ["anthropic:claude-sonnet-4-5-20250929", "groq:llama-3.1-70b-versatile"]
+  )
+
+{:ok, result} = Nous.run(agent, "Hello")
+```
+
+Fallback triggers on `ProviderError` and `ModelError` only — application
+errors (validation, max iterations, tool errors) return immediately because
+a different model wouldn't help.
+
+### Retries on transient errors
+
+```elixir
+defmodule Retry do
+  def with_backoff(fun, attempts \\ 3, base \\ 200)
+  def with_backoff(_fun, 0, _base), do: {:error, :exhausted}
+
+  def with_backoff(fun, attempts, base) do
+    case fun.() do
+      {:ok, _} = ok -> ok
+      {:error, %Nous.ProviderError{}} ->
+        Process.sleep(base)
+        with_backoff(fun, attempts - 1, base * 2)
+      {:error, _} = err -> err
+    end
   end
 end
 
-agent = Nous.new("openai:gpt-4o-mini", output_type: UserInfo)
-{:ok, result} = Nous.run(agent, "Generate a user named Alice, age 30")
-# result.output == %UserInfo{name: "Alice", age: 30}
+Retry.with_backoff(fn -> Nous.run(agent, "Hello") end)
 ```
 
-For more details, see the **[Structured Output Guide](structured_output.md)**.
+Working version: [`examples/advanced/error_handling.exs`](../examples/advanced/error_handling.exs).
 
-### Streaming Responses
+## Persisting agent state
+
+For agents that live longer than a single request — chatbots, long-running
+research jobs, anything user-facing — wire them through
+`Nous.AgentDynamicSupervisor` with a persistence backend.
+
 ```elixir
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929")
+{:ok, _pid} =
+  Nous.AgentDynamicSupervisor.start_agent(
+    agent,
+    session_id: "user-123",
+    persistence: Nous.Persistence.ETS,
+    name: {:via, Registry, {Nous.AgentRegistry, "user-123"}}
+  )
 
-Nous.run_stream(agent, "Tell me a story")
-|> Enum.each(fn
-  {:text_delta, text} -> IO.write(text)  # Print as it arrives
-  {:finish, result} -> IO.puts("\n✅ Complete")
-end)
+# Context auto-saves; restore on a later run:
+{:ok, context} = Nous.Persistence.ETS.load("user-123")
+{:ok, result} = Nous.run(agent, "Continue our conversation", context: context)
 ```
 
-## Next Steps
+ETS is built in. For SQLite/DuckDB persistence and crash recovery patterns,
+see [`examples/09_agent_server.exs`](../examples/09_agent_server.exs) and the
+[best practices guide](guides/best_practices.md).
 
-### Immediate Next Steps (15 minutes)
-1. **Try examples** → [quickstart examples](../examples/quickstart/README.md)
-2. **Follow tutorials** → [structured learning](../examples/tutorials/README.md)
-3. **Browse by feature** → [reference guides](../examples/reference/README.md)
+## Wiring up callbacks for observability
 
-### Learning Path
-- **Beginner** (15 min) → [01-basics](../examples/tutorials/01-basics/README.md)
-- **Intermediate** (1 hour) → [02-patterns](../examples/tutorials/02-patterns/README.md)
-- **Advanced** (deep dive) → [03-production](../examples/tutorials/03-production/README.md)
-- **Complete projects** → [04-projects](../examples/tutorials/04-projects/README.md)
+Callbacks fire at well-known points in the agent loop. Use them for token
+streaming to a UI, structured logging, metrics, or to bridge into PubSub.
 
-### Production Setup
-- **[Best Practices Guide](guides/best_practices.md)** - Production deployment
-- **[Tool Development Guide](guides/tool_development.md)** - Custom tools
-- **[Troubleshooting Guide](guides/troubleshooting.md)** - Common issues
-
-## Provider Configuration
-
-### All Supported Providers
 ```elixir
-# Local (Free)
-agent = Nous.new("lmstudio:qwen3-vl-4b-thinking-mlx")
-agent = Nous.new("ollama:llama3")
-
-# Cloud
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929")
-agent = Nous.new("openai:gpt-4o")
-agent = Nous.new("gemini:gemini-1.5-pro")
-agent = Nous.new("mistral:mistral-large-latest")
-agent = Nous.new("groq:llama-3.1-70b-versatile")
+{:ok, result} =
+  Nous.run(agent, "Summarize the latest news on Elixir.",
+    callbacks: %{
+      on_llm_new_delta:        fn _event, delta -> IO.write(delta) end,
+      on_llm_new_thinking_delta: fn _event, t -> IO.write(["[think] ", t]) end,
+      on_tool_call:            fn _event, call -> Logger.info("tool: #{call.name}") end,
+      on_tool_response:        fn _event, resp -> Logger.info("result: #{inspect(resp)}") end
+    }
+  )
 ```
 
-### Model Settings
+For LiveView you typically prefer `notify_pid:` over inline callbacks — the
+agent runs in a Task and sends `{:agent_delta, _}` / `{:agent_complete, _}`
+messages to your view process. See
+[`examples/05_callbacks.exs`](../examples/05_callbacks.exs) and
+[`examples/advanced/liveview_integration.exs`](../examples/advanced/liveview_integration.exs).
+
+For metrics, attach to the built-in telemetry events:
+
 ```elixir
-agent = Nous.new("anthropic:claude-sonnet-4-5-20250929",
-  model_settings: %{
-    temperature: 0.7,      # Creativity (0.0 - 1.0)
-    max_tokens: 2000,      # Response length
-    top_p: 0.9            # Nucleus sampling
-  }
-)
+Nous.Telemetry.attach_default_handler()
 ```
 
-## Architecture Overview
-
-### Core Concepts
-- **Agent**: Stateless configuration object (model + instructions + tools)
-- **Tools**: Elixir functions the AI can call
-- **Messages**: Structured conversation history
-- **Streaming**: Real-time response generation
-
-### Key Features
-- **Multi-provider**: Works with 10+ AI providers
-- **Tool calling**: AI can execute Elixir functions
-- **Streaming**: Real-time response generation
-- **Type safety**: Comprehensive type specifications
-- **Production ready**: GenServer, LiveView, distributed systems
+See [`examples/advanced/telemetry.exs`](../examples/advanced/telemetry.exs).
 
 ## Common Patterns
 
 ### Error Handling
+
 ```elixir
 case Nous.run(agent, prompt) do
   {:ok, result} ->
     IO.puts("Success: #{result.output}")
   {:error, reason} ->
-    IO.puts("Error: #{reason}")
+    IO.puts("Error: #{inspect(reason)}")
 end
 ```
 
-### Conversation State
+### Conversation State as a GenServer
+
+When you want a process-local chat session with full conversation history:
+
 ```elixir
 defmodule ChatBot do
   use GenServer
@@ -237,35 +215,15 @@ defmodule ChatBot do
 end
 ```
 
-## Troubleshooting
-
-### Connection Issues
-- **"Connection refused"**: LM Studio not running or wrong port
-- **"401 Unauthorized"**: Check API key is set correctly
-- **"Model not found"**: Verify model name spelling
-
-### Performance
-- **Slow responses**: Try smaller models or local inference
-- **High costs**: Use local models for development
-- **Rate limits**: Implement exponential backoff
-
-### Debug Mode
-```elixir
-# Enable debug logging
-require Logger
-Logger.configure(level: :debug)
-
-# See all agent iterations and tool calls
-{:ok, result} = Nous.run(agent, prompt)
-```
-
-For more help, see the **[Troubleshooting Guide](guides/troubleshooting.md)**.
-
----
+For supervised, crash-recoverable versions of this pattern, see
+[`examples/09_agent_server.exs`](../examples/09_agent_server.exs).
 
 ## What's Next?
 
-- **Hands-on learning** → [Examples](../examples/README.md)
-- **Specific features** → [Reference guides](../examples/reference/README.md)
-- **Production deployment** → [Best practices](guides/best_practices.md)
-- **Custom tools** → [Tool development](guides/tool_development.md)
+- **More examples** → [`examples/`](../examples/) (numbered 01–19, plus
+  `providers/`, `memory/`, `advanced/`, `workflow/`)
+- **Specific features** → [`docs/guides/`](guides/) — tool development,
+  structured output, hooks, skills, memory, workflows, knowledge base,
+  LiveView integration, evaluation
+- **Production deployment** → [Best Practices](guides/best_practices.md)
+- **Troubleshooting** → [Troubleshooting Guide](guides/troubleshooting.md)

--- a/docs/guides/http_backends.md
+++ b/docs/guides/http_backends.md
@@ -1,0 +1,71 @@
+# HTTP Backends (Req vs Hackney)
+
+[Back to README](../../README.md#supported-providers)
+
+Both the non-streaming and streaming HTTP paths go through pluggable
+backends. Defaults are `Nous.HTTP.Backend.Req` and
+`Nous.HTTP.StreamBackend.Req` (both on Req + Finch).
+`Nous.HTTP.Backend.Hackney` and `Nous.HTTP.StreamBackend.Hackney` are
+shipped as alternatives.
+
+For headline numbers and full benchmark methodology, see the
+[HTTP backend benchmark report](../benchmarks/http_backend.md).
+
+## Non-streaming (`Nous.HTTP.Backend`)
+
+Pick per-call, per-environment, or per-app:
+
+```elixir
+# Per-call
+HTTP.post(url, body, headers, backend: Nous.HTTP.Backend.Hackney)
+
+# Env (highest precedence after per-call):
+# NOUS_HTTP_BACKEND=hackney   # also accepts "req" or a fully-qualified
+#                             # custom module name like "MyApp.MyBackend"
+
+# App config
+config :nous, :http_backend, Nous.HTTP.Backend.Hackney
+```
+
+## Streaming (`Nous.HTTP.StreamBackend`)
+
+Same resolution chain, separate config knob:
+
+```elixir
+# Per-call
+HTTP.stream(url, body, headers,
+  stream_backend: Nous.HTTP.StreamBackend.Hackney)
+
+# Env
+# NOUS_HTTP_STREAM_BACKEND=hackney
+
+# App config
+config :nous, :http_stream_backend, Nous.HTTP.StreamBackend.Hackney
+```
+
+When to pick which streaming backend:
+
+| Backend | Pick it when |
+|---------|--------------|
+| `Nous.HTTP.StreamBackend.Req` *(default)* | One HTTP stack across streaming + non-streaming. Right default for almost every app. Backpressure is bounded by parsing speed, not strict pull pacing — fine for typical LLM workloads where token rate is the bottleneck. |
+| `Nous.HTTP.StreamBackend.Hackney` | Strict pull-based backpressure via `[{:async, :once}]`. Pick this when downstream consumers can block per chunk (LiveView fan-out under load, persistence-on-every-chunk, slow IO). |
+
+Both emit identical normalized event streams (parsed JSON maps,
+`{:stream_done, _}`, `{:stream_error, _}`); switching backends needs no
+other code changes.
+
+## Hackney pool
+
+Tune the shared hackney `:default` pool from app config (used by both
+the Hackney non-streaming and Hackney streaming backends):
+
+```elixir
+config :nous, :hackney_pool,
+  max_connections: 200,
+  timeout: 1_500   # idle keepalive ms (hackney 4 caps at 2_000)
+```
+
+See [the HTTP backend benchmark report](../benchmarks/http_backend.md)
+for localhost + real-endpoint benchmark numbers and guidance on when
+to switch backends. Headline: stick with the Req defaults unless you
+have a specific reason (strict backpressure, HTTP/3 upgrade, single-HTTP-stack consolidation).

--- a/docs/guides/vertex_ai_setup.md
+++ b/docs/guides/vertex_ai_setup.md
@@ -1,0 +1,147 @@
+# Google Vertex AI Setup
+
+[Back to README](../../README.md#supported-providers)
+
+Vertex AI is Google Cloud's enterprise platform for accessing Gemini models with
+VPC-SC, CMEK, IAM, regional/global endpoints, and the latest preview models.
+Use it when you need GCP-native auth, data residency, or features that aren't
+on the public Gemini API (Vertex-only previews, enterprise compliance).
+
+## Supported Models
+
+| Model | Model ID | Endpoint | API Version |
+|-------|----------|----------|-------------|
+| Gemini 3.1 Pro (preview) | `gemini-3.1-pro-preview` | global only | v1beta1 |
+| Gemini 3 Flash (preview) | `gemini-3-flash-preview` | global only | v1beta1 |
+| Gemini 3.1 Flash-Lite (preview) | `gemini-3.1-flash-lite-preview` | global only | v1beta1 |
+| Gemini 2.5 Pro | `gemini-2.5-pro` | regional + global | v1 |
+| Gemini 2.5 Flash | `gemini-2.5-flash` | regional + global | v1 |
+| Gemini 2.0 Flash | `gemini-2.0-flash` | regional + global | v1 |
+
+> **Note:** Preview and experimental models automatically use the `v1beta1` API version.
+> The Gemini 3.x preview models are **global endpoint only** — set `GOOGLE_CLOUD_LOCATION=global`.
+
+## Regional vs Global Endpoints
+
+Vertex AI offers two endpoint types:
+
+- **Regional** (e.g., `us-central1`, `europe-west1`): Low-latency, data residency guarantees
+  ```
+  https://us-central1-aiplatform.googleapis.com/v1/projects/{project}/locations/us-central1
+  ```
+- **Global**: Higher availability, required for Gemini 3.x preview models
+  ```
+  https://aiplatform.googleapis.com/v1beta1/projects/{project}/locations/global
+  ```
+
+The provider automatically selects the correct hostname and API version based on the
+region and model name. Set `GOOGLE_CLOUD_LOCATION=global` for Gemini 3.x preview models.
+
+## Step 1: Create a Service Account
+
+```bash
+export PROJECT_ID="your-project-id"
+
+# Enable Vertex AI API
+gcloud services enable aiplatform.googleapis.com --project=$PROJECT_ID
+
+# Create service account
+gcloud iam service-accounts create nous-vertex-ai \
+  --display-name="Nous Vertex AI" \
+  --project=$PROJECT_ID
+
+# Grant the Vertex AI User role
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:nous-vertex-ai@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+
+# Download the key file
+gcloud iam service-accounts keys create /tmp/sa-key.json \
+  --iam-account="nous-vertex-ai@${PROJECT_ID}.iam.gserviceaccount.com"
+```
+
+## Step 2: Set Environment Variables
+
+```bash
+# Load the service account JSON into an env var (recommended — no file path dependency)
+export GOOGLE_CREDENTIALS="$(cat /tmp/sa-key.json)"
+
+# Required: your GCP project ID
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# Required for Gemini 3.x preview models (global endpoint only)
+export GOOGLE_CLOUD_LOCATION="global"
+
+# Or use a regional endpoint for stable models:
+# export GOOGLE_CLOUD_LOCATION="us-central1"
+# export GOOGLE_CLOUD_LOCATION="europe-west1"
+```
+
+Both `GOOGLE_CLOUD_REGION` and `GOOGLE_CLOUD_LOCATION` are supported (consistent with
+other Google Cloud libraries). `GOOGLE_CLOUD_REGION` takes precedence if both are set.
+Defaults to `us-central1` if neither is set.
+
+## Step 3: Add Goth to Your Application
+
+Goth handles OAuth2 token fetching and auto-refresh from the service account credentials.
+
+```elixir
+# mix.exs
+{:goth, "~> 1.4"}
+```
+
+```elixir
+# application.ex — start Goth in your supervision tree
+credentials = System.get_env("GOOGLE_CREDENTIALS") |> JSON.decode!()
+
+children = [
+  {Goth, name: MyApp.Goth, source: {:service_account, credentials}}
+]
+```
+
+## Step 4: Configure and Use
+
+```elixir
+# Option A: App config (recommended for production)
+# config/config.exs
+config :nous, :vertex_ai, goth: MyApp.Goth
+
+# Then use it — Goth handles token refresh automatically:
+agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")
+{:ok, result} = Nous.run(agent, "Hello from Vertex AI!")
+```
+
+```elixir
+# Option B: Per-model Goth (useful for multiple projects)
+agent = Nous.new("vertex_ai:gemini-3-flash-preview",
+  default_settings: %{goth: MyApp.Goth}
+)
+```
+
+```elixir
+# Option C: Explicit base_url (for custom endpoint or specific region)
+alias Nous.Providers.VertexAI
+
+agent = Nous.new("vertex_ai:gemini-3.1-pro-preview",
+  base_url: VertexAI.endpoint("my-project", "global", "gemini-3.1-pro-preview"),
+  default_settings: %{goth: MyApp.Goth}
+)
+```
+
+```elixir
+# Option D: Quick testing with gcloud CLI (no Goth needed)
+# export VERTEX_AI_ACCESS_TOKEN="$(gcloud auth print-access-token)"
+agent = Nous.new("vertex_ai:gemini-3.1-pro-preview")
+```
+
+## Input Validation
+
+The provider validates `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` at request time
+and returns helpful error messages for invalid values instead of opaque DNS or HTTP errors.
+
+## Examples
+
+- [`examples/providers/vertex_ai.exs`](../../examples/providers/vertex_ai.exs) — Basic usage with access token
+- [`examples/providers/vertex_ai_goth_test.exs`](../../examples/providers/vertex_ai_goth_test.exs) — Service account with Goth
+- [`examples/providers/vertex_ai_multi_region.exs`](../../examples/providers/vertex_ai_multi_region.exs) — Multi-region + v1/v1beta1 demo
+- [`examples/providers/vertex_ai_integration_test.exs`](../../examples/providers/vertex_ai_integration_test.exs) — Full integration test (Flash + Pro, streaming + non-streaming)

--- a/lib/nous/providers/anthropic.ex
+++ b/lib/nous/providers/anthropic.ex
@@ -73,37 +73,30 @@ defmodule Nous.Providers.Anthropic do
     HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
   end
 
-  # Build headers for the request
   defp build_headers(api_key, opts) do
-    headers = [
-      {"content-type", "application/json"},
-      {"anthropic-version", @api_version}
-    ]
+    HTTP.json_headers() ++
+      [{"anthropic-version", @api_version}] ++
+      HTTP.api_key_header(api_key, "x-api-key") ++
+      anthropic_beta_headers(opts)
+  end
 
-    # Add API key authentication
-    headers =
-      if api_key && api_key != "" do
-        [{"x-api-key", api_key} | headers]
-      else
-        headers
-      end
+  # Collect long-context and custom beta features into the single
+  # `anthropic-beta` header. Anthropic accepts a comma-separated list per
+  # header, but emitting one header per beta is just as valid; we use
+  # separate headers so each beta is independently inspectable in logs.
+  defp anthropic_beta_headers(opts) do
+    long_context =
+      if Keyword.get(opts, :enable_long_context, false),
+        do: [{"anthropic-beta", @long_context_beta}],
+        else: []
 
-    # Add beta headers for long context
-    headers =
-      if Keyword.get(opts, :enable_long_context, false) do
-        [{"anthropic-beta", @long_context_beta} | headers]
-      else
-        headers
-      end
-
-    # Add any custom beta features
-    headers =
+    custom =
       case Keyword.get(opts, :beta) do
-        nil -> headers
-        beta when is_binary(beta) -> [{"anthropic-beta", beta} | headers]
-        betas when is_list(betas) -> [{"anthropic-beta", Enum.join(betas, ",")} | headers]
+        nil -> []
+        beta when is_binary(beta) -> [{"anthropic-beta", beta}]
+        betas when is_list(betas) -> [{"anthropic-beta", Enum.join(betas, ",")}]
       end
 
-    headers
+    long_context ++ custom
   end
 end

--- a/lib/nous/providers/custom.ex
+++ b/lib/nous/providers/custom.ex
@@ -206,24 +206,11 @@ defmodule Nous.Providers.Custom do
     end
   end
 
-  # Build headers for the request
+  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed",
+  # so the "not-needed" sentinel for local servers is preserved.
   defp build_headers(api_key, opts) do
-    headers = [
-      {"content-type", "application/json"}
-    ]
-
-    # Add authorization if API key provided (skip for "not-needed" sentinel)
-    headers =
-      if api_key && api_key != "" && api_key != "not-needed" do
-        [{"authorization", "Bearer #{api_key}"} | headers]
-      else
-        headers
-      end
-
-    # Add organization header if provided
-    case Keyword.get(opts, :organization) do
-      nil -> headers
-      org -> [{"openai-organization", org} | headers]
-    end
+    HTTP.json_headers() ++
+      HTTP.bearer_auth_header(api_key) ++
+      HTTP.organization_header(Keyword.get(opts, :organization))
   end
 end

--- a/lib/nous/providers/custom.ex
+++ b/lib/nous/providers/custom.ex
@@ -142,60 +142,67 @@ defmodule Nous.Providers.Custom do
 
   @impl Nous.Provider
   def chat(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts), opts)
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts), opts)
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
 
-    HTTP.post(url, params, headers, timeout: timeout)
+      HTTP.post(url, params, headers, timeout: timeout)
+    end
   end
 
   @impl Nous.Provider
   def chat_stream(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts), opts)
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-    finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts), opts)
+      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+      finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
 
-    params = Map.put(params, "stream", true)
+      params = Map.put(params, "stream", true)
 
-    HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
+      HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
+    end
   end
 
   # Get base URL from opts, env var, or config (required for custom provider).
   # The custom provider accepts user-supplied base_url, so the URL is
   # validated through UrlGuard for SSRF protection. Set
   # `allow_private_hosts: true` in opts (or :allow_private_hosts in app
-  # config) for local development against private services.
+  # config) for local development against private services. Returns
+  # `{:ok, base}` on success or `{:error, {:invalid_config, reason}}` so
+  # callers can pattern-match without rescuing exceptions.
   defp get_base_url(opts) do
     base =
       Keyword.get(opts, :base_url) ||
         System.get_env("CUSTOM_BASE_URL") ||
         get_in(Application.get_env(:nous, :custom, []), [:base_url])
 
-    if is_nil(base) or base == "" do
-      raise ArgumentError, """
-      Custom provider requires a base_url.
+    cond do
+      is_nil(base) or base == "" ->
+        {:error,
+         {:invalid_config,
+          "Custom provider requires a base_url. Set one of: " <>
+            "Nous.new(\"custom:model\", base_url: \"http://...\"), " <>
+            "CUSTOM_BASE_URL env var, or " <>
+            "config :nous, :custom, base_url: \"http://...\""}}
 
-      Set one of:
-      1. Option: Nous.new("custom:model", base_url: "http://...")
-      2. Environment: export CUSTOM_BASE_URL="http://..."
-      3. Config: config :nous, :custom, base_url: "http://..."
-      """
-    end
+      true ->
+        allow_private =
+          Keyword.get(opts, :allow_private_hosts) ||
+            get_in(Application.get_env(:nous, :custom, []), [:allow_private_hosts]) ||
+            false
 
-    allow_private =
-      Keyword.get(opts, :allow_private_hosts) ||
-        get_in(Application.get_env(:nous, :custom, []), [:allow_private_hosts]) ||
-        false
+        case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: allow_private) do
+          {:ok, _uri} ->
+            {:ok, base}
 
-    case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: allow_private) do
-      {:ok, _uri} ->
-        base
-
-      {:error, reason} ->
-        raise ArgumentError,
+          {:error, reason} ->
+            {:error,
+             {:invalid_config,
               "Custom provider base_url failed SSRF validation: #{reason}. " <>
-                "Set `allow_private_hosts: true` for local dev if intentional."
+                "Set `allow_private_hosts: true` for local dev if intentional."}}
+        end
     end
   end
 

--- a/lib/nous/providers/gemini.ex
+++ b/lib/nous/providers/gemini.ex
@@ -197,8 +197,6 @@ defmodule Nous.Providers.Gemini do
     "#{base_url}/models/#{model}:streamGenerateContent?key=#{api_key}"
   end
 
-  # Build headers (no auth header - it's in the URL)
-  defp build_headers do
-    [{"content-type", "application/json"}]
-  end
+  # Auth header is omitted because the API key lives in the URL query string.
+  defp build_headers, do: HTTP.json_headers()
 end

--- a/lib/nous/providers/http.ex
+++ b/lib/nous/providers/http.ex
@@ -356,6 +356,12 @@ defmodule Nous.Providers.HTTP do
   # ============================================================================
 
   @doc """
+  Base JSON content-type headers. Most providers start their header list here.
+  """
+  @spec json_headers() :: list()
+  def json_headers, do: [{"content-type", "application/json"}]
+
+  @doc """
   Build authorization header for Bearer token auth (OpenAI style).
 
   Returns empty list for nil, empty string, or "not-needed" values.
@@ -384,6 +390,25 @@ defmodule Nous.Providers.HTTP do
   end
 
   def api_key_header(_, _), do: []
+
+  @doc """
+  Build OpenAI-style `openai-organization` header. Returns empty list when nil/empty.
+  """
+  @spec organization_header(String.t() | nil) :: list()
+  def organization_header(nil), do: []
+  def organization_header(""), do: []
+  def organization_header(org) when is_binary(org), do: [{"openai-organization", org}]
+  def organization_header(_), do: []
+
+  @doc """
+  Build OpenAI-style `openai-project` header (project-scoped API keys).
+  Returns empty list when nil/empty.
+  """
+  @spec openai_project_header(String.t() | nil) :: list()
+  def openai_project_header(nil), do: []
+  def openai_project_header(""), do: []
+  def openai_project_header(project) when is_binary(project), do: [{"openai-project", project}]
+  def openai_project_header(_), do: []
 
   @doc false
   # Public for stream-backend reuse. Ensures the request carries

--- a/lib/nous/providers/llamacpp.ex
+++ b/lib/nous/providers/llamacpp.ex
@@ -77,16 +77,16 @@ if Code.ensure_loaded?(LlamaCppEx) do
 
     @impl Nous.Provider
     def request(model, messages, settings) do
-      start_time = System.monotonic_time()
       merged_settings = Map.merge(model.default_settings, settings)
 
-      llamacpp_model = merged_settings[:llamacpp_model]
-
-      unless llamacpp_model do
-        raise ArgumentError,
-              "llamacpp provider requires :llamacpp_model option. " <>
-                "Pass it when creating the agent: Nous.new(\"llamacpp:local\", llamacpp_model: llm)"
+      case merged_settings[:llamacpp_model] do
+        nil -> {:error, missing_model_error()}
+        llamacpp_model -> do_request(model, messages, merged_settings, llamacpp_model)
       end
+    end
+
+    defp do_request(model, messages, merged_settings, llamacpp_model) do
+      start_time = System.monotonic_time()
 
       :telemetry.execute(
         [:nous, :provider, :request, :start],
@@ -158,16 +158,16 @@ if Code.ensure_loaded?(LlamaCppEx) do
 
     @impl Nous.Provider
     def request_stream(model, messages, settings) do
-      start_time = System.monotonic_time()
       merged_settings = Map.merge(model.default_settings, settings)
 
-      llamacpp_model = merged_settings[:llamacpp_model]
-
-      unless llamacpp_model do
-        raise ArgumentError,
-              "llamacpp provider requires :llamacpp_model option. " <>
-                "Pass it when creating the agent: Nous.new(\"llamacpp:local\", llamacpp_model: llm)"
+      case merged_settings[:llamacpp_model] do
+        nil -> {:error, missing_model_error()}
+        llamacpp_model -> do_request_stream(model, messages, merged_settings, llamacpp_model)
       end
+    end
+
+    defp do_request_stream(model, messages, merged_settings, llamacpp_model) do
+      start_time = System.monotonic_time()
 
       :telemetry.execute(
         [:nous, :provider, :stream, :start],
@@ -230,6 +230,16 @@ if Code.ensure_loaded?(LlamaCppEx) do
     # (since we override request/3 and request_stream/3 which are their only callers)
     defp default_stream_normalizer, do: Nous.StreamNormalizer.LlamaCpp
     defp build_request_params(_model, _messages, _settings), do: %{}
+
+    defp missing_model_error do
+      Nous.Errors.ProviderError.exception(
+        provider: :llamacpp,
+        message:
+          "llamacpp provider requires :llamacpp_model option. " <>
+            "Pass it when creating the agent: Nous.new(\"llamacpp:local\", llamacpp_model: llm)",
+        details: :missing_llamacpp_model
+      )
+    end
 
     # Convert string-keyed maps from to_openai_format to atom-keyed maps for LlamaCppEx.
     # NEVER call String.to_atom/1 on data flowing from to_openai_format - if the keyset

--- a/lib/nous/providers/lmstudio.ex
+++ b/lib/nous/providers/lmstudio.ex
@@ -50,28 +50,34 @@ defmodule Nous.Providers.LMStudio do
 
   @impl Nous.Provider
   def chat(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
 
-    HTTP.post(url, params, headers, timeout: timeout)
+      HTTP.post(url, params, headers, timeout: timeout)
+    end
   end
 
   @impl Nous.Provider
   def chat_stream(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
 
-    params = Map.put(params, "stream", true)
+      params = Map.put(params, "stream", true)
 
-    HTTP.stream(url, params, headers, timeout: timeout)
+      HTTP.stream(url, params, headers, timeout: timeout)
+    end
   end
 
   # Resolve and validate the base URL. The resolved URL goes through
   # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (LM Studio is
   # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default.
+  # still allowing the localhost default. Returns `{:ok, base}` on success
+  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
+  # without rescuing exceptions.
   defp get_base_url(opts) do
     base =
       Keyword.get(opts, :base_url) ||
@@ -80,11 +86,12 @@ defmodule Nous.Providers.LMStudio do
 
     case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
       {:ok, _uri} ->
-        base
+        {:ok, base}
 
       {:error, reason} ->
-        raise ArgumentError,
-              "LM Studio base_url failed validation: #{reason}. Got: #{inspect(base)}"
+        {:error,
+         {:invalid_config,
+          "LM Studio base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
     end
   end
 

--- a/lib/nous/providers/lmstudio.ex
+++ b/lib/nous/providers/lmstudio.ex
@@ -95,14 +95,9 @@ defmodule Nous.Providers.LMStudio do
     end
   end
 
+  # LM Studio doesn't require auth, but we support it if configured.
+  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
   defp build_headers(api_key) do
-    headers = [{"content-type", "application/json"}]
-
-    # LM Studio doesn't require auth, but we support it if configured
-    if api_key && api_key != "" do
-      [{"authorization", "Bearer #{api_key}"} | headers]
-    else
-      headers
-    end
+    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
   end
 end

--- a/lib/nous/providers/mistral.ex
+++ b/lib/nous/providers/mistral.ex
@@ -70,12 +70,6 @@ defmodule Nous.Providers.Mistral do
   end
 
   defp build_headers(api_key) do
-    headers = [{"content-type", "application/json"}]
-
-    if api_key && api_key != "" do
-      [{"authorization", "Bearer #{api_key}"} | headers]
-    else
-      headers
-    end
+    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
   end
 end

--- a/lib/nous/providers/openai.ex
+++ b/lib/nous/providers/openai.ex
@@ -136,31 +136,10 @@ defmodule Nous.Providers.OpenAI do
     end
   end
 
-  # Build headers for the request
   defp build_headers(api_key, opts) do
-    headers = [
-      {"content-type", "application/json"}
-    ]
-
-    # Add authorization
-    headers =
-      if api_key && api_key != "" do
-        [{"authorization", "Bearer #{api_key}"} | headers]
-      else
-        headers
-      end
-
-    # Add organization header if provided
-    headers =
-      case Keyword.get(opts, :organization) do
-        nil -> headers
-        org -> [{"openai-organization", org} | headers]
-      end
-
-    # Add project header if provided (for project-scoped API keys)
-    case Keyword.get(opts, :project) do
-      nil -> headers
-      project -> [{"openai-project", project} | headers]
-    end
+    HTTP.json_headers() ++
+      HTTP.bearer_auth_header(api_key) ++
+      HTTP.organization_header(Keyword.get(opts, :organization)) ++
+      HTTP.openai_project_header(Keyword.get(opts, :project))
   end
 end

--- a/lib/nous/providers/openai_compatible.ex
+++ b/lib/nous/providers/openai_compatible.ex
@@ -157,24 +157,11 @@ defmodule Nous.Providers.OpenAICompatible do
     HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
   end
 
-  # Build headers for the request
+  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed",
+  # so the "not-needed" sentinel for local servers is preserved.
   defp build_headers(api_key, opts) do
-    headers = [
-      {"content-type", "application/json"}
-    ]
-
-    # Add authorization if API key provided
-    headers =
-      if api_key && api_key != "" && api_key != "not-needed" do
-        [{"authorization", "Bearer #{api_key}"} | headers]
-      else
-        headers
-      end
-
-    # Add organization header if provided
-    case Keyword.get(opts, :organization) do
-      nil -> headers
-      org -> [{"openai-organization", org} | headers]
-    end
+    HTTP.json_headers() ++
+      HTTP.bearer_auth_header(api_key) ++
+      HTTP.organization_header(Keyword.get(opts, :organization))
   end
 end

--- a/lib/nous/providers/sglang.ex
+++ b/lib/nous/providers/sglang.ex
@@ -102,14 +102,9 @@ defmodule Nous.Providers.SGLang do
     end
   end
 
+  # SGLang doesn't require auth by default, but we support it if configured.
+  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
   defp build_headers(api_key) do
-    headers = [{"content-type", "application/json"}]
-
-    # SGLang doesn't require auth by default, but we support it if configured
-    if api_key && api_key != "" do
-      [{"authorization", "Bearer #{api_key}"} | headers]
-    else
-      headers
-    end
+    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
   end
 end

--- a/lib/nous/providers/sglang.ex
+++ b/lib/nous/providers/sglang.ex
@@ -58,28 +58,34 @@ defmodule Nous.Providers.SGLang do
 
   @impl Nous.Provider
   def chat(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
 
-    HTTP.post(url, params, headers, timeout: timeout)
+      HTTP.post(url, params, headers, timeout: timeout)
+    end
   end
 
   @impl Nous.Provider
   def chat_stream(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
 
-    params = Map.put(params, "stream", true)
+      params = Map.put(params, "stream", true)
 
-    HTTP.stream(url, params, headers, timeout: timeout)
+      HTTP.stream(url, params, headers, timeout: timeout)
+    end
   end
 
   # Resolve and validate the base URL. The resolved URL goes through
   # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (SGLang is
   # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default.
+  # still allowing the localhost default. Returns `{:ok, base}` on success
+  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
+  # without rescuing exceptions.
   defp get_base_url(opts) do
     base =
       Keyword.get(opts, :base_url) ||
@@ -88,11 +94,11 @@ defmodule Nous.Providers.SGLang do
 
     case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
       {:ok, _uri} ->
-        base
+        {:ok, base}
 
       {:error, reason} ->
-        raise ArgumentError,
-              "SGLang base_url failed validation: #{reason}. Got: #{inspect(base)}"
+        {:error,
+         {:invalid_config, "SGLang base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
     end
   end
 

--- a/lib/nous/providers/vertex_ai.ex
+++ b/lib/nous/providers/vertex_ai.ex
@@ -399,12 +399,8 @@ defmodule Nous.Providers.VertexAI do
     "#{base_url}/publishers/google/models/#{model}:streamGenerateContent?alt=sse"
   end
 
-  # Build headers with Bearer token auth
   defp build_headers(token) do
-    [
-      {"content-type", "application/json"},
-      {"authorization", "Bearer #{token}"}
-    ]
+    HTTP.json_headers() ++ HTTP.bearer_auth_header(token)
   end
 
   # Build default base URL from environment variables

--- a/lib/nous/providers/vertex_ai.ex
+++ b/lib/nous/providers/vertex_ai.ex
@@ -461,16 +461,29 @@ defmodule Nous.Providers.VertexAI do
     end
   end
 
-  # Resolve access token from multiple sources
+  # Resolve a Vertex AI access token from one of three sources, in
+  # precedence order:
+  #
+  #   1. `:api_key` passed directly in opts — explicit always wins.
+  #   2. `:goth` (in opts or app config) — if a Goth instance is named,
+  #      USE IT exclusively. A Goth failure surfaces here as
+  #      `{:error, %{reason: :goth_error, ...}}` instead of silently
+  #      falling through to a stale `VERTEX_AI_ACCESS_TOKEN` env var.
+  #   3. Env var / app config token (via the macro-injected `api_key/1`).
+  #
+  # The previous ordering put `api_key/1` (which transparently reads the
+  # env var) ahead of Goth. That meant a misconfigured Goth + a stale
+  # env var would produce 401s with no hint that Goth was even tried.
   defp resolve_token(opts) do
     cond do
-      # 1. Direct api_key option
-      token = api_key(opts) ->
+      token = Keyword.get(opts, :api_key) ->
         {:ok, token}
 
-      # 2. Goth integration
       goth_name = goth_name(opts) ->
         fetch_goth_token(goth_name)
+
+      token = api_key(opts) ->
+        {:ok, token}
 
       true ->
         {:error,

--- a/lib/nous/providers/vllm.ex
+++ b/lib/nous/providers/vllm.ex
@@ -58,28 +58,34 @@ defmodule Nous.Providers.VLLM do
 
   @impl Nous.Provider
   def chat(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
 
-    HTTP.post(url, params, headers, timeout: timeout)
+      HTTP.post(url, params, headers, timeout: timeout)
+    end
   end
 
   @impl Nous.Provider
   def chat_stream(params, opts \\ []) do
-    url = "#{get_base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
+    with {:ok, base} <- get_base_url(opts) do
+      url = "#{base}/chat/completions"
+      headers = build_headers(api_key(opts))
+      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
 
-    params = Map.put(params, "stream", true)
+      params = Map.put(params, "stream", true)
 
-    HTTP.stream(url, params, headers, timeout: timeout)
+      HTTP.stream(url, params, headers, timeout: timeout)
+    end
   end
 
   # Resolve and validate the base URL. The resolved URL goes through
   # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (vLLM is
   # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default.
+  # still allowing the localhost default. Returns `{:ok, base}` on success
+  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
+  # without rescuing exceptions.
   defp get_base_url(opts) do
     base =
       Keyword.get(opts, :base_url) ||
@@ -88,11 +94,11 @@ defmodule Nous.Providers.VLLM do
 
     case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
       {:ok, _uri} ->
-        base
+        {:ok, base}
 
       {:error, reason} ->
-        raise ArgumentError,
-              "vLLM base_url failed validation: #{reason}. Got: #{inspect(base)}"
+        {:error,
+         {:invalid_config, "vLLM base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
     end
   end
 

--- a/lib/nous/providers/vllm.ex
+++ b/lib/nous/providers/vllm.ex
@@ -102,14 +102,9 @@ defmodule Nous.Providers.VLLM do
     end
   end
 
+  # vLLM doesn't require auth by default, but we support it if configured.
+  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
   defp build_headers(api_key) do
-    headers = [{"content-type", "application/json"}]
-
-    # vLLM doesn't require auth by default, but we support it if configured
-    if api_key && api_key != "" do
-      [{"authorization", "Bearer #{api_key}"} | headers]
-    else
-      headers
-    end
+    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
   end
 end

--- a/lib/nous/tools/string_tools.ex
+++ b/lib/nous/tools/string_tools.ex
@@ -22,6 +22,21 @@ defmodule Nous.Tools.StringTools do
       {:ok, result} = Nous.run(agent, "How many characters in 'Hello World'?")
   """
 
+  # Extract a string arg, accepting any of the given keys. Returns the
+  # first value present whose type matches `expected`, or `default`
+  # otherwise. Replaces nil-pun chains like
+  # `Map.get(args, "pattern") || Map.get(args, "old") || ""`, which
+  # silently propagate non-string values from the LLM (e.g. `123`,
+  # `nil`, `[]`) into `String.replace/3` and crash.
+  defp fetch_arg(args, keys, default) when is_list(keys) do
+    Enum.find_value(keys, default, fn key ->
+      case Map.get(args, key) do
+        v when is_binary(v) -> v
+        _ -> nil
+      end
+    end)
+  end
+
   @doc """
   Get the length of a string.
 
@@ -30,7 +45,7 @@ defmodule Nous.Tools.StringTools do
   - text: The string to measure
   """
   def string_length(_ctx, args) do
-    text = Map.get(args, "text", "")
+    text = fetch_arg(args, ["text"], "")
 
     %{
       text: text,
@@ -51,10 +66,9 @@ defmodule Nous.Tools.StringTools do
   - case_sensitive: Whether to match case (default: true)
   """
   def replace_text(_ctx, args) do
-    text = Map.get(args, "text", "")
-    # Support multiple parameter names
-    pattern = Map.get(args, "pattern") || Map.get(args, "old") || ""
-    replacement = Map.get(args, "replacement") || Map.get(args, "new") || ""
+    text = fetch_arg(args, ["text"], "")
+    pattern = fetch_arg(args, ["pattern", "old"], "")
+    replacement = fetch_arg(args, ["replacement", "new"], "")
     case_sensitive = Map.get(args, "case_sensitive", true)
 
     result =
@@ -96,9 +110,8 @@ defmodule Nous.Tools.StringTools do
   - remove_empty: Whether to remove empty strings (default: false)
   """
   def split_text(_ctx, args) do
-    text = Map.get(args, "text", "")
-    # Support multiple parameter names
-    delimiter = Map.get(args, "delimiter") || Map.get(args, "separator") || " "
+    text = fetch_arg(args, ["text"], "")
+    delimiter = fetch_arg(args, ["delimiter", "separator"], " ")
     trim = Map.get(args, "trim", false)
     remove_empty = Map.get(args, "remove_empty", false)
 
@@ -167,9 +180,8 @@ defmodule Nous.Tools.StringTools do
   - case_sensitive: Whether to match case (default: true)
   """
   def count_occurrences(_ctx, args) do
-    text = Map.get(args, "text", "")
-    # Support multiple parameter names
-    pattern = Map.get(args, "pattern") || Map.get(args, "substring") || ""
+    text = fetch_arg(args, ["text"], "")
+    pattern = fetch_arg(args, ["pattern", "substring"], "")
     case_sensitive = Map.get(args, "case_sensitive", true)
 
     count =
@@ -338,9 +350,8 @@ defmodule Nous.Tools.StringTools do
   - case_sensitive: Whether to match case (default: true)
   """
   def contains(_ctx, args) do
-    text = Map.get(args, "text", "")
-    # Support multiple parameter names
-    pattern = Map.get(args, "pattern") || Map.get(args, "substring") || ""
+    text = fetch_arg(args, ["text"], "")
+    pattern = fetch_arg(args, ["pattern", "substring"], "")
     case_sensitive = Map.get(args, "case_sensitive", true)
 
     contains =

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.16.0"
+  @version "0.16.1"
   @source_url "https://github.com/nyo16/nous"
 
   def project do

--- a/test/nous/prompt_template_test.exs
+++ b/test/nous/prompt_template_test.exs
@@ -98,16 +98,20 @@ defmodule Nous.PromptTemplateTest do
   end
 
   describe "security: untrusted template body cannot execute Elixir" do
-    test "format on a hostile template body never invokes EEx" do
+    @tag :tmp_dir
+    test "format on a hostile template body never invokes EEx", %{tmp_dir: tmp_dir} do
       # If from_template/2 had let this through, EEx.eval_string would execute
       # File.write!/2. Since from_template rejects it, no execution happens.
-      hostile = ~S{<%= File.write!("/tmp/nous_pwn_test", "x") %>}
+      # Using @tag :tmp_dir gives a unique async-safe path per test, so this
+      # test can stay parallel and won't leak a sentinel under /tmp.
+      canary = Path.join(tmp_dir, "nous_pwn_canary")
+      hostile = ~s{<%= File.write!(#{inspect(canary)}, "x") %>}
 
       assert_raise ArgumentError, fn ->
         PromptTemplate.from_template(hostile)
       end
 
-      refute File.exists?("/tmp/nous_pwn_test")
+      refute File.exists?(canary)
     end
   end
 end

--- a/test/nous/providers/custom_test.exs
+++ b/test/nous/providers/custom_test.exs
@@ -1,0 +1,73 @@
+defmodule Nous.Providers.CustomTest do
+  # async: false — manipulates the CUSTOM_BASE_URL env var.
+  use ExUnit.Case, async: false
+
+  alias Nous.Providers.Custom
+
+  setup do
+    prev = System.get_env("CUSTOM_BASE_URL")
+    System.delete_env("CUSTOM_BASE_URL")
+    on_exit(fn -> restore("CUSTOM_BASE_URL", prev) end)
+
+    bypass = Bypass.open()
+    %{bypass: bypass, base: "http://localhost:#{bypass.port}/v1"}
+  end
+
+  defp restore(k, nil), do: System.delete_env(k)
+  defp restore(k, v), do: System.put_env(k, v)
+
+  describe "macro-injected metadata" do
+    test "exposes provider_id and default_env_key" do
+      assert Custom.provider_id() == :custom
+      assert Custom.default_env_key() == "CUSTOM_API_KEY"
+    end
+  end
+
+  describe "chat/2 missing base_url" do
+    test "returns {:error, {:invalid_config, _}} when no base_url is configured" do
+      assert {:error, {:invalid_config, msg}} =
+               Custom.chat(%{"model" => "m", "messages" => []})
+
+      assert msg =~ "requires a base_url"
+    end
+
+    test "chat_stream returns {:error, {:invalid_config, _}} when no base_url is configured" do
+      assert {:error, {:invalid_config, msg}} =
+               Custom.chat_stream(%{"model" => "m", "messages" => []})
+
+      assert msg =~ "requires a base_url"
+    end
+  end
+
+  describe "chat/2 SSRF validation" do
+    test "rejects private hosts by default" do
+      assert {:error, {:invalid_config, msg}} =
+               Custom.chat(%{"model" => "m", "messages" => []},
+                 base_url: "http://127.0.0.1:9/v1"
+               )
+
+      assert msg =~ "SSRF validation"
+    end
+
+    test "allows private hosts when allow_private_hosts: true", %{bypass: bypass, base: base} do
+      Bypass.expect_once(bypass, "POST", "/v1/chat/completions", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.resp(200, ~s({"id": "x"}))
+      end)
+
+      assert {:ok, %{"id" => "x"}} =
+               Custom.chat(%{"model" => "m", "messages" => []},
+                 base_url: base,
+                 allow_private_hosts: true
+               )
+    end
+
+    test "rejects non-http schemes" do
+      assert {:error, {:invalid_config, _}} =
+               Custom.chat(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
+    end
+  end
+end

--- a/test/nous/providers/http_test.exs
+++ b/test/nous/providers/http_test.exs
@@ -280,6 +280,36 @@ defmodule Nous.Providers.HTTPTest do
     end
   end
 
+  describe "json_headers/0" do
+    test "returns content-type application/json" do
+      assert HTTP.json_headers() == [{"content-type", "application/json"}]
+    end
+  end
+
+  describe "organization_header/1" do
+    test "builds openai-organization header" do
+      assert HTTP.organization_header("org-abc") == [{"openai-organization", "org-abc"}]
+    end
+
+    test "returns empty list for nil/empty/non-string" do
+      assert HTTP.organization_header(nil) == []
+      assert HTTP.organization_header("") == []
+      assert HTTP.organization_header(123) == []
+    end
+  end
+
+  describe "openai_project_header/1" do
+    test "builds openai-project header" do
+      assert HTTP.openai_project_header("proj-xyz") == [{"openai-project", "proj-xyz"}]
+    end
+
+    test "returns empty list for nil/empty/non-string" do
+      assert HTTP.openai_project_header(nil) == []
+      assert HTTP.openai_project_header("") == []
+      assert HTTP.openai_project_header(123) == []
+    end
+  end
+
   # ============================================================================
   # Input Validation Tests
   # ============================================================================

--- a/test/nous/providers/lmstudio_test.exs
+++ b/test/nous/providers/lmstudio_test.exs
@@ -93,10 +93,20 @@ defmodule Nous.Providers.LMStudioTest do
       assert {:ok, _} = LMStudio.chat(%{"model" => "m", "messages" => []})
     end
 
-    test "rejects non-http schemes via UrlGuard" do
-      assert_raise ArgumentError, ~r/failed validation/, fn ->
-        LMStudio.chat(%{"model" => "m", "messages" => []}, base_url: "file:///etc/passwd")
-      end
+    test "rejects non-http schemes via UrlGuard as {:error, :invalid_config}" do
+      assert {:error, {:invalid_config, msg}} =
+               LMStudio.chat(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
+
+      assert msg =~ "failed validation"
+    end
+
+    test "chat_stream returns {:error, :invalid_config} on bad base_url" do
+      assert {:error, {:invalid_config, _}} =
+               LMStudio.chat_stream(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
     end
   end
 end

--- a/test/nous/providers/sglang_test.exs
+++ b/test/nous/providers/sglang_test.exs
@@ -95,10 +95,20 @@ defmodule Nous.Providers.SGLangTest do
       assert {:ok, _} = SGLang.chat(%{"model" => "m", "messages" => []})
     end
 
-    test "rejects non-http schemes via UrlGuard" do
-      assert_raise ArgumentError, ~r/failed validation/, fn ->
-        SGLang.chat(%{"model" => "m", "messages" => []}, base_url: "file:///etc/passwd")
-      end
+    test "rejects non-http schemes via UrlGuard as {:error, :invalid_config}" do
+      assert {:error, {:invalid_config, msg}} =
+               SGLang.chat(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
+
+      assert msg =~ "failed validation"
+    end
+
+    test "chat_stream returns {:error, :invalid_config} on bad base_url" do
+      assert {:error, {:invalid_config, _}} =
+               SGLang.chat_stream(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
     end
   end
 end

--- a/test/nous/providers/vllm_test.exs
+++ b/test/nous/providers/vllm_test.exs
@@ -95,10 +95,20 @@ defmodule Nous.Providers.VLLMTest do
       assert {:ok, _} = VLLM.chat(%{"model" => "m", "messages" => []})
     end
 
-    test "rejects non-http schemes via UrlGuard" do
-      assert_raise ArgumentError, ~r/failed validation/, fn ->
-        VLLM.chat(%{"model" => "m", "messages" => []}, base_url: "file:///etc/passwd")
-      end
+    test "rejects non-http schemes via UrlGuard as {:error, :invalid_config}" do
+      assert {:error, {:invalid_config, msg}} =
+               VLLM.chat(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
+
+      assert msg =~ "failed validation"
+    end
+
+    test "chat_stream returns {:error, :invalid_config} on bad base_url" do
+      assert {:error, {:invalid_config, _}} =
+               VLLM.chat_stream(%{"model" => "m", "messages" => []},
+                 base_url: "file:///etc/passwd"
+               )
     end
   end
 end

--- a/test/nous/tools/string_tools_test.exs
+++ b/test/nous/tools/string_tools_test.exs
@@ -1,0 +1,95 @@
+defmodule Nous.Tools.StringToolsTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.Tools.StringTools
+
+  describe "string_length/2" do
+    test "returns length for valid string" do
+      assert %{length: 11, byte_size: 11} =
+               StringTools.string_length(nil, %{"text" => "hello world"})
+    end
+
+    test "returns 0 for missing text" do
+      assert %{length: 0} = StringTools.string_length(nil, %{})
+    end
+
+    test "coerces non-string text to default" do
+      # Nil-pun chains used to crash here. Now non-strings degrade to "".
+      assert %{length: 0} = StringTools.string_length(nil, %{"text" => 123})
+    end
+  end
+
+  describe "replace_text/2" do
+    test "replaces with primary key 'pattern'" do
+      assert %{result: "hi world"} =
+               StringTools.replace_text(nil, %{
+                 "text" => "hello world",
+                 "pattern" => "hello",
+                 "replacement" => "hi"
+               })
+    end
+
+    test "falls back to alias 'old' / 'new'" do
+      assert %{result: "hi world"} =
+               StringTools.replace_text(nil, %{
+                 "text" => "hello world",
+                 "old" => "hello",
+                 "new" => "hi"
+               })
+    end
+
+    test "prefers primary key when both keys present" do
+      assert %{result: "hi world"} =
+               StringTools.replace_text(nil, %{
+                 "text" => "hello world",
+                 "pattern" => "hello",
+                 "old" => "should-be-ignored",
+                 "replacement" => "hi",
+                 "new" => "should-be-ignored"
+               })
+    end
+
+    test "non-string pattern degrades to '' rather than crashing the tool call" do
+      # The LLM occasionally hands tools args of the wrong type. We don't
+      # care what the resulting string-edit looks like for an empty
+      # pattern — we care that this DOESN'T raise FunctionClauseError
+      # from `String.replace/3` like the old nil-pun chain did.
+      result =
+        StringTools.replace_text(nil, %{
+          "text" => "hello",
+          "pattern" => 123,
+          "replacement" => "hi"
+        })
+
+      assert %{pattern: ""} = result
+    end
+  end
+
+  describe "split_text/2" do
+    test "splits with delimiter alias 'separator'" do
+      assert %{parts: ["a", "b", "c"]} =
+               StringTools.split_text(nil, %{"text" => "a,b,c", "separator" => ","})
+    end
+
+    test "defaults to space delimiter" do
+      assert %{parts: ["a", "b"]} = StringTools.split_text(nil, %{"text" => "a b"})
+    end
+  end
+
+  describe "count_occurrences/2" do
+    test "counts with alias 'substring'" do
+      assert %{count: 2} =
+               StringTools.count_occurrences(nil, %{
+                 "text" => "abc abc xyz",
+                 "substring" => "abc"
+               })
+    end
+  end
+
+  describe "contains/2" do
+    test "checks contains with alias 'substring'" do
+      assert %{contains: true} =
+               StringTools.contains(nil, %{"text" => "hello", "substring" => "ell"})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  Five stacked commits from an extensive code review and README reorganization:

  - **PR 1 — `93aa7e7` provider error contracts (breaking).** LMStudio, SGLang, VLLM, Custom, and LlamaCpp providers now return
  `{:error, {:invalid_config, reason}}` (or `%Nous.Errors.ProviderError{}` for LlamaCpp's missing-model case) instead of raising
  `ArgumentError`. Restores the documented `chat/2 :: {:ok, _} | {:error, _}` contract. High-level `Nous.run/2`,
  `Nous.generate_text/3`, and `Nous.Agent.run/3` are unaffected — they already returned result tuples.
  - **PR 2 — `4dc0b3b` shared HTTP header helpers.** Extracted `json_headers/0`, `organization_header/1`, `openai_project_header/1`
  into `Nous.Providers.HTTP` and rewired all 11 providers. The four local providers (LMStudio, SGLang, vLLM, Mistral) collapse to a
  single-line `build_headers`. Pure refactor — no header values changed.
  - **PR 3 — `0029d88` Vertex Goth precedence + StringTools type guards.** `Nous.Providers.VertexAI.resolve_token/1` now uses Goth
  exclusively when configured, surfacing Goth failures as `{:error, %{reason: :goth_error, ...}}` instead of silently falling
  through to a stale `VERTEX_AI_ACCESS_TOKEN`. `Nous.Tools.StringTools` extracts args through a typed helper, eliminating nil-pun
  chains that crashed on non-string LLM input.
  - **PR 4 — `1a4cfd6` EEx-injection canary uses `@tag :tmp_dir`.** Replaces the hardcoded `/tmp/nous_pwn_test` path with an
  async-safe per-test temp dir. Spec coverage was inventoried as part of this PR; provider callbacks are already typed via
  `Nous.Provider` behaviour, dialyzer runs clean.
  - **PR 5 — `105486d` README + docs reorganization.** README dropped from 1454 → 791 lines. Extracted Vertex AI setup (140 lines)
  to `docs/guides/vertex_ai_setup.md`, HTTP backends (65 lines) to `docs/guides/http_backends.md`, contributor docs (140 lines) to
  new `CONTRIBUTING.md`. Repurposed `docs/getting-started.md` (was bit-rotted with `~> 0.9.0` and broken example links). Added
  positioning section, AGENTS.md callout, troubleshooting link.

  Breaking changes are documented in `CHANGELOG.md` under `[Unreleased]`.

  ## Test plan

  - [x] `mix compile --warnings-as-errors` clean
  - [x] `mix test` — 1734 tests, 0 failures (101 excluded)
  - [x] `mix dialyzer` — 0 errors
  - [x] `mix credo --strict` — 0 issues
  - [x] New unit tests cover the new error paths (`custom_test.exs`, invalid-URL assertions in lmstudio/sglang/vllm tests,
  `string_tools_test.exs`)
  - [ ] Smoke-test one live request per provider (skipped in CI; reviewer should hit Anthropic + OpenAI + Gemini + Vertex on a real
  key before merging — PR 2 is the highest header-regression risk)
  - [ ] Render README + CONTRIBUTING.md on GitHub preview; click through every `docs/guides/*.md` and `examples/*.exs` link
