### PR TITLE
Audit-driven fixes: provider marshalling, ETS lifecycle, OTP hygiene, telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,121 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed (critical)
+
+- **Gemini/Vertex tool-result roundtrip was broken.** `Nous.Messages.Gemini`
+  was sending the tool call_id (e.g. `"gemini_abc123"`) as the
+  `functionResponse.name`, but Gemini's API requires the original
+  `functionCall.name`. Every Gemini tool roundtrip shipped a malformed
+  payload. `Message.tool/3` now threads the original name through the
+  `:name` field; agent_runner and llm pass it at every call site.
+- **OpenAI tool-call malformed JSON used to be passed to the tool as bogus
+  args.** `Nous.Messages.OpenAI.decode_arguments/1` now returns
+  `{:ok, map()} | {:error, {:invalid_json, raw}}`. Parsers tag the
+  tool_call with `"_invalid_arguments"`; AgentRunner short-circuits with a
+  proper tool-error result so the LLM can retry.
+- **Workflow checkpoint ETS table lost its data when the saving process
+  exited.** The `:nous_workflow_checkpoints` table is now owned by a
+  supervised `TableOwner` under `Nous.Application` (mirrors the existing
+  `Nous.Persistence.ETS` pattern). Every suspended workflow relying on
+  resume is now durable to caller exits.
+- **Memory plugin re-initialized its ETS store on every agent run.**
+  `Nous.Plugins.Memory.init/2` now reuses the existing `store_state` when
+  present; per-run defaults are still refreshed. Avoids
+  `ets_too_many_tables` under load and the silent loss of memories across
+  runs.
+- **`Nous.LLM.stream_text_with_tools` silently halted on dispatcher error.**
+  Now emits an `{:error, reason}` event before halting so consumers can
+  detect LLM failures on the streaming + tools path.
+- **AgentServer subscribed to the wrong PubSub topic.** It used
+  `"agent:#{session_id}"` while `Nous.PubSub.agent_topic/1` returned
+  `"nous:agent:#{session_id}"` — anyone publishing via the helper never
+  reached the server. Now uses the helper.
+- **AgentServer didn't cancel its in-flight task on shutdown.** Streaming
+  LLM calls kept consuming tokens and HTTP connections after the server
+  was already gone. `terminate/2` now sets the cancellation atomic and
+  calls `Task.shutdown`.
+- **Research coordinator crashed on task exit.** `Task.yield` returns
+  `{:exit, reason}` on task crash; the `case` only matched `{:ok, _}` /
+  `nil` and produced `CaseClauseError`. Now handles `{:exit, _}` with
+  `{:error, {:task_exit, _}}`.
+
+### Fixed (important)
+
+- **Anthropic + Gemini usage parsing dropped requests count and cache
+  tokens.** Now sets `requests: 1` (was always 0) and captures
+  Anthropic's `cache_creation_input_tokens` /
+  `cache_read_input_tokens` and Gemini's `cachedContentTokenCount`.
+  `Nous.Usage` gained `cache_creation_input_tokens` and
+  `cache_read_input_tokens` fields, which propagate through `add/2`.
+- **Tool validator dropped the `enum` constraint when `type` was also
+  declared.** `Nous.Tool.Validator.validate_types/2` now runs every
+  constraint independently — a schema `%{"type" => "string", "enum" =>
+  ["a","b"]}` properly rejects values outside the enum.
+- **Hooks can now opt into fail-closed semantics.** `Nous.Hook` gains a
+  `fail_closed: boolean()` field. When set on a hook bound to a blocking
+  event (`:pre_tool_use`, `:pre_request`), runtime errors deny the action
+  instead of silently failing open — so a broken security-gating hook
+  can't be bypassed. Default `false` keeps existing behavior.
+- **Streaming Gemini tool calls had `id: nil`.** Stream and non-stream
+  paths now both synthesize a `"gemini_<base64>"` id.
+- **Bumblebee embedding serialization removed.** `ServingHolder` no longer
+  runs `Nx.Serving.run/2` inside `handle_call`. Concurrent embeddings now
+  go through the serving's own batching mechanism instead of serializing
+  through one process.
+- **Bare `Task.async` migrated to supervised `Task.Supervisor.async_nolink`**
+  in `research/coordinator.ex`, `eval/runner.ex`, `tools/search_scrape.ex`,
+  `plugins/input_guard.ex`, and `http/stream_backend/req.ex` — so a
+  crashed sub-task no longer takes down its caller (and vice-versa), and
+  graceful shutdown can signal in-flight work.
+- **Default Req streaming backend gains backpressure.** The producing
+  Task watches the consumer's `message_queue_len` before each `send/2`;
+  past `@backpressure_high_water` it pauses until the queue drops below
+  `@backpressure_low_water`, and after `@backpressure_max_wait_ms` it
+  emits `{:error, %{reason: :backpressure_overflow}}` and halts. The
+  M-12 risk called out in `mix.exs`.
+- **AgentRegistry partitioned across schedulers** (was `partitions: 1`).
+  High-concurrency LiveView lookups no longer serialize on a single
+  partition.
+- **AgentServer's persistence load moved to `handle_continue`.** `init/1`
+  returns immediately, so `DynamicSupervisor.start_child` (and
+  `Teams.Coordinator.spawn_agent`) no longer wedge waiting for slow
+  persistence backends.
+
+### Changed
+
+- **Telemetry events reconciled.** The documented-but-never-emitted events
+  `[:nous, :agent, :iteration, :start/:stop]`, `[:nous, :context, :update]`,
+  and `[:nous, :callback, :execute]` are now actually emitted. The
+  unreached `[:nous, :provider, :stream, :chunk]` was removed from the
+  docs and default handler (per-chunk telemetry is too hot for the
+  streaming path). Existing-but-undocumented events
+  (`fallback`, `hook`, `skill`, `workflow`) are now documented in the
+  `Nous.Telemetry` moduledoc.
+
+### Deprecated
+
+- `Nous.ToolSchema.to_openai/1` — use `Nous.Tool.to_openai_schema/1`.
+- `Nous.Agent.tool/3` — use `Agent.new/2` with `:tools`, or build a
+  `%Nous.Tool{}` directly.
+- `Nous.Eval.run!/2` — match `Nous.Eval.run/2`'s
+  `{:ok, _} | {:error, _}` result.
+- `Nous.Decisions.path_between/4`, `descendants/3`, `ancestors/3` —
+  call `store_mod.query(state, ..., ...)` directly.
+
+### Internal / Hygiene
+
+- `mix compile --warnings-as-errors` is clean. Removed unreachable
+  `Vertex AI validate_project_id(nil)` clause; tightened
+  `Nous.Research.Planner.plan/2` spec to `{:ok, plan()}` and dropped the
+  unreachable `{:error, _}` clause in `research/coordinator.ex`.
+- `Nous.Workflow.Checkpoint.ETS` and `Nous.Plugins.Memory` now expose
+  proper supervised / reusable lifecycle (see Fixed).
+- `Nous.Memory.Store.SQLite` FTS5 escape now doubles embedded `"`
+  characters per FTS5 syntax — queries containing `"` no longer error.
+
 ## [0.16.1] - 2026-05-15
 
 ### Changed (breaking)

--- a/lib/nous/agent.ex
+++ b/lib/nous/agent.ex
@@ -326,6 +326,7 @@ defmodule Nous.Agent do
       )
 
   """
+  @deprecated "Prefer Agent.new/2 with the :tools option, or build %Nous.Tool{} directly"
   @spec tool(t(), function(), keyword()) :: t()
   def tool(%__MODULE__{} = agent, tool_fun, opts \\ []) do
     tool = Tool.from_function(tool_fun, opts)

--- a/lib/nous/agent/callbacks.ex
+++ b/lib/nous/agent/callbacks.ex
@@ -135,6 +135,8 @@ defmodule Nous.Agent.Callbacks do
   """
   @spec execute(Context.t(), event(), payload()) :: :ok
   def execute(%Context{} = ctx, event, payload) when is_atom(event) do
+    start_time = System.monotonic_time()
+
     # 1. Execute map-based callback if present
     execute_callback(ctx.callbacks, event, payload)
 
@@ -143,6 +145,12 @@ defmodule Nous.Agent.Callbacks do
 
     # 3. Broadcast via PubSub if configured
     broadcast_event(ctx, event, payload)
+
+    :telemetry.execute(
+      [:nous, :callback, :execute],
+      %{duration: System.monotonic_time() - start_time},
+      %{callback_type: event, agent_name: ctx.agent_name}
+    )
 
     :ok
   end

--- a/lib/nous/agent/context.ex
+++ b/lib/nous/agent/context.ex
@@ -424,20 +424,21 @@ defmodule Nous.Agent.Context do
   """
   @spec patch_dangling_tool_calls(t()) :: t()
   def patch_dangling_tool_calls(%__MODULE__{messages: messages} = ctx) do
-    # Collect all tool_call IDs from assistant messages
-    tool_call_ids =
+    # Build id -> name map from assistant tool_calls (name needed so providers
+    # like Gemini can populate functionResponse.name correctly).
+    tool_call_names =
       messages
       |> Enum.filter(&(&1.role == :assistant))
       |> Enum.flat_map(fn msg ->
         (msg.tool_calls || [])
         |> Enum.map(fn call ->
-          Map.get(call, :id) || Map.get(call, "id")
+          {Map.get(call, :id) || Map.get(call, "id"),
+           Map.get(call, :name) || Map.get(call, "name")}
         end)
-        |> Enum.reject(&is_nil/1)
+        |> Enum.reject(fn {id, _} -> is_nil(id) end)
       end)
-      |> MapSet.new()
+      |> Map.new()
 
-    # Collect all tool result IDs
     tool_result_ids =
       messages
       |> Enum.filter(&(&1.role == :tool))
@@ -445,16 +446,18 @@ defmodule Nous.Agent.Context do
       |> Enum.reject(&is_nil/1)
       |> MapSet.new()
 
-    # Find unmatched tool calls
-    dangling_ids = MapSet.difference(tool_call_ids, tool_result_ids)
+    dangling_ids = MapSet.difference(MapSet.new(Map.keys(tool_call_names)), tool_result_ids)
 
     if MapSet.size(dangling_ids) == 0 do
       ctx
     else
-      # Inject synthetic tool results for dangling calls
       synthetic_results =
         Enum.map(dangling_ids, fn id ->
-          Message.tool(id, "Tool call was interrupted and not executed. Please retry if needed.")
+          Message.tool(
+            id,
+            "Tool call was interrupted and not executed. Please retry if needed.",
+            name: Map.get(tool_call_names, id)
+          )
         end)
 
       %{ctx | messages: messages ++ synthetic_results}

--- a/lib/nous/agent_registry.ex
+++ b/lib/nous/agent_registry.ex
@@ -2,7 +2,15 @@ defmodule Nous.AgentRegistry do
   @moduledoc "Registry for looking up agent processes by session ID."
 
   def child_spec(_opts) do
-    Registry.child_spec(keys: :unique, name: __MODULE__)
+    # Partition across schedulers so high-concurrency lookups (e.g. a
+    # LiveView fan-in calling Nous.AgentRegistry.lookup/1 from many sockets)
+    # don't serialize on a single ETS-backed partition. Registry defaults to
+    # partitions: 1 which becomes a contention point at scale.
+    Registry.child_spec(
+      keys: :unique,
+      name: __MODULE__,
+      partitions: System.schedulers_online()
+    )
   end
 
   def via_tuple(session_id) do

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -709,100 +709,40 @@ defmodule Nous.AgentRunner do
 
             cleaned_name = clean_tool_name(call_name)
 
-            # Run pre_tool_use hooks first (can block or modify args)
-            hook_payload = %{
-              tool_name: cleaned_name,
-              tool_id: call_id,
-              arguments: call_arguments
-            }
+            # Short-circuit on tool_call whose arguments JSON failed to parse.
+            # The provider marshalling tagged it with "_invalid_arguments" so
+            # we surface a clean tool-error result and let the LLM retry —
+            # rather than invoking the tool with bogus/empty args.
+            invalid_args =
+              Map.get(call, "_invalid_arguments") || Map.get(call, :_invalid_arguments)
 
-            case Hook.Runner.run(acc_ctx.hook_registry, :pre_tool_use, hook_payload) do
-              :deny ->
-                Logger.info("Tool '#{cleaned_name}' denied by hook")
-                result_msg = Message.tool(call_id, "Tool call was denied by hook.")
-                {[result_msg | results], acc_ctx}
+            if is_binary(invalid_args) do
+              Logger.warning(
+                "Tool '#{cleaned_name}' called with malformed arguments JSON: #{invalid_args}"
+              )
 
-              {:deny, reason} ->
-                Logger.info("Tool '#{cleaned_name}' denied by hook: #{reason}")
-                result_msg = Message.tool(call_id, "Tool call was denied by hook: #{reason}")
-                {[result_msg | results], acc_ctx}
+              result_msg =
+                Message.tool(
+                  call_id,
+                  "Error: tool arguments were not valid JSON. Please retry with a JSON object.",
+                  name: cleaned_name
+                )
 
-              {:modify, %{arguments: new_args}} ->
-                # Hook modified the arguments — continue with modified call
-                modified_call = put_tool_field(call, :arguments, new_args)
-                tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
-
-                case check_tool_approval(tool, modified_call, acc_ctx) do
-                  :reject ->
-                    result_msg =
-                      Message.tool(call_id, "Tool call was rejected by approval handler.")
-
-                    {[result_msg | results], acc_ctx}
-
-                  {:edit, edited_args} ->
-                    edited_call = put_tool_field(modified_call, :arguments, edited_args)
-
-                    {result_msg, acc_ctx} =
-                      execute_and_record_tool(
-                        tools,
-                        edited_call,
-                        run_ctx,
-                        behaviour,
-                        agent,
-                        acc_ctx
-                      )
-
-                    {[result_msg | results], acc_ctx}
-
-                  :approve ->
-                    {result_msg, acc_ctx} =
-                      execute_and_record_tool(
-                        tools,
-                        modified_call,
-                        run_ctx,
-                        behaviour,
-                        agent,
-                        acc_ctx
-                      )
-
-                    {[result_msg | results], acc_ctx}
-                end
-
-              _ ->
-                # :allow or other — proceed to approval check
-                tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
-
-                case check_tool_approval(tool, call, acc_ctx) do
-                  :reject ->
-                    Logger.info("Tool '#{cleaned_name}' rejected by approval handler")
-
-                    result_msg =
-                      Message.tool(call_id, "Tool call was rejected by approval handler.")
-
-                    {[result_msg | results], acc_ctx}
-
-                  {:edit, new_args} ->
-                    Logger.debug("Tool '#{cleaned_name}' arguments edited by approval handler")
-                    edited_call = put_tool_field(call, :arguments, new_args)
-
-                    {result_msg, acc_ctx} =
-                      execute_and_record_tool(
-                        tools,
-                        edited_call,
-                        run_ctx,
-                        behaviour,
-                        agent,
-                        acc_ctx
-                      )
-
-                    {[result_msg | results], acc_ctx}
-
-                  :approve ->
-                    {result_msg, acc_ctx} =
-                      execute_and_record_tool(tools, call, run_ctx, behaviour, agent, acc_ctx)
-
-                    {[result_msg | results], acc_ctx}
-                end
+              {[result_msg | results], acc_ctx}
+            else
+              run_tool_with_hooks(
+                call,
+                call_id,
+                call_name,
+                cleaned_name,
+                call_arguments,
+                tools,
+                run_ctx,
+                behaviour,
+                agent,
+                acc_ctx,
+                results
+              )
             end
           end)
 
@@ -815,6 +755,128 @@ defmodule Nous.AgentRunner do
           Context.add_tool_call(acc, call)
         end)
       end
+    end
+  end
+
+  # Run hooks + execute the tool call, returning the {results, acc_ctx} pair
+  # that the outer Enum.reduce expects. Extracted to keep the main loop
+  # legible after the invalid-args short-circuit was added.
+  defp run_tool_with_hooks(
+         call,
+         call_id,
+         _call_name,
+         cleaned_name,
+         call_arguments,
+         tools,
+         run_ctx,
+         behaviour,
+         agent,
+         acc_ctx,
+         results
+       ) do
+    hook_payload = %{
+      tool_name: cleaned_name,
+      tool_id: call_id,
+      arguments: call_arguments
+    }
+
+    case Hook.Runner.run(acc_ctx.hook_registry, :pre_tool_use, hook_payload) do
+      :deny ->
+        Logger.info("Tool '#{cleaned_name}' denied by hook")
+
+        result_msg =
+          Message.tool(call_id, "Tool call was denied by hook.", name: cleaned_name)
+
+        {[result_msg | results], acc_ctx}
+
+      {:deny, reason} ->
+        Logger.info("Tool '#{cleaned_name}' denied by hook: #{reason}")
+
+        result_msg =
+          Message.tool(call_id, "Tool call was denied by hook: #{reason}", name: cleaned_name)
+
+        {[result_msg | results], acc_ctx}
+
+      {:modify, %{arguments: new_args}} ->
+        # Hook modified the arguments — continue with modified call
+        modified_call = put_tool_field(call, :arguments, new_args)
+        tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
+
+        case check_tool_approval(tool, modified_call, acc_ctx) do
+          :reject ->
+            result_msg =
+              Message.tool(call_id, "Tool call was rejected by approval handler.",
+                name: cleaned_name
+              )
+
+            {[result_msg | results], acc_ctx}
+
+          {:edit, edited_args} ->
+            edited_call = put_tool_field(modified_call, :arguments, edited_args)
+
+            {result_msg, acc_ctx} =
+              execute_and_record_tool(
+                tools,
+                edited_call,
+                run_ctx,
+                behaviour,
+                agent,
+                acc_ctx
+              )
+
+            {[result_msg | results], acc_ctx}
+
+          :approve ->
+            {result_msg, acc_ctx} =
+              execute_and_record_tool(
+                tools,
+                modified_call,
+                run_ctx,
+                behaviour,
+                agent,
+                acc_ctx
+              )
+
+            {[result_msg | results], acc_ctx}
+        end
+
+      _ ->
+        # :allow or other — proceed to approval check
+        tool = Enum.find(tools, fn t -> t.name == cleaned_name end)
+
+        case check_tool_approval(tool, call, acc_ctx) do
+          :reject ->
+            Logger.info("Tool '#{cleaned_name}' rejected by approval handler")
+
+            result_msg =
+              Message.tool(call_id, "Tool call was rejected by approval handler.",
+                name: cleaned_name
+              )
+
+            {[result_msg | results], acc_ctx}
+
+          {:edit, new_args} ->
+            Logger.debug("Tool '#{cleaned_name}' arguments edited by approval handler")
+            edited_call = put_tool_field(call, :arguments, new_args)
+
+            {result_msg, acc_ctx} =
+              execute_and_record_tool(
+                tools,
+                edited_call,
+                run_ctx,
+                behaviour,
+                agent,
+                acc_ctx
+              )
+
+            {[result_msg | results], acc_ctx}
+
+          :approve ->
+            {result_msg, acc_ctx} =
+              execute_and_record_tool(tools, call, run_ctx, behaviour, agent, acc_ctx)
+
+            {[result_msg | results], acc_ctx}
+        end
     end
   end
 
@@ -835,7 +897,7 @@ defmodule Nous.AgentRunner do
              result: result_msg.content
            }) do
         {:modify, %{result: new_result}} ->
-          Message.tool(call_id, new_result)
+          Message.tool(call_id, new_result, name: cleaned_name)
 
         _ ->
           result_msg
@@ -938,7 +1000,7 @@ defmodule Nous.AgentRunner do
         {error_msg, %{}}
       end
 
-    {Message.tool(call_id, result), context_updates}
+    {Message.tool(call_id, result, name: cleaned_name), context_updates}
   end
 
   # Apply plugin system prompt fragments to context

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -487,181 +487,222 @@ defmodule Nous.AgentRunner do
       error = Errors.MaxIterationsExceeded.exception(max_iterations: ctx.max_iterations)
       {:error, error}
     else
-      # Get tools from behaviour + plugins
-      tools = behaviour.get_tools(agent)
-      plugin_tools = Plugin.collect_tools(agent.plugins, agent, ctx)
-      all_tools = tools ++ plugin_tools
+      iteration_start = System.monotonic_time()
 
-      # Apply plugin system prompt fragments only on first iteration
-      ctx = if ctx.iteration == 0, do: apply_plugin_system_prompts(agent, ctx), else: ctx
-
-      # Run plugin before_request hooks
-      {ctx, all_tools} = Plugin.run_before_request(agent.plugins, agent, ctx, all_tools)
-
-      # Run pre_request hooks (can block the LLM call)
-      pre_request_result =
-        Hook.Runner.run(ctx.hook_registry, :pre_request, %{
+      :telemetry.execute(
+        [:nous, :agent, :iteration, :start],
+        %{system_time: System.system_time()},
+        %{
           agent_name: agent.name,
-          tool_count: length(all_tools),
-          iteration: ctx.iteration
-        })
+          iteration: ctx.iteration,
+          max_iterations: ctx.max_iterations
+        }
+      )
 
-      # If a plugin (e.g. InputGuard) halted execution or a hook denied, skip the LLM call
-      if ctx.needs_response and pre_request_result != :deny do
-        # Build messages via behaviour
-        messages = behaviour.build_messages(agent, ctx)
+      result = do_iteration_body(agent, behaviour, ctx)
 
-        # Add tools to model settings if any
-        model_settings =
-          if Enum.empty?(all_tools) do
-            agent.model_settings
-          else
-            Logger.debug(
-              "Converting #{length(all_tools)} tools for provider: #{agent.model.provider}"
-            )
+      iteration_duration = System.monotonic_time() - iteration_start
 
-            tool_schemas = convert_tools_for_provider(agent.model.provider, all_tools)
-            Map.put(agent.model_settings, :tools, tool_schemas)
+      iteration_meta = %{
+        agent_name: agent.name,
+        iteration: ctx.iteration,
+        tool_calls:
+          case result do
+            {:ok, %{usage: %{tool_calls: tc}}} -> tc
+            _ -> 0
+          end,
+        needs_response:
+          case result do
+            {:ok, %{needs_response: nr}} -> nr
+            _ -> false
           end
+      }
 
-        # Inject structured output settings
-        model_settings =
-          if agent.output_type != :string do
-            inject_structured_output_settings(agent, model_settings, all_tools)
-          else
-            model_settings
-          end
+      :telemetry.execute(
+        [:nous, :agent, :iteration, :stop],
+        %{duration: iteration_duration},
+        iteration_meta
+      )
 
-        # Apply before_request callback if implemented
-        model_settings =
-          Behaviour.call(
-            behaviour,
-            :before_request,
-            [agent, ctx, Keyword.new(model_settings)],
-            Keyword.new(model_settings)
+      result
+    end
+  end
+
+  defp do_iteration_body(agent, behaviour, ctx) do
+    # Get tools from behaviour + plugins
+    tools = behaviour.get_tools(agent)
+    plugin_tools = Plugin.collect_tools(agent.plugins, agent, ctx)
+    all_tools = tools ++ plugin_tools
+
+    # Apply plugin system prompt fragments only on first iteration
+    ctx = if ctx.iteration == 0, do: apply_plugin_system_prompts(agent, ctx), else: ctx
+
+    # Run plugin before_request hooks
+    {ctx, all_tools} = Plugin.run_before_request(agent.plugins, agent, ctx, all_tools)
+
+    # Run pre_request hooks (can block the LLM call)
+    pre_request_result =
+      Hook.Runner.run(ctx.hook_registry, :pre_request, %{
+        agent_name: agent.name,
+        tool_count: length(all_tools),
+        iteration: ctx.iteration
+      })
+
+    # If a plugin (e.g. InputGuard) halted execution or a hook denied, skip the LLM call
+    if ctx.needs_response and pre_request_result != :deny do
+      # Build messages via behaviour
+      messages = behaviour.build_messages(agent, ctx)
+
+      # Add tools to model settings if any
+      model_settings =
+        if Enum.empty?(all_tools) do
+          agent.model_settings
+        else
+          Logger.debug(
+            "Converting #{length(all_tools)} tools for provider: #{agent.model.provider}"
           )
-          |> Map.new()
 
-        # Make model request (with fallback chain if configured).
-        #
-        # Sticky-fallback: if a previous iteration already promoted to a
-        # fallback model (recorded in ctx.deps[:active_model]), call into
-        # request_with_fallback with that model first to avoid retrying
-        # a known-bad primary on every iteration.
-        request_agent =
-          case get_in(ctx.deps, [:active_model]) do
-            nil -> agent
-            am -> %{agent | model: am}
-          end
-
-        Logger.debug(
-          "Agent iteration #{ctx.iteration + 1}/#{ctx.max_iterations}: requesting model response"
-        )
-
-        request_result =
-          if ctx.stream do
-            stream_request_with_fallback(
-              request_agent,
-              messages,
-              model_settings,
-              all_tools,
-              ctx
-            )
-          else
-            request_with_fallback(request_agent, messages, model_settings, all_tools)
-          end
-
-        case request_result do
-          {:ok, response, active_model} ->
-            # Track active_model in ctx for downstream telemetry / observability,
-            # but do NOT mutate agent.model. Mutating made the start-of-run
-            # telemetry tag with one provider and the stop with another, with
-            # no fallback_used indicator - operational metrics drifted apart
-            # for any agent that ever fell back.
-            ctx =
-              if active_model != agent.model do
-                :telemetry.execute(
-                  [:nous, :agent, :fallback, :used],
-                  %{system_time: System.system_time()},
-                  %{
-                    agent_name: agent.name,
-                    original_provider: agent.model.provider,
-                    original_model: agent.model.model,
-                    active_provider: active_model.provider,
-                    active_model: active_model.model
-                  }
-                )
-
-                %{ctx | deps: Map.put(ctx.deps, :active_model, active_model)}
-              else
-                ctx
-              end
-
-            # Update usage
-            usage_update = response.metadata.usage || %{}
-            ctx = Context.add_usage(ctx, usage_update)
-            ctx = Context.increment_iteration(ctx)
-
-            # Get total tokens safely from struct or map
-            tokens_added =
-              case usage_update do
-                %{total_tokens: t} when is_integer(t) -> t
-                _ -> 0
-              end
-
-            Logger.debug(
-              "Model response received (tokens: +#{tokens_added}, total: #{ctx.usage.total_tokens})"
-            )
-
-            # Execute callback
-            Callbacks.execute(ctx, :on_llm_new_message, response)
-
-            # Run plugin after_response hooks
-            ctx = Plugin.run_after_response(agent.plugins, agent, response, ctx)
-
-            # Run post_response hooks
-            Hook.Runner.run(ctx.hook_registry, :post_response, %{
-              agent_name: agent.name,
-              iteration: ctx.iteration
-            })
-
-            # Process response via behaviour - this handles tool calls and updates needs_response
-            ctx = behaviour.process_response(agent, response, ctx)
-
-            # Check if we need to handle tool calls (behaviour may have set this up)
-            ctx =
-              if Message.has_tool_calls?(response) do
-                handle_tool_calls(agent, behaviour, ctx, response, all_tools)
-              else
-                ctx
-              end
-
-            # Continue loop
-            execute_loop(agent, behaviour, ctx)
-
-          {:error, reason} ->
-            Logger.error("""
-            Model request failed in iteration #{ctx.iteration + 1}
-              Agent: #{agent.name}
-              Model: #{agent.model.provider}:#{agent.model.model}
-              Reason: #{inspect(reason)}
-            """)
-
-            # Try error handler if implemented
-            case Behaviour.call(behaviour, :handle_error, [agent, reason, ctx], {:error, reason}) do
-              {:retry, new_ctx} ->
-                execute_loop(agent, behaviour, new_ctx)
-
-              {:continue, new_ctx} ->
-                execute_loop(agent, behaviour, new_ctx)
-
-              {:error, _} = err ->
-                err
-            end
+          tool_schemas = convert_tools_for_provider(agent.model.provider, all_tools)
+          Map.put(agent.model_settings, :tools, tool_schemas)
         end
-      else
-        {:ok, ctx}
+
+      # Inject structured output settings
+      model_settings =
+        if agent.output_type != :string do
+          inject_structured_output_settings(agent, model_settings, all_tools)
+        else
+          model_settings
+        end
+
+      # Apply before_request callback if implemented
+      model_settings =
+        Behaviour.call(
+          behaviour,
+          :before_request,
+          [agent, ctx, Keyword.new(model_settings)],
+          Keyword.new(model_settings)
+        )
+        |> Map.new()
+
+      # Make model request (with fallback chain if configured).
+      #
+      # Sticky-fallback: if a previous iteration already promoted to a
+      # fallback model (recorded in ctx.deps[:active_model]), call into
+      # request_with_fallback with that model first to avoid retrying
+      # a known-bad primary on every iteration.
+      request_agent =
+        case get_in(ctx.deps, [:active_model]) do
+          nil -> agent
+          am -> %{agent | model: am}
+        end
+
+      Logger.debug(
+        "Agent iteration #{ctx.iteration + 1}/#{ctx.max_iterations}: requesting model response"
+      )
+
+      request_result =
+        if ctx.stream do
+          stream_request_with_fallback(
+            request_agent,
+            messages,
+            model_settings,
+            all_tools,
+            ctx
+          )
+        else
+          request_with_fallback(request_agent, messages, model_settings, all_tools)
+        end
+
+      case request_result do
+        {:ok, response, active_model} ->
+          # Track active_model in ctx for downstream telemetry / observability,
+          # but do NOT mutate agent.model. Mutating made the start-of-run
+          # telemetry tag with one provider and the stop with another, with
+          # no fallback_used indicator - operational metrics drifted apart
+          # for any agent that ever fell back.
+          ctx =
+            if active_model != agent.model do
+              :telemetry.execute(
+                [:nous, :agent, :fallback, :used],
+                %{system_time: System.system_time()},
+                %{
+                  agent_name: agent.name,
+                  original_provider: agent.model.provider,
+                  original_model: agent.model.model,
+                  active_provider: active_model.provider,
+                  active_model: active_model.model
+                }
+              )
+
+              %{ctx | deps: Map.put(ctx.deps, :active_model, active_model)}
+            else
+              ctx
+            end
+
+          # Update usage
+          usage_update = response.metadata.usage || %{}
+          ctx = Context.add_usage(ctx, usage_update)
+          ctx = Context.increment_iteration(ctx)
+
+          # Get total tokens safely from struct or map
+          tokens_added =
+            case usage_update do
+              %{total_tokens: t} when is_integer(t) -> t
+              _ -> 0
+            end
+
+          Logger.debug(
+            "Model response received (tokens: +#{tokens_added}, total: #{ctx.usage.total_tokens})"
+          )
+
+          # Execute callback
+          Callbacks.execute(ctx, :on_llm_new_message, response)
+
+          # Run plugin after_response hooks
+          ctx = Plugin.run_after_response(agent.plugins, agent, response, ctx)
+
+          # Run post_response hooks
+          Hook.Runner.run(ctx.hook_registry, :post_response, %{
+            agent_name: agent.name,
+            iteration: ctx.iteration
+          })
+
+          # Process response via behaviour - this handles tool calls and updates needs_response
+          ctx = behaviour.process_response(agent, response, ctx)
+
+          # Check if we need to handle tool calls (behaviour may have set this up)
+          ctx =
+            if Message.has_tool_calls?(response) do
+              handle_tool_calls(agent, behaviour, ctx, response, all_tools)
+            else
+              ctx
+            end
+
+          # Continue loop
+          execute_loop(agent, behaviour, ctx)
+
+        {:error, reason} ->
+          Logger.error("""
+          Model request failed in iteration #{ctx.iteration + 1}
+            Agent: #{agent.name}
+            Model: #{agent.model.provider}:#{agent.model.model}
+            Reason: #{inspect(reason)}
+          """)
+
+          # Try error handler if implemented
+          case Behaviour.call(behaviour, :handle_error, [agent, reason, ctx], {:error, reason}) do
+            {:retry, new_ctx} ->
+              execute_loop(agent, behaviour, new_ctx)
+
+            {:continue, new_ctx} ->
+              execute_loop(agent, behaviour, new_ctx)
+
+            {:error, _} = err ->
+              err
+          end
       end
+    else
+      {:ok, ctx}
     end
   end
 

--- a/lib/nous/agent_server.ex
+++ b/lib/nous/agent_server.ex
@@ -285,28 +285,20 @@ defmodule Nous.AgentServer do
           )
       end
 
-    # Initialize context - try loading from persistence first
+    # Start with a fresh context; restore persisted state in handle_continue
+    # so init/1 doesn't block on persistence I/O. Without this, the parent
+    # DynamicSupervisor (and any caller blocked on start_child — notably
+    # Teams.Coordinator's spawn_agent handle_call) waits the full load time.
     initial_deps = Map.get(agent_config, :deps, %{})
 
     context =
-      case maybe_load_context(persistence, session_id) do
-        {:ok, loaded_ctx} ->
-          Logger.info("Restored persisted context for session: #{session_id}")
-          # Merge initial deps back in (they may contain runtime values like PIDs)
-          loaded_ctx
-          |> Context.merge_deps(initial_deps)
-          |> Context.patch_dangling_tool_calls()
-          |> Map.merge(%{pubsub: pubsub, pubsub_topic: topic})
-
-        _ ->
-          Context.new(
-            deps: initial_deps,
-            system_prompt: Map.get(agent_config, :instructions, ""),
-            agent_name: "agent_server_#{session_id}",
-            pubsub: pubsub,
-            pubsub_topic: topic
-          )
-      end
+      Context.new(
+        deps: initial_deps,
+        system_prompt: Map.get(agent_config, :instructions, ""),
+        agent_name: "agent_server_#{session_id}",
+        pubsub: pubsub,
+        pubsub_topic: topic
+      )
 
     Logger.info("AgentServer started for session: #{session_id}")
 
@@ -337,7 +329,28 @@ defmodule Nous.AgentServer do
       persistence: persistence
     }
 
-    {:ok, state}
+    {:ok, state, {:continue, :load_persisted_context}}
+  end
+
+  @impl true
+  def handle_continue(:load_persisted_context, state) do
+    case maybe_load_context(state.persistence, state.session_id) do
+      {:ok, loaded_ctx} ->
+        Logger.info("Restored persisted context for session: #{state.session_id}")
+
+        # Merge initial deps back in (they may contain runtime values like PIDs)
+        # and patch any dangling tool calls left over from an interrupted run.
+        new_context =
+          loaded_ctx
+          |> Context.merge_deps(state.context.deps)
+          |> Context.patch_dangling_tool_calls()
+          |> Map.merge(%{pubsub: state.pubsub, pubsub_topic: state.topic})
+
+        {:noreply, %{state | context: new_context}}
+
+      _ ->
+        {:noreply, state}
+    end
   end
 
   @impl true

--- a/lib/nous/agent_server.ex
+++ b/lib/nous/agent_server.ex
@@ -256,8 +256,11 @@ defmodule Nous.AgentServer do
     inactivity_timeout = Keyword.get(opts, :inactivity_timeout, @default_inactivity_timeout)
     persistence = Keyword.get(opts, :persistence)
 
-    # Subscribe to messages for this session
-    topic = "agent:#{session_id}"
+    # Subscribe to messages for this session. Use the helper so the topic
+    # matches what publishers via Nous.PubSub.agent_topic/1 send to —
+    # previously this was a bare "agent:#{id}" string while the helper
+    # returned "nous:agent:#{id}", so external publishers never reached us.
+    topic = Nous.PubSub.agent_topic(session_id)
     Nous.PubSub.subscribe(pubsub, topic)
 
     # Create agent based on type
@@ -412,7 +415,21 @@ defmodule Nous.AgentServer do
     state =
       if state.current_task do
         case Task.shutdown(state.current_task, 2_000) do
-          _ -> :ok
+          {:ok, _result} ->
+            :ok
+
+          nil ->
+            # task did not respond to graceful shutdown within timeout
+            :ok
+
+          {:exit, reason} ->
+            # Task crashed during shutdown. Log so it isn't silently
+            # swallowed — debugging mid-run crashes was painful when
+            # this clause was `_ -> :ok`.
+            Logger.warning(
+              "AgentServer task exited during reset for session " <>
+                "#{state.session_id}: #{inspect(reason)}"
+            )
         end
 
         %{state | current_task: nil}
@@ -654,6 +671,17 @@ defmodule Nous.AgentServer do
   @impl true
   def terminate(reason, state) do
     Logger.info("AgentServer terminating for session #{state.session_id}: #{inspect(reason)}")
+
+    # Cancel any in-flight task on shutdown. Without this, an LLM stream
+    # started under this server would keep consuming tokens (and HTTP
+    # connections) until it hit max_iterations, even though the server is
+    # going away. Setting the cancelled atomic also lets the runner's
+    # cancellation checks short-circuit if it's still running.
+    if state.current_task do
+      :atomics.put(state.cancelled_ref, 1, 1)
+      _ = Task.shutdown(state.current_task, 1_000)
+    end
+
     :ok
   end
 

--- a/lib/nous/application.ex
+++ b/lib/nous/application.ex
@@ -18,7 +18,11 @@ defmodule Nous.Application do
         # ETS persistence table owner - keeps the :nous_persistence table
         # alive across transient agent processes. Without this the table
         # dies with whichever process happens to call save/load first.
-        Nous.Persistence.ETS
+        Nous.Persistence.ETS,
+        # Same ownership pattern for the workflow checkpoint table — without
+        # a supervised owner, suspended workflows could vanish whenever the
+        # process that saved them exited.
+        Nous.Workflow.Checkpoint.ETS
       ] ++ optional_bumblebee_children()
 
     # Tuned restart limits to match AgentDynamicSupervisor - default 3-in-5

--- a/lib/nous/decisions.ex
+++ b/lib/nous/decisions.ex
@@ -178,6 +178,7 @@ defmodule Nous.Decisions do
       {:ok, path} = Nous.Decisions.path_between(Store.ETS, state, from_id, to_id)
 
   """
+  @deprecated "Call store_mod.query(state, :path_between, ...) directly"
   @spec path_between(module(), term(), String.t(), String.t()) :: {:ok, [Node.t()]}
   def path_between(store_mod, state, from_id, to_id) do
     store_mod.query(state, :path_between, from_id: from_id, to_id: to_id)
@@ -191,6 +192,7 @@ defmodule Nous.Decisions do
       {:ok, descendants} = Nous.Decisions.descendants(Store.ETS, state, node_id)
 
   """
+  @deprecated "Call store_mod.query(state, :descendants, ...) directly"
   @spec descendants(module(), term(), String.t()) :: {:ok, [Node.t()]}
   def descendants(store_mod, state, node_id) do
     store_mod.query(state, :descendants, node_id: node_id)
@@ -204,6 +206,7 @@ defmodule Nous.Decisions do
       {:ok, ancestors} = Nous.Decisions.ancestors(Store.ETS, state, node_id)
 
   """
+  @deprecated "Call store_mod.query(state, :ancestors, ...) directly"
   @spec ancestors(module(), term(), String.t()) :: {:ok, [Node.t()]}
   def ancestors(store_mod, state, node_id) do
     store_mod.query(state, :ancestors, node_id: node_id)

--- a/lib/nous/eval.ex
+++ b/lib/nous/eval.ex
@@ -128,6 +128,7 @@ defmodule Nous.Eval do
   @doc """
   Run an evaluation suite, raising on error.
   """
+  @deprecated "Match on Nous.Eval.run/2's {:ok, _} | {:error, _} result instead"
   @spec run!(Suite.t(), keyword()) :: map()
   def run!(%Suite{} = suite, opts \\ []) do
     case run(suite, opts) do

--- a/lib/nous/eval/runner.ex
+++ b/lib/nous/eval/runner.ex
@@ -154,8 +154,9 @@ defmodule Nous.Eval.Runner do
   defp run_parallel(%Suite{} = suite, opts, parallelism, setup_result) do
     opts = Keyword.put(opts, :setup_result, setup_result)
 
-    suite.test_cases
-    |> Task.async_stream(
+    Task.Supervisor.async_stream_nolink(
+      Nous.TaskSupervisor,
+      suite.test_cases,
       fn test_case ->
         execute_test_case(test_case, suite, opts)
       end,
@@ -272,15 +273,19 @@ defmodule Nous.Eval.Runner do
         timeout: timeout
       ]
 
-      # Run with timeout protection
+      # Run with timeout protection under the application TaskSupervisor so
+      # an eval crash doesn't take down the parent eval runner.
       task =
-        Task.async(fn ->
+        Task.Supervisor.async_nolink(Nous.TaskSupervisor, fn ->
           Nous.run(agent, test_case.input, run_opts)
         end)
 
       case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
         {:ok, result} ->
           result
+
+        {:exit, reason} ->
+          {:error, {:task_exit, reason}}
 
         nil ->
           {:error, :timeout}

--- a/lib/nous/hook.ex
+++ b/lib/nous/hook.ex
@@ -75,7 +75,8 @@ defmodule Nous.Hook do
           handler: (event(), map() -> result()) | module() | String.t(),
           priority: integer(),
           timeout: non_neg_integer(),
-          name: String.t() | nil
+          name: String.t() | nil,
+          fail_closed: boolean()
         }
 
   @enforce_keys [:event, :type, :handler]
@@ -86,7 +87,14 @@ defmodule Nous.Hook do
     type: :function,
     matcher: nil,
     priority: 100,
-    timeout: 10_000
+    timeout: 10_000,
+    # When set on a hook bound to a blocking event (:pre_tool_use, :pre_request),
+    # runtime errors (raised exceptions, timeouts, non-0/2 exit codes from
+    # command hooks) deny the action instead of allowing it. Defaults to
+    # false to preserve existing fail-open behavior; set to true on hooks
+    # that gate security-sensitive operations so a broken hook can't
+    # silently bypass the check.
+    fail_closed: false
   ]
 
   @doc """

--- a/lib/nous/hook/runner.ex
+++ b/lib/nous/hook/runner.ex
@@ -109,8 +109,25 @@ defmodule Nous.Hook.Runner do
           "Hook #{inspect(hook.name || hook.type)} errored on #{event}: #{inspect(reason)}"
         )
 
-        # Errors in hooks don't block — fail open
-        run_blocking(rest, event, payload)
+        # By default errors fail OPEN (continue to the next hook). When the
+        # hook opts in with `fail_closed: true` we treat the error as :deny
+        # — so a broken security-gating hook can't be silently bypassed.
+        if hook.fail_closed do
+          :telemetry.execute(
+            [:nous, :hook, :denied],
+            %{},
+            %{
+              event: event,
+              hook_name: hook.name,
+              hook_type: hook.type,
+              reason: {:fail_closed, reason}
+            }
+          )
+
+          {:deny, "hook errored (fail_closed): #{inspect(reason)}"}
+        else
+          run_blocking(rest, event, payload)
+        end
     end
   end
 
@@ -190,12 +207,12 @@ defmodule Nous.Hook.Runner do
   # caller-controllable handler value became RCE through shell expansion.
   # Lists bypass the shell entirely.
   defp execute_hook(
-         %Hook{type: :command, handler: [program | _] = argv, timeout: timeout},
+         %Hook{type: :command, handler: [program | _] = argv} = hook,
          event,
          payload
        )
        when is_binary(program) do
-    execute_command_hook(argv, event, payload, timeout)
+    execute_command_hook(argv, event, payload, hook.timeout, hook.fail_closed)
   end
 
   defp execute_hook(%Hook{type: :command, handler: handler}, _event, _payload) do
@@ -215,7 +232,7 @@ defmodule Nous.Hook.Runner do
 
   # Execute a command hook via NetRunner. The argv list is passed
   # directly - no shell, no expansion.
-  defp execute_command_hook(argv, event, payload, timeout) do
+  defp execute_command_hook(argv, event, payload, timeout, fail_closed) do
     json_input =
       JSON.encode!(%{
         event: event,
@@ -237,8 +254,14 @@ defmodule Nous.Hook.Runner do
         {output, exit_code} ->
           Logger.warning("Command hook exited with code #{exit_code}: #{String.trim(output)}")
 
-          # Non-0/2 exit codes fail open
-          :allow
+          # Non-0/2 exit codes default to fail OPEN for backward compat;
+          # set fail_closed: true on the hook to treat them as :deny so a
+          # crashing security-gating hook can't be silently bypassed.
+          if fail_closed do
+            {:deny, "command hook exited with code #{exit_code} (fail_closed)"}
+          else
+            :allow
+          end
       end
     rescue
       e ->

--- a/lib/nous/http/stream_backend/req.ex
+++ b/lib/nous/http/stream_backend/req.ex
@@ -11,14 +11,27 @@ defmodule Nous.HTTP.StreamBackend.Req do
 
   Req's `:into` callback runs in the spawned `Task`. Forwarding to the
   consumer process is `send/2`, so a fast producer + slow consumer can
-  grow the consumer's mailbox unboundedly. This is acceptable for
-  typical LLM workloads where token-generation rate is the bottleneck
-  and consumers are parsing-bound (parsing throttles naturally).
+  grow the consumer's mailbox.
 
-  Callers whose downstream consumers can block per chunk (LiveView
-  fan-out under load, persistence-on-every-chunk, slow IO) should use
-  `Nous.HTTP.StreamBackend.Hackney` instead, which provides strict
-  pull-based backpressure via `:hackney`'s `{:async, :once}` mode.
+  The producer task watches the consumer's mailbox via
+  `Process.info(parent, :message_queue_len)`. When the queue length
+  crosses `@backpressure_high_water` (default 1_000 chunks) the task
+  busy-waits in 5ms increments until it drops below
+  `@backpressure_low_water` (default 100). This gives Req's `:into`
+  callback natural backpressure — the producing socket doesn't read
+  more bytes while we're waiting — without requiring the consumer to
+  switch to the Hackney backend.
+
+  If the consumer is *truly* unresponsive (the mailbox stays high for
+  longer than `:backpressure_max_wait_ms`), the task emits
+  `{:backpressure_overflow, %{queue_len: n}}` and aborts the stream
+  rather than wedging forever.
+
+  Callers whose downstream consumers reliably block per chunk
+  (LiveView fan-out under load, persistence-on-every-chunk, slow IO)
+  can still prefer `Nous.HTTP.StreamBackend.Hackney`, which provides
+  strict pull-based backpressure via `:hackney`'s `{:async, :once}`
+  mode.
 
   ## TLS verification
 
@@ -36,6 +49,12 @@ defmodule Nous.HTTP.StreamBackend.Req do
   # between chunks long enough to trip a tighter timeout. Per-call
   # `:timeout` opt overrides.
   @default_timeout 180_000
+
+  # Backpressure watermarks (see @moduledoc). Tuned so that an under-load
+  # LiveView consumer pauses the producer rather than OOMing.
+  @backpressure_high_water 1_000
+  @backpressure_low_water 100
+  @backpressure_max_wait_ms 30_000
 
   @impl Nous.HTTP.StreamBackend
   def stream(url, body, headers, opts \\ [])
@@ -84,13 +103,26 @@ defmodule Nous.HTTP.StreamBackend.Req do
           receive_timeout: timeout,
           finch: finch_name,
           into: fn {:data, chunk}, {req, resp} ->
-            if resp.status in 200..299 do
-              send(parent, {ref, {:chunk, chunk}})
-              {:cont, {req, resp}}
-            else
-              # Non-2xx: accumulate body locally so the post-call status
-              # check has the full error body to report. Do not forward.
-              {:cont, {req, %{resp | body: (resp.body || "") <> chunk}}}
+            cond do
+              resp.status not in 200..299 ->
+                # Non-2xx: accumulate body locally so the post-call status
+                # check has the full error body to report. Do not forward.
+                {:cont, {req, %{resp | body: (resp.body || "") <> chunk}}}
+
+              true ->
+                case await_consumer_capacity(parent) do
+                  :ok ->
+                    send(parent, {ref, {:chunk, chunk}})
+                    {:cont, {req, resp}}
+
+                  {:error, :backpressure_timeout, queue_len} ->
+                    send(
+                      parent,
+                      {ref, {:error, %{reason: :backpressure_overflow, queue_len: queue_len}}}
+                    )
+
+                    {:halt, {req, resp}}
+                end
             end
           end
         )
@@ -118,6 +150,43 @@ defmodule Nous.HTTP.StreamBackend.Req do
           send(parent, {ref, {:error, reason}})
       end
     end)
+  end
+
+  # Block the producer task while the consumer's mailbox is above the
+  # high-water mark, releasing once it drops back below the low-water mark.
+  # Returns :ok when capacity is available, or {:error, :backpressure_timeout, queue_len}
+  # if the consumer doesn't drain within @backpressure_max_wait_ms.
+  defp await_consumer_capacity(parent) do
+    case message_queue_len(parent) do
+      n when n < @backpressure_high_water ->
+        :ok
+
+      _ ->
+        wait_for_drain(parent, System.monotonic_time(:millisecond))
+    end
+  end
+
+  defp wait_for_drain(parent, started_at) do
+    case message_queue_len(parent) do
+      n when n < @backpressure_low_water ->
+        :ok
+
+      n ->
+        if System.monotonic_time(:millisecond) - started_at > @backpressure_max_wait_ms do
+          {:error, :backpressure_timeout, n}
+        else
+          Process.sleep(5)
+          wait_for_drain(parent, started_at)
+        end
+    end
+  end
+
+  defp message_queue_len(pid) do
+    case Process.info(pid, :message_queue_len) do
+      {:message_queue_len, n} -> n
+      # parent already gone — let the next send/2 fail and surface that
+      nil -> 0
+    end
   end
 
   # Get the next batch of events.

--- a/lib/nous/http/stream_backend/req.ex
+++ b/lib/nous/http/stream_backend/req.ex
@@ -72,7 +72,11 @@ defmodule Nous.HTTP.StreamBackend.Req do
   end
 
   defp start_request_task(url, body, headers, timeout, finch_name, parent, ref) do
-    Task.async(fn ->
+    # Run under Nous.TaskSupervisor (async_nolink) so the streaming task
+    # is supervised — graceful shutdown gets a chance to send :EXIT, and
+    # neither the producer task nor the consuming caller takes the other
+    # down on crash. The consumer monitors the task pid for completion.
+    Task.Supervisor.async_nolink(Nous.TaskSupervisor, fn ->
       result =
         Req.post(url,
           json: body,

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -257,8 +257,13 @@ defmodule Nous.LLM do
                 {chunks, {new_messages, iteration + 1}}
               end
 
-            {:error, _} ->
-              {:halt, :done}
+            {:error, reason} ->
+              # Surface the failure as an event before halting. Previously
+              # this silently :halt'd, so a consumer iterating the stream
+              # saw it cleanly terminate with no signal that the LLM call
+              # had actually failed.
+              Logger.warning("LLM stream failed: #{inspect(reason)}; emitting :error event")
+              {[{:error, reason}], :done}
           end
       end,
       fn _ -> :ok end

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -360,7 +360,7 @@ defmodule Nous.LLM do
           "Error: Unknown tool '#{name}'"
         end
 
-      Message.tool(id, result)
+      Message.tool(id, result, name: name)
     end)
   end
 

--- a/lib/nous/memory/embedding/bumblebee.ex
+++ b/lib/nous/memory/embedding/bumblebee.ex
@@ -127,12 +127,42 @@ if Code.ensure_loaded?(Bumblebee) do
 
     @doc "Run the serving on a single text input."
     def run(pid, text, timeout) do
-      GenServer.call(pid, {:run, text}, timeout)
+      # Fetch the serving struct via a cheap GenServer.call (returns the
+      # already-loaded reference, no inference inside the GenServer), then
+      # run Nx.Serving.run/2 in the CALLER process. This avoids serializing
+      # every embedding through the single holder process — Nx.Serving is
+      # designed to batch concurrent calls itself.
+      with {:ok, serving} <- get_serving(pid, timeout) do
+        try do
+          result = Nx.Serving.run(serving, text)
+          {:ok, result.embedding |> Nx.to_flat_list()}
+        rescue
+          e -> {:error, Exception.message(e)}
+        end
+      end
     end
 
     @doc "Run the serving on a batch of text inputs."
     def run_batch(pid, texts, timeout) do
-      GenServer.call(pid, {:run_batch, texts}, timeout)
+      with {:ok, serving} <- get_serving(pid, timeout) do
+        try do
+          results = Nx.Serving.run(serving, texts)
+
+          embeddings =
+            results.embedding
+            |> Nx.to_batched(1)
+            |> Enum.map(&Nx.to_flat_list/1)
+
+          {:ok, embeddings}
+        rescue
+          e -> {:error, Exception.message(e)}
+        end
+      end
+    end
+
+    @doc false
+    def get_serving(pid, timeout \\ 5_000) do
+      GenServer.call(pid, :get_serving, timeout)
     end
 
     @impl true
@@ -170,30 +200,11 @@ if Code.ensure_loaded?(Bumblebee) do
     end
 
     @impl true
-    def handle_call({:run, text}, _from, %{serving: serving} = state) do
-      try do
-        result = Nx.Serving.run(serving, text)
-        embedding = result.embedding |> Nx.to_flat_list()
-        {:reply, {:ok, embedding}, state}
-      rescue
-        e -> {:reply, {:error, Exception.message(e)}, state}
-      end
-    end
-
-    @impl true
-    def handle_call({:run_batch, texts}, _from, %{serving: serving} = state) do
-      try do
-        results = Nx.Serving.run(serving, texts)
-
-        embeddings =
-          results.embedding
-          |> Nx.to_batched(1)
-          |> Enum.map(&Nx.to_flat_list/1)
-
-        {:reply, {:ok, embeddings}, state}
-      rescue
-        e -> {:reply, {:error, Exception.message(e)}, state}
-      end
+    def handle_call(:get_serving, _from, %{serving: serving} = state) do
+      # Cheap accessor — returns the already-loaded Nx.Serving struct so
+      # callers run inference in parallel rather than serializing through
+      # this process. See run/3 / run_batch/3 above.
+      {:reply, {:ok, serving}, state}
     end
   end
 else

--- a/lib/nous/memory/store/sqlite.ex
+++ b/lib/nous/memory/store/sqlite.ex
@@ -217,11 +217,14 @@ if Code.ensure_loaded?(Exqlite) do
       LIMIT ?#{map_size(scope) + 2}
       """
 
-      # Escape FTS5 special characters by wrapping each term in double quotes
+      # Escape FTS5 special characters by wrapping each term in double quotes.
+      # FTS5 inside-quotes escape rule: an embedded `"` is written as `""`.
+      # Without this, a search term like `say "hi"` produced invalid FTS5
+      # syntax and the call errored.
       escaped_query =
         query
         |> String.split(~r/\s+/, trim: true)
-        |> Enum.map(&"\"#{&1}\"")
+        |> Enum.map(fn term -> "\"" <> String.replace(term, "\"", "\"\"") <> "\"" end)
         |> Enum.join(" ")
 
       params = scope_params ++ [escaped_query, limit]

--- a/lib/nous/messages/anthropic.ex
+++ b/lib/nous/messages/anthropic.ex
@@ -291,11 +291,18 @@ defmodule Nous.Messages.Anthropic do
   """
   @spec parse_usage(map() | nil) :: Usage.t()
   def parse_usage(usage_data) when is_map(usage_data) do
+    input = Map.get(usage_data, "input_tokens", 0)
+    output = Map.get(usage_data, "output_tokens", 0)
+    cache_creation = Map.get(usage_data, "cache_creation_input_tokens", 0)
+    cache_read = Map.get(usage_data, "cache_read_input_tokens", 0)
+
     %Usage{
-      input_tokens: Map.get(usage_data, "input_tokens", 0),
-      output_tokens: Map.get(usage_data, "output_tokens", 0),
-      total_tokens:
-        Map.get(usage_data, "input_tokens", 0) + Map.get(usage_data, "output_tokens", 0)
+      requests: 1,
+      input_tokens: input,
+      output_tokens: output,
+      total_tokens: input + output,
+      cache_creation_input_tokens: cache_creation,
+      cache_read_input_tokens: cache_read
     }
   end
 

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -175,8 +175,15 @@ defmodule Nous.Messages.Gemini do
     %{"role" => "model", "parts" => Enum.reverse(parts)}
   end
 
-  defp message_to_gemini(%Message{role: :tool, content: content, tool_call_id: tool_call_id}) do
-    # Gemini handles tool results as user messages with functionResponse
+  defp message_to_gemini(%Message{
+         role: :tool,
+         content: content,
+         tool_call_id: tool_call_id,
+         name: name
+       }) do
+    # Gemini's API requires functionResponse.name to match the original
+    # functionCall.name. Prefer the explicit :name field; fall back to
+    # tool_call_id only for legacy callers that didn't set it.
     response =
       case JSON.decode(content) do
         {:ok, decoded} -> decoded
@@ -189,7 +196,7 @@ defmodule Nous.Messages.Gemini do
       "parts" => [
         %{
           "functionResponse" => %{
-            "name" => tool_call_id,
+            "name" => name || tool_call_id,
             "response" => response
           }
         }
@@ -244,6 +251,15 @@ defmodule Nous.Messages.Gemini do
     %{"text" => ContentPart.to_text([part])}
   end
 
+  # Two parsers exist intentionally:
+  # - parse_content/1 is for API responses (from_response/1) and returns
+  #   ContentPart structs that are later consolidated; whitespace-only text
+  #   parts are dropped because Gemini emits them between tool calls.
+  # - parse_parts/1 is for round-tripping Gemini-format messages back into
+  #   our Message struct (from_messages/1) and returns plain joined strings.
+  # Do not consolidate these: from_response needs structured parts so the
+  # downstream tool-call/text ordering is preserved; from_messages flattens
+  # to text because the on-disk format is already user-edited.
   defp parse_content(parts_data) when is_list(parts_data) do
     {content_parts, reasoning_content, tool_calls} =
       Enum.reduce(parts_data, {[], [], []}, fn item, {parts, reasoning, tools} ->
@@ -514,9 +530,11 @@ defmodule Nous.Messages.Gemini do
   @spec parse_usage(map() | nil) :: Usage.t()
   def parse_usage(usage_data) when is_map(usage_data) do
     %Usage{
+      requests: 1,
       input_tokens: Map.get(usage_data, "promptTokenCount", 0),
       output_tokens: Map.get(usage_data, "candidatesTokenCount", 0),
-      total_tokens: Map.get(usage_data, "totalTokenCount", 0)
+      total_tokens: Map.get(usage_data, "totalTokenCount", 0),
+      cache_read_input_tokens: Map.get(usage_data, "cachedContentTokenCount", 0)
     }
   end
 

--- a/lib/nous/messages/openai.ex
+++ b/lib/nous/messages/openai.ex
@@ -211,36 +211,41 @@ defmodule Nous.Messages.OpenAI do
     name = Map.get(func, "name") || Map.get(func, :name)
     arguments = Map.get(func, "arguments") || Map.get(func, :arguments)
 
-    %{
-      "id" => id,
-      "name" => name,
-      "arguments" => decode_arguments(arguments)
-    }
+    case decode_arguments(arguments) do
+      {:ok, decoded} ->
+        %{"id" => id, "name" => name, "arguments" => decoded}
+
+      {:error, {:invalid_json, raw}} ->
+        %{"id" => id, "name" => name, "arguments" => %{}, "_invalid_arguments" => raw}
+    end
   end
 
   @doc """
   Decode an OpenAI tool-call `arguments` JSON string into a map.
 
-  Falls back to `%{"error" => "Invalid JSON arguments", "raw" => raw}` and logs a
-  warning when the JSON is malformed. Used by both the non-streaming response
-  parser and the streaming `ToolCallAccumulator`.
+  Returns `{:ok, map()}` on success, `{:error, {:invalid_json, raw}}` on
+  malformed JSON or non-object payload. Used by both the non-streaming
+  response parser and the streaming `ToolCallAccumulator`; callers tag the
+  tool_call with `"_invalid_arguments"` so the agent runner can surface a
+  proper error tool result instead of invoking the tool with bogus args.
   """
-  @spec decode_arguments(String.t() | nil) :: map()
-  def decode_arguments(nil), do: %{}
-  def decode_arguments(""), do: %{}
+  @spec decode_arguments(String.t() | nil) ::
+          {:ok, map()} | {:error, {:invalid_json, String.t()}}
+  def decode_arguments(nil), do: {:ok, %{}}
+  def decode_arguments(""), do: {:ok, %{}}
 
   def decode_arguments(arguments) when is_binary(arguments) do
     case JSON.decode(arguments) do
       {:ok, decoded_args} when is_map(decoded_args) ->
-        decoded_args
+        {:ok, decoded_args}
 
       {:ok, other} ->
         Logger.warning("Tool arguments decoded to non-map: #{inspect(other)}")
-        %{"error" => "Invalid JSON arguments", "raw" => arguments}
+        {:error, {:invalid_json, arguments}}
 
       {:error, _} ->
         Logger.warning("Failed to decode tool arguments: #{inspect(arguments)}")
-        %{"error" => "Invalid JSON arguments", "raw" => arguments}
+        {:error, {:invalid_json, arguments}}
     end
   end
 

--- a/lib/nous/plugins/input_guard.ex
+++ b/lib/nous/plugins/input_guard.ex
@@ -175,8 +175,9 @@ defmodule Nous.Plugins.InputGuard do
   end
 
   defp run_strategies(strategies, input, ctx, false = _short_circuit) do
-    strategies
-    |> Task.async_stream(
+    Task.Supervisor.async_stream_nolink(
+      Nous.TaskSupervisor,
+      strategies,
       fn {mod, opts} -> safe_check(mod, input, opts, ctx) end,
       timeout: 30_000,
       on_timeout: :kill_task

--- a/lib/nous/plugins/memory.ex
+++ b/lib/nous/plugins/memory.ex
@@ -101,43 +101,66 @@ defmodule Nous.Plugins.Memory do
     config = ctx.deps[:memory_config] || %{}
     store_mod = config[:store]
 
-    unless store_mod do
-      Logger.warning(
-        "Nous.Plugins.Memory: No :store configured in deps[:memory_config]. " <>
-          "Memory tools will not function."
-      )
+    cond do
+      is_nil(store_mod) ->
+        Logger.warning(
+          "Nous.Plugins.Memory: No :store configured in deps[:memory_config]. " <>
+            "Memory tools will not function."
+        )
 
-      ctx
-    else
-      store_opts = Map.get(config, :store_opts, [])
-      store_opts = if is_map(store_opts), do: Map.to_list(store_opts), else: store_opts
+        ctx
 
-      case store_mod.init(store_opts) do
-        {:ok, store_state} ->
-          updated_config =
-            config
-            |> Map.put(:store_state, store_state)
-            |> Map.put_new(:auto_inject, true)
-            |> Map.put_new(:inject_strategy, :first_only)
-            |> Map.put_new(:inject_limit, 5)
-            |> Map.put_new(:inject_min_score, 0.3)
-            |> Map.put_new(:decay_lambda, 0.001)
-            |> Map.put_new(:default_search_scope, :agent)
-            |> Map.put(:_inject_done, false)
-            |> Map.put_new(:auto_update_memory, false)
-            |> Map.put_new(:auto_update_every, 1)
-            |> Map.put_new(:reflection_max_tokens, 1000)
-            |> Map.put_new(:reflection_max_messages, 20)
-            |> Map.put_new(:reflection_max_memories, 50)
-            |> Map.put_new(:_run_count, 0)
+      Map.has_key?(config, :store_state) ->
+        # Plugin.init/2 is called on every agent run; calling store_mod.init/1
+        # again would create a fresh ETS table (or DB handle) per run, silently
+        # discarding everything stored on previous runs and leaking the prior
+        # table. Reuse the existing store_state and refresh per-run defaults.
+        updated_config =
+          config
+          |> apply_defaults()
+          |> Map.put(:_inject_done, false)
 
-          %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
+        %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
 
-        {:error, reason} ->
-          Logger.error("Nous.Plugins.Memory: Store init failed: #{inspect(reason)}")
-          ctx
-      end
+      true ->
+        do_init_store(store_mod, config, ctx)
     end
+  end
+
+  defp do_init_store(store_mod, config, ctx) do
+    store_opts = Map.get(config, :store_opts, [])
+    store_opts = if is_map(store_opts), do: Map.to_list(store_opts), else: store_opts
+
+    case store_mod.init(store_opts) do
+      {:ok, store_state} ->
+        updated_config =
+          config
+          |> Map.put(:store_state, store_state)
+          |> apply_defaults()
+          |> Map.put(:_inject_done, false)
+
+        %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
+
+      {:error, reason} ->
+        Logger.error("Nous.Plugins.Memory: Store init failed: #{inspect(reason)}")
+        ctx
+    end
+  end
+
+  defp apply_defaults(config) do
+    config
+    |> Map.put_new(:auto_inject, true)
+    |> Map.put_new(:inject_strategy, :first_only)
+    |> Map.put_new(:inject_limit, 5)
+    |> Map.put_new(:inject_min_score, 0.3)
+    |> Map.put_new(:decay_lambda, 0.001)
+    |> Map.put_new(:default_search_scope, :agent)
+    |> Map.put_new(:auto_update_memory, false)
+    |> Map.put_new(:auto_update_every, 1)
+    |> Map.put_new(:reflection_max_tokens, 1000)
+    |> Map.put_new(:reflection_max_messages, 20)
+    |> Map.put_new(:reflection_max_memories, 50)
+    |> Map.put_new(:_run_count, 0)
   end
 
   @impl true

--- a/lib/nous/providers/vertex_ai.ex
+++ b/lib/nous/providers/vertex_ai.ex
@@ -422,15 +422,9 @@ defmodule Nous.Providers.VertexAI do
     end
   end
 
-  # Validates a GCP project ID matches the expected format.
-  defp validate_project_id(nil) do
-    {:error,
-     %{
-       reason: :invalid_project_id,
-       message: "GOOGLE_CLOUD_PROJECT is not set."
-     }}
-  end
-
+  # Validates a GCP project ID matches the expected format. The `if project`
+  # guard in build_default_base_url/1 already filters out nil/false, so this
+  # function only ever sees a non-nil binary.
   defp validate_project_id(project) do
     if Regex.match?(~r/^[a-z][a-z0-9-]{4,28}[a-z0-9]$/, project) do
       {:ok, project}

--- a/lib/nous/research/coordinator.ex
+++ b/lib/nous/research/coordinator.ex
@@ -60,14 +60,14 @@ defmodule Nous.Research.Coordinator do
 
     timeout = Keyword.get(opts, :timeout, :timer.minutes(10))
 
-    # Run with timeout
-    task =
-      Task.async(fn ->
-        research_loop(state)
-      end)
+    # Run with timeout under the application TaskSupervisor so the work
+    # doesn't bring down its caller (and vice-versa) on crash, and so app
+    # shutdown can send graceful exits to in-flight research.
+    task = Task.Supervisor.async_nolink(Nous.TaskSupervisor, fn -> research_loop(state) end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
       {:ok, result} -> result
+      {:exit, reason} -> {:error, {:task_exit, reason}}
       nil -> {:error, :timeout}
     end
   end
@@ -75,23 +75,15 @@ defmodule Nous.Research.Coordinator do
   defp research_loop(state) do
     notify(state, {:research_progress, %{phase: :planning, iteration: state.iteration}})
 
-    # Phase 1: Plan
-    case plan_phase(state) do
-      {:ok, plan, state} ->
-        # Check HITL checkpoint for plan
-        case check_plan_approval(plan, state) do
-          :approve ->
-            execute_plan(plan, state)
+    # Phase 1: Plan. plan_phase/1 (and Planner.plan/2) currently always
+    # return {:ok, _} — planning errors are absorbed into a single-step
+    # fallback plan inside Planner.plan/2.
+    {:ok, plan, state} = plan_phase(state)
 
-          {:edit, modified_plan} ->
-            execute_plan(modified_plan, state)
-
-          :reject ->
-            {:error, :plan_rejected}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+    case check_plan_approval(plan, state) do
+      :approve -> execute_plan(plan, state)
+      {:edit, modified_plan} -> execute_plan(modified_plan, state)
+      :reject -> {:error, :plan_rejected}
     end
   end
 
@@ -186,8 +178,9 @@ defmodule Nous.Research.Coordinator do
 
   defp search_parallel(steps, model, search_tool, deps, state) do
     results =
-      steps
-      |> Task.async_stream(
+      Task.Supervisor.async_stream_nolink(
+        Nous.TaskSupervisor,
+        steps,
         fn step ->
           notify(state, {:research_finding, %{query: step.query, phase: :searching}})
 

--- a/lib/nous/research/planner.ex
+++ b/lib/nous/research/planner.ex
@@ -28,7 +28,11 @@ defmodule Nous.Research.Planner do
 
   Uses an LLM to decompose the query into searchable sub-questions.
   """
-  @spec plan(String.t(), keyword()) :: {:ok, plan()} | {:error, term()}
+  # Always returns {:ok, _}: planning failures fall back to a single-step
+  # plan using the original query as-is. The error branch in the
+  # LLM-call case below logs the underlying reason and then wraps the
+  # query as a one-step plan.
+  @spec plan(String.t(), keyword()) :: {:ok, plan()}
   def plan(query, opts \\ []) do
     model = Keyword.get(opts, :model, "openai:gpt-4o-mini")
     strategy = Keyword.get(opts, :strategy, :parallel)

--- a/lib/nous/stream_normalizer/tool_call_accumulator.ex
+++ b/lib/nous/stream_normalizer/tool_call_accumulator.ex
@@ -99,10 +99,13 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulator do
 
   def feed(acc, %{"_phase" => :stop, "_index" => _index}), do: acc
 
-  # Gemini: already-complete tool call
+  # Gemini: already-complete tool call. Gemini's API does not return tool-call
+  # IDs, so we synthesize one in the same `"gemini_<base64>"` shape as the
+  # non-streaming parser (`Nous.Messages.Gemini.generate_tool_call_id/0`) to
+  # keep stream and non-stream paths consistent for downstream linking.
   def feed(acc, %{"name" => name, "arguments" => arguments}) when is_map(arguments) do
     call = %{
-      "id" => Map.get(acc, "id"),
+      "id" => generate_gemini_id(),
       "name" => name,
       "arguments" => arguments
     }
@@ -142,15 +145,20 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulator do
 
   defp feed_openai_one(_, acc), do: acc
 
+  defp generate_gemini_id do
+    "gemini_" <> (:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false))
+  end
+
   @doc """
   Finalize the accumulator into a list of tool calls in the unified shape:
 
       [%{"id" => id_or_nil, "name" => name, "arguments" => decoded_map}, ...]
 
   OpenAI and Anthropic argument buffers are JSON-decoded via
-  `Nous.Messages.OpenAI.decode_arguments/1` (which logs a warning and falls
-  back to `%{"error" => "Invalid JSON arguments", "raw" => raw}` on
-  malformed JSON). Gemini calls already carry decoded `arguments`.
+  `Nous.Messages.OpenAI.decode_arguments/1`. On malformed JSON the tool call
+  is tagged with `"_invalid_arguments" => raw` so the agent runner can emit
+  a clean tool-error result instead of invoking the tool with bogus args.
+  Gemini calls already carry decoded `arguments`.
 
   Order: OpenAI calls sorted by index, then Anthropic calls sorted by
   `_index`, then Gemini calls in arrival order. In practice only one of the
@@ -167,11 +175,15 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulator do
     map
     |> Enum.sort_by(fn {index, _} -> index end)
     |> Enum.map(fn {_index, %{id: id, name: name, args_io: args_io}} ->
-      %{
-        "id" => id,
-        "name" => name,
-        "arguments" => OpenAIMessages.decode_arguments(IO.iodata_to_binary(args_io))
-      }
+      raw = IO.iodata_to_binary(args_io)
+
+      case OpenAIMessages.decode_arguments(raw) do
+        {:ok, decoded} ->
+          %{"id" => id, "name" => name, "arguments" => decoded}
+
+        {:error, {:invalid_json, raw}} ->
+          %{"id" => id, "name" => name, "arguments" => %{}, "_invalid_arguments" => raw}
+      end
     end)
   end
 end

--- a/lib/nous/telemetry.ex
+++ b/lib/nous/telemetry.ex
@@ -50,10 +50,6 @@ defmodule Nous.Telemetry do
       * Measurement: `%{duration: native_time}`
       * Metadata: `%{provider: atom, model_name: string}`
 
-    * `[:nous, :provider, :stream, :chunk]` - Dispatched when a stream chunk is received
-      * Measurement: `%{chunk_size: integer}`
-      * Metadata: `%{provider: atom, model_name: string, chunk_type: atom}`
-
     * `[:nous, :provider, :stream, :exception]` - Dispatched when streaming request fails
       * Measurement: `%{duration: native_time}`
       * Metadata: `%{provider: atom, model_name: string, kind: atom, reason: term}`
@@ -87,6 +83,41 @@ defmodule Nous.Telemetry do
     * `[:nous, :callback, :execute]` - Dispatched when a callback is executed
       * Measurement: `%{duration: native_time}`
       * Metadata: `%{callback_type: atom, agent_name: string}`
+
+  ## Fallback Events
+
+    * `[:nous, :agent, :fallback, :used]` - Dispatched when an iteration switches
+      to a fallback model (sticky-fallback). Use this to alert on provider
+      degradation.
+      * Measurement: `%{system_time: native_time}`
+      * Metadata: `%{agent_name, original_provider, original_model, active_provider, active_model}`
+
+    * `[:nous, :fallback, :activated]` - Dispatched when the fallback chain
+      promotes to the next model after the primary returns an error.
+      * Measurement: depends on the call site
+      * Metadata: includes the active model and the reason for activation
+
+  ## Hook Events
+
+    * `[:nous, :hook, :execute, :start]` / `[:nous, :hook, :execute, :stop]`
+      * Measurement: `%{system_time | duration}`
+      * Metadata: `%{event, hook_name, hook_type, result?}`
+    * `[:nous, :hook, :denied]` - emitted when a blocking hook returns :deny
+      or when a fail_closed hook errors.
+      * Metadata: `%{event, hook_name, hook_type, reason?}`
+
+  ## Skill Events
+
+    * `[:nous, :skill, :activate]` / `[:nous, :skill, :deactivate]`
+      * Metadata: `%{skill_name, agent_name}`
+
+  ## Workflow Events
+
+    * `[:nous, :workflow, :run, :start]` / `[:nous, :workflow, :run, :stop]`
+      / `[:nous, :workflow, :run, :exception]`
+    * `[:nous, :workflow, :node, :start]` / `[:nous, :workflow, :node, :stop]`
+      / `[:nous, :workflow, :node, :exception]`
+      * See `Nous.Workflow.Telemetry` for full measurement/metadata payloads.
 
   All times are in `:native` time unit. Use `System.convert_time_unit/3` to
   convert to desired unit.
@@ -174,7 +205,6 @@ defmodule Nous.Telemetry do
       [:nous, :provider, :request, :exception],
       [:nous, :provider, :stream, :start],
       [:nous, :provider, :stream, :connected],
-      [:nous, :provider, :stream, :chunk],
       [:nous, :provider, :stream, :exception],
       # Tool events
       [:nous, :tool, :execute, :start],
@@ -313,14 +343,6 @@ defmodule Nous.Telemetry do
     Logger.debug(
       "[Nous] Agent #{metadata.agent_name} iteration #{metadata.iteration} completed in #{duration_ms}ms" <>
         " (#{metadata.tool_calls} tool calls)#{continue_msg}"
-    )
-  end
-
-  # Stream chunk event
-  defp handle_event([:nous, :provider, :stream, :chunk], measurements, metadata, _config) do
-    Logger.debug(
-      "[Nous] Stream chunk from #{metadata.provider}:#{metadata.model_name} " <>
-        "(#{measurements.chunk_size} bytes, type: #{metadata.chunk_type})"
     )
   end
 

--- a/lib/nous/tool/context_update.ex
+++ b/lib/nous/tool/context_update.ex
@@ -157,8 +157,24 @@ defmodule Nous.Tool.ContextUpdate do
   @spec apply(t(), Nous.Agent.Context.t()) :: Nous.Agent.Context.t()
   def apply(%__MODULE__{operations: ops}, %Nous.Agent.Context{} = ctx) do
     new_deps = Enum.reduce(ops, ctx.deps || %{}, &apply_operation/2)
+
+    keys =
+      ops
+      |> Enum.map(&op_key/1)
+      |> Enum.uniq()
+
+    :telemetry.execute(
+      [:nous, :context, :update],
+      %{keys_updated: length(keys)},
+      %{agent_name: ctx.agent_name, keys: keys}
+    )
+
     %{ctx | deps: new_deps}
   end
+
+  defp op_key({_op, key, _value}), do: key
+  defp op_key({_op, key}), do: key
+  defp op_key(_), do: nil
 
   @doc """
   Apply all operations to a RunContext, returning the updated context.

--- a/lib/nous/tool/validator.ex
+++ b/lib/nous/tool/validator.ex
@@ -116,29 +116,16 @@ defmodule Nous.Tool.Validator do
   @spec validate_types(map(), map()) :: :ok | {:error, {:type_mismatch, list()}}
   def validate_types(args, properties) when is_map(args) and is_map(properties) do
     errors =
-      args
-      |> Enum.reduce([], fn {key, value}, acc ->
+      Enum.reduce(args, [], fn {key, value}, acc ->
         case Map.get(properties, key) do
           nil ->
             # Unknown keys are allowed (additionalProperties: true by default)
             acc
 
-          %{"type" => expected_type} ->
-            if matches_type?(value, expected_type) do
-              acc
-            else
-              [{key, expected_type, typeof(value)} | acc]
-            end
-
-          %{"enum" => allowed_values} ->
-            if value in allowed_values do
-              acc
-            else
-              [{key, "enum:#{inspect(allowed_values)}", inspect(value)} | acc]
-            end
+          schema when is_map(schema) ->
+            check_schema(key, value, schema, acc)
 
           _other ->
-            # Schema without type constraint
             acc
         end
       end)
@@ -149,6 +136,36 @@ defmodule Nous.Tool.Validator do
       {:error, {:type_mismatch, Enum.reverse(errors)}}
     end
   end
+
+  # Apply ALL constraints present on a property schema, not just the first
+  # one matched. Previously `%{"type" => _}` matched before `%{"enum" => _}`,
+  # so a schema like `%{"type" => "string", "enum" => ["a","b"]}` validated
+  # only the type and silently dropped the enum constraint.
+  defp check_schema(key, value, schema, acc) do
+    acc
+    |> maybe_check_type(key, value, schema)
+    |> maybe_check_enum(key, value, schema)
+  end
+
+  defp maybe_check_type(acc, key, value, %{"type" => expected_type}) do
+    if matches_type?(value, expected_type) do
+      acc
+    else
+      [{key, expected_type, typeof(value)} | acc]
+    end
+  end
+
+  defp maybe_check_type(acc, _key, _value, _schema), do: acc
+
+  defp maybe_check_enum(acc, key, value, %{"enum" => allowed_values}) do
+    if value in allowed_values do
+      acc
+    else
+      [{key, "enum:#{inspect(allowed_values)}", inspect(value)} | acc]
+    end
+  end
+
+  defp maybe_check_enum(acc, _key, _value, _schema), do: acc
 
   @doc """
   Check if a value matches a JSON schema type.

--- a/lib/nous/tool_schema.ex
+++ b/lib/nous/tool_schema.ex
@@ -25,7 +25,12 @@ defmodule Nous.ToolSchema do
 
   @doc """
   Convert tool to OpenAI function calling schema (string keys).
+
+  Deprecated alias — call `Nous.Tool.to_openai_schema/1` directly. This
+  module's `to_anthropic/1` and `to_gemini/1` are the actively used
+  conversions; `to_openai/1` is only kept for backward compatibility.
   """
+  @deprecated "Use Nous.Tool.to_openai_schema/1 directly"
   @spec to_openai(Tool.t()) :: map()
   def to_openai(tool) do
     Tool.to_openai_schema(tool)

--- a/lib/nous/tools/search_scrape.ex
+++ b/lib/nous/tools/search_scrape.ex
@@ -44,9 +44,9 @@ defmodule Nous.Tools.SearchScrape do
       %{results: [], error: "No URLs provided"}
     else
       results =
-        urls
-        |> Enum.take(concurrency)
-        |> Task.async_stream(
+        Task.Supervisor.async_stream_nolink(
+          Nous.TaskSupervisor,
+          Enum.take(urls, concurrency),
           fn url -> fetch_and_summarize(ctx, url, query) end,
           max_concurrency: concurrency,
           timeout: timeout,

--- a/lib/nous/usage.ex
+++ b/lib/nous/usage.ex
@@ -19,7 +19,9 @@ defmodule Nous.Usage do
           tool_calls: non_neg_integer(),
           input_tokens: non_neg_integer(),
           output_tokens: non_neg_integer(),
-          total_tokens: non_neg_integer()
+          total_tokens: non_neg_integer(),
+          cache_creation_input_tokens: non_neg_integer(),
+          cache_read_input_tokens: non_neg_integer()
         }
 
   @enforce_keys []
@@ -27,7 +29,9 @@ defmodule Nous.Usage do
             tool_calls: 0,
             input_tokens: 0,
             output_tokens: 0,
-            total_tokens: 0
+            total_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0
 
   @doc """
   Create a new empty usage tracker.
@@ -61,7 +65,10 @@ defmodule Nous.Usage do
       tool_calls: u1.tool_calls + u2.tool_calls,
       input_tokens: u1.input_tokens + u2.input_tokens,
       output_tokens: u1.output_tokens + u2.output_tokens,
-      total_tokens: u1.total_tokens + u2.total_tokens
+      total_tokens: u1.total_tokens + u2.total_tokens,
+      cache_creation_input_tokens:
+        u1.cache_creation_input_tokens + u2.cache_creation_input_tokens,
+      cache_read_input_tokens: u1.cache_read_input_tokens + u2.cache_read_input_tokens
     }
   end
 

--- a/lib/nous/workflow/checkpoint.ex
+++ b/lib/nous/workflow/checkpoint.ex
@@ -77,36 +77,59 @@ defmodule Nous.Workflow.Checkpoint.ETS do
   @moduledoc """
   ETS-backed checkpoint store. Suitable for development and testing.
 
-  Note: Data is lost on process/node restart. For production, use a
-  persistent backend.
+  The table is owned by a supervised TableOwner GenServer started under the
+  Nous application supervisor. Without it the table would die with whichever
+  transient process happened to create it first, silently losing every
+  suspended workflow that relied on resume.
+
+  Note: Data is lost on node restart. For production, use a persistent
+  backend.
   """
 
   @behaviour Nous.Workflow.Checkpoint.Store
 
   @table :nous_workflow_checkpoints
 
-  @doc """
-  Initialize the ETS table. Call once at application start.
-  """
-  @spec init() :: :ok
-  def init do
-    if :ets.whereis(@table) == :undefined do
-      :ets.new(@table, [:named_table, :set, :public])
+  defmodule TableOwner do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_opts) do
+      GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
     end
 
-    :ok
+    @impl true
+    def init(:ok) do
+      table_name = :nous_workflow_checkpoints
+
+      table =
+        case :ets.whereis(table_name) do
+          :undefined ->
+            :ets.new(table_name, [:named_table, :set, :public, read_concurrency: true])
+
+          _ref ->
+            table_name
+        end
+
+      {:ok, %{table: table}}
+    end
+  end
+
+  @doc false
+  def child_spec(_opts) do
+    %{id: __MODULE__, start: {TableOwner, :start_link, [[]]}, type: :worker}
   end
 
   @impl true
   def save(checkpoint) do
-    init()
+    ensure_table()
     :ets.insert(@table, {checkpoint.run_id, checkpoint})
     :ok
   end
 
   @impl true
   def load(run_id) do
-    init()
+    ensure_table()
 
     case :ets.lookup(@table, run_id) do
       [{^run_id, checkpoint}] -> {:ok, checkpoint}
@@ -116,7 +139,7 @@ defmodule Nous.Workflow.Checkpoint.ETS do
 
   @impl true
   def list(workflow_id) do
-    init()
+    ensure_table()
 
     checkpoints =
       :ets.tab2list(@table)
@@ -129,8 +152,24 @@ defmodule Nous.Workflow.Checkpoint.ETS do
 
   @impl true
   def delete(run_id) do
-    init()
+    ensure_table()
     :ets.delete(@table, run_id)
     :ok
+  end
+
+  # Fallback for callers used before the supervisor started the owner
+  # (mainly ad-hoc tests). Production code goes through TableOwner.
+  defp ensure_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        try do
+          :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+        rescue
+          ArgumentError -> :ok
+        end
+
+      _ref ->
+        :ok
+    end
   end
 end

--- a/test/nous/hook/runner_test.exs
+++ b/test/nous/hook/runner_test.exs
@@ -12,7 +12,8 @@ defmodule Nous.Hook.RunnerTest do
       matcher: Keyword.get(opts, :matcher),
       priority: Keyword.get(opts, :priority, 100),
       timeout: Keyword.get(opts, :timeout, 10_000),
-      name: Keyword.get(opts, :name)
+      name: Keyword.get(opts, :name),
+      fail_closed: Keyword.get(opts, :fail_closed, false)
     }
   end
 
@@ -112,10 +113,20 @@ defmodule Nous.Hook.RunnerTest do
       assert Runner.run(registry, :pre_tool_use, %{tool_name: "test", arguments: %{}}) == :allow
     end
 
-    test "errors fail open" do
+    test "errors fail open by default" do
       hook = make_hook(:pre_tool_use, fn _, _ -> raise "boom" end)
       registry = Registry.from_hooks([hook])
       assert Runner.run(registry, :pre_tool_use, %{tool_name: "test"}) == :allow
+    end
+
+    test "errors fail closed when fail_closed: true" do
+      # Security-sensitive hooks opt in to fail-closed so a crashing
+      # deny-hook can't be silently bypassed.
+      hook = make_hook(:pre_tool_use, fn _, _ -> raise "boom" end, fail_closed: true)
+      registry = Registry.from_hooks([hook])
+
+      assert {:deny, reason} = Runner.run(registry, :pre_tool_use, %{tool_name: "test"})
+      assert reason =~ "fail_closed"
     end
   end
 

--- a/test/nous/llm_test.exs
+++ b/test/nous/llm_test.exs
@@ -43,6 +43,16 @@ defmodule Nous.LLMTest do
     end
   end
 
+  defmodule FailingStreamDispatcher do
+    @moduledoc false
+
+    def request(_model, _messages, _settings),
+      do: {:error, %Nous.Errors.ModelError{message: "boom", provider: :test}}
+
+    def request_stream(_model, _messages, _settings),
+      do: {:error, %Nous.Errors.ModelError{message: "boom", provider: :test}}
+  end
+
   setup do
     CapturingDispatcher.configure()
     prev = Application.get_env(:nous, :model_dispatcher)
@@ -113,6 +123,32 @@ defmodule Nous.LLMTest do
 
       [captured] = CapturingDispatcher.get_models()
       assert captured.receive_timeout == 600_000
+    end
+  end
+
+  describe "stream_text/3 with tools surfaces dispatcher errors" do
+    test "emits an {:error, _} event instead of silently halting" do
+      # Before fix: stream_text_with_tools silently :halt'd on Fallback error,
+      # so the consumer saw a clean empty stream with no signal that the LLM
+      # call had failed. Now an {:error, _} event is emitted before halt.
+      Application.put_env(:nous, :model_dispatcher, FailingStreamDispatcher)
+
+      tool = %Nous.Tool{
+        name: "noop",
+        description: "no-op for test",
+        parameters: %{type: "object", properties: %{}},
+        function: fn _, _ -> {:ok, "x"} end,
+        takes_ctx: false
+      }
+
+      {:ok, stream} = Nous.LLM.stream_text("openai:gpt-4", "hi", tools: [tool])
+      events = Enum.to_list(stream)
+
+      assert Enum.any?(events, fn
+               {:error, _} -> true
+               _ -> false
+             end),
+             "stream should emit an {:error, _} event when the dispatcher fails, got: #{inspect(events)}"
     end
   end
 end

--- a/test/nous/messages_gemini_test.exs
+++ b/test/nous/messages_gemini_test.exs
@@ -330,6 +330,23 @@ defmodule Nous.MessagesGeminiTest do
       assert part["functionResponse"]["response"] == %{"temp" => 22}
     end
 
+    test "functionResponse.name uses :name field, not tool_call_id" do
+      # Gemini's API requires functionResponse.name to equal the original
+      # functionCall.name. The call_id is opaque and may be a random string.
+      messages = [
+        Message.new!(%{
+          role: :tool,
+          content: ~s({"temp": 22}),
+          tool_call_id: "gemini_abc123",
+          name: "get_weather"
+        })
+      ]
+
+      {_sys, [msg]} = Gemini.to_format(messages)
+      [part] = msg["parts"]
+      assert part["functionResponse"]["name"] == "get_weather"
+    end
+
     test "wraps plain text tool result" do
       messages = [
         Message.new!(%{

--- a/test/nous/messages_generic_helpers_test.exs
+++ b/test/nous/messages_generic_helpers_test.exs
@@ -585,8 +585,8 @@ defmodule Nous.MessagesGenericHelpersTest do
       assert [tool_call] = tool_calls
       assert tool_call["id"] == "call_invalid"
       assert tool_call["name"] == "test_tool"
-      assert tool_call["arguments"]["error"] == "Invalid JSON arguments"
-      assert tool_call["arguments"]["raw"] == "invalid json {"
+      assert tool_call["arguments"] == %{}
+      assert tool_call["_invalid_arguments"] == "invalid json {"
     end
 
     test "handles complex multi-modal content" do

--- a/test/nous/messages_openai_test.exs
+++ b/test/nous/messages_openai_test.exs
@@ -1,0 +1,57 @@
+defmodule Nous.MessagesOpenAITest do
+  use ExUnit.Case, async: true
+  alias Nous.Messages.OpenAI
+
+  describe "decode_arguments/1" do
+    test "returns {:ok, map} for valid JSON object" do
+      assert {:ok, %{"city" => "Paris"}} = OpenAI.decode_arguments(~s({"city":"Paris"}))
+    end
+
+    test "returns {:ok, %{}} for nil or empty string" do
+      assert {:ok, %{}} == OpenAI.decode_arguments(nil)
+      assert {:ok, %{}} == OpenAI.decode_arguments("")
+    end
+
+    test "returns {:error, {:invalid_json, raw}} for malformed JSON" do
+      assert {:error, {:invalid_json, "{not json"}} == OpenAI.decode_arguments("{not json")
+    end
+
+    test "returns {:error, {:invalid_json, raw}} for JSON that isn't an object" do
+      assert {:error, {:invalid_json, "[1,2,3]"}} == OpenAI.decode_arguments("[1,2,3]")
+    end
+  end
+
+  describe "from_response with malformed tool_call arguments" do
+    test "tags the tool_call with _invalid_arguments instead of injecting fake args" do
+      response = %{
+        "choices" => [
+          %{
+            "message" => %{
+              "role" => "assistant",
+              "tool_calls" => [
+                %{
+                  "id" => "call_1",
+                  "function" => %{
+                    "name" => "get_weather",
+                    "arguments" => "{not json"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "model" => "gpt-4"
+      }
+
+      msg = OpenAI.from_response(response)
+      [call] = msg.tool_calls
+
+      assert call["name"] == "get_weather"
+      # arguments should NOT contain the synthetic "error"/"raw" map that
+      # would have been passed straight to the tool function.
+      refute Map.has_key?(call["arguments"], "error")
+      assert call["arguments"] == %{}
+      assert call["_invalid_arguments"] == "{not json"
+    end
+  end
+end

--- a/test/nous/plugins/memory_test.exs
+++ b/test/nous/plugins/memory_test.exs
@@ -40,6 +40,21 @@ defmodule Nous.Plugins.MemoryTest do
       assert result == ctx
     end
 
+    test "reuses existing store_state across runs instead of re-initializing",
+         %{agent: agent, ctx: ctx} do
+      # First run sets up the store.
+      ctx = MemoryPlugin.init(agent, ctx)
+      first_store_state = ctx.deps[:memory_config][:store_state]
+
+      # Second run on the same context (e.g. AgentRunner re-invoking init
+      # on subsequent calls) must NOT call store_mod.init/1 again, which
+      # would create a fresh ETS table and silently discard memories.
+      ctx = MemoryPlugin.init(agent, ctx)
+      second_store_state = ctx.deps[:memory_config][:store_state]
+
+      assert second_store_state == first_store_state
+    end
+
     test "respects custom config values", %{agent: agent} do
       config = %{
         store: Store.ETS,

--- a/test/nous/stream_normalizer/gemini_test.exs
+++ b/test/nous/stream_normalizer/gemini_test.exs
@@ -305,7 +305,15 @@ defmodule Nous.StreamNormalizer.GeminiTest do
       events = Gemini.normalize_chunk(chunk)
 
       assert {:text_delta, "hi"} in events
-      assert {:usage, %Nous.Usage{input_tokens: 4, output_tokens: 2, total_tokens: 6}} in events
+
+      assert Enum.any?(events, fn
+               {:usage,
+                %Nous.Usage{requests: 1, input_tokens: 4, output_tokens: 2, total_tokens: 6}} ->
+                 true
+
+               _ ->
+                 false
+             end)
     end
 
     test "missing usageMetadata produces no usage event" do

--- a/test/nous/stream_normalizer/tool_call_accumulator_test.exs
+++ b/test/nous/stream_normalizer/tool_call_accumulator_test.exs
@@ -76,7 +76,7 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulatorTest do
       assert [%{"arguments" => %{}}] = Accumulator.finalize(acc)
     end
 
-    test "malformed JSON falls back to error map with raw payload" do
+    test "malformed JSON tags tool call with _invalid_arguments and empty args" do
       acc =
         Accumulator.feed(Accumulator.new(), [
           %{
@@ -86,8 +86,12 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulatorTest do
           }
         ])
 
-      assert [%{"arguments" => %{"error" => "Invalid JSON arguments", "raw" => "{invalid"}}] =
-               Accumulator.finalize(acc)
+      assert [
+               %{
+                 "arguments" => %{},
+                 "_invalid_arguments" => "{invalid"
+               }
+             ] = Accumulator.finalize(acc)
     end
 
     test "atom-keyed fragments are accepted" do
@@ -191,15 +195,18 @@ defmodule Nous.StreamNormalizer.ToolCallAccumulatorTest do
   end
 
   describe "Gemini shape" do
-    test "already-complete functionCall is passed through" do
+    test "already-complete functionCall synthesizes an id matching the non-streaming format" do
       acc =
         Accumulator.feed(Accumulator.new(), %{
           "name" => "search",
           "arguments" => %{"query" => "elixir"}
         })
 
-      assert [%{"id" => nil, "name" => "search", "arguments" => %{"query" => "elixir"}}] =
+      assert [%{"id" => id, "name" => "search", "arguments" => %{"query" => "elixir"}}] =
                Accumulator.finalize(acc)
+
+      assert is_binary(id) and String.starts_with?(id, "gemini_"),
+             "streaming Gemini tool calls should carry a synthesized gemini_* id like the non-streaming parser"
     end
 
     test "multiple sequential calls preserve arrival order" do

--- a/test/nous/tool/validator_test.exs
+++ b/test/nous/tool/validator_test.exs
@@ -1,0 +1,54 @@
+defmodule Nous.Tool.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.Tool.Validator
+
+  describe "validate_types/2" do
+    test "accepts values matching the declared type" do
+      props = %{"count" => %{"type" => "integer"}}
+      assert :ok = Validator.validate_types(%{"count" => 5}, props)
+    end
+
+    test "rejects values whose type does not match" do
+      props = %{"count" => %{"type" => "integer"}}
+
+      assert {:error, {:type_mismatch, [{"count", "integer", "string"}]}} =
+               Validator.validate_types(%{"count" => "five"}, props)
+    end
+
+    test "enforces enum even when type is also declared" do
+      # Before fix: %{"type" => _} clause matched before %{"enum" => _} so the
+      # enum constraint was silently dropped — a tool restricted to
+      # ["low", "high"] would accept any other string.
+      props = %{"level" => %{"type" => "string", "enum" => ["low", "high"]}}
+
+      assert :ok = Validator.validate_types(%{"level" => "low"}, props)
+
+      assert {:error, {:type_mismatch, _}} =
+               Validator.validate_types(%{"level" => "weird"}, props)
+    end
+
+    test "enforces enum when type is absent" do
+      props = %{"level" => %{"enum" => [:a, :b]}}
+      assert :ok = Validator.validate_types(%{"level" => :a}, props)
+      assert {:error, _} = Validator.validate_types(%{"level" => :c}, props)
+    end
+
+    test "reports type and enum violations independently" do
+      props = %{"level" => %{"type" => "string", "enum" => ["a", "b"]}}
+      # Integer value violates BOTH the string type AND the enum.
+      assert {:error, {:type_mismatch, errors}} =
+               Validator.validate_types(%{"level" => 1}, props)
+
+      keys = Enum.map(errors, fn {k, _, _} -> k end)
+      assert "level" in keys
+      # Two failures for the same field — once for type, once for enum.
+      assert length(Enum.filter(errors, fn {k, _, _} -> k == "level" end)) == 2
+    end
+
+    test "ignores keys not declared in properties (additionalProperties: true)" do
+      props = %{"declared" => %{"type" => "string"}}
+      assert :ok = Validator.validate_types(%{"undeclared" => 123}, props)
+    end
+  end
+end

--- a/test/nous/workflow/phase4_test.exs
+++ b/test/nous/workflow/phase4_test.exs
@@ -235,5 +235,27 @@ defmodule Nous.Workflow.Phase4Test do
       Store.delete(cp.run_id)
       assert {:error, :not_found} = Store.load(cp.run_id)
     end
+
+    test "checkpoint survives crash of the saving process" do
+      # Before fix: the ETS table was owned by whichever process first called
+      # Store.save/init. When that process died, the table died with it and
+      # init/0 silently recreated an empty one — silently losing every
+      # suspended workflow that depended on resume.
+      state = Nous.Workflow.State.new(%{x: 42})
+      cp = Checkpoint.new(%{workflow_id: "wf_crash", node_id: "n", state: state})
+
+      task =
+        Task.async(fn ->
+          :ok = Store.save(cp)
+          cp.run_id
+        end)
+
+      run_id = Task.await(task)
+      # Task is dead now. If the ETS table was owned by it, the table is gone.
+      refute Process.alive?(task.pid)
+
+      assert {:ok, loaded} = Store.load(run_id)
+      assert loaded.state.data.x == 42
+    end
   end
 end

--- a/test/nous/workflow/phase5_test.exs
+++ b/test/nous/workflow/phase5_test.exs
@@ -263,5 +263,43 @@ defmodule Nous.Workflow.Phase5Test do
       scratch = Scratch.new()
       assert Scratch.cleanup(scratch) == :ok
     end
+
+    test "scratch ETS table is cleaned up even when a node raises" do
+      # Before fix: if execute_loop raised mid-workflow, the
+      # `unless suspended?, do: maybe_cleanup_scratch(...)` line never ran,
+      # so the :"nous_scratch_<id>" table leaked. Long-running supervisors
+      # that retry on failure would eventually OOM via ets_too_many_tables.
+      alias Nous.Workflow
+      alias Nous.Workflow.Graph
+
+      graph =
+        Graph.new("leak_check")
+        |> Graph.add_node(:boom, :transform, tf(fn _ -> raise "boom" end))
+        |> Graph.set_entry(:boom)
+
+      # Count :nous_scratch_* ETS tables before and after a workflow that
+      # raises with `scratch: true`. They must match.
+      scratch_table_count = fn ->
+        :ets.all()
+        |> Enum.count(fn t ->
+          case :ets.info(t, :name) do
+            name when is_atom(name) ->
+              name |> Atom.to_string() |> String.starts_with?("nous_scratch_")
+
+            _ ->
+              false
+          end
+        end)
+      end
+
+      before_count = scratch_table_count.()
+
+      assert {:error, _} = Workflow.run(graph, %{}, scratch: true)
+
+      after_count = scratch_table_count.()
+
+      assert after_count == before_count,
+             "scratch ETS table leaked when the workflow raised"
+    end
   end
 end


### PR DESCRIPTION
## Summary

  Comprehensive bug-fix pass driven by a parallel multi-agent code audit (dead code / leaks / broken code / OTP concurrency lenses). Eleven logically-grouped commits, all
  individually verified with TDD where applicable.

  **1754 tests passing** (was 1737 — 17 new regression tests). **`mix compile --warnings-as-errors` is clean** in both dev and test envs.

  | #  | Commit     | Theme                                                                  |
  |----|------------|------------------------------------------------------------------------|
  | 1  | `1c1253c`  | Gemini tool name, OpenAI bad-JSON, Anthropic/Gemini usage, streaming tool-call id |
  | 2  | `3a8cc9e`  | Workflow checkpoint TableOwner, Memory plugin re-init, scratch cleanup test |
  | 3  | `d75dd6b`  | Migrate `Task.async` → `Task.Supervisor.async_nolink`; clear compile warnings |
  | 4  | `ea99c5d`  | AgentServer PubSub topic mismatch + terminate cancellation             |
  | 5  | `993af69`  | Hook `fail_closed:` opt-in + tool validator enum/type composition      |
  | 6  | `3fba62e`  | `LLM.stream_text_with_tools` emits `{:error, _}` instead of silent halt |
  | 7  | `4410fd5`  | Telemetry: emit documented events, document existing ones              |
  | 8  | `37002c3`  | Bumblebee serving holder, AgentRegistry partitions, async context load |
  | 9  | `23fca73`  | Req streaming backend backpressure guard (M-12)                        |
  | 10 | `65b7648`  | `@deprecated` on orphan public API + SQLite FTS5 escape                |
  | 11 | `9baa035`  | CHANGELOG                                                              |

  See `CHANGELOG.md` "Unreleased" for the full per-fix breakdown.

  ## Critical bugs fixed

  - **Every Gemini/Vertex tool roundtrip was malformed** — `functionResponse.name` carried the `tool_call_id` instead of the function name. Fixed by threading `:name`
  through `Message.tool/3`.
  - **OpenAI tool-call malformed JSON was passed to tools as bogus args** — now surfaced as a clean tool-error result the LLM can retry.
  - **Workflow checkpoints vanished when the saving process exited** — ETS table now owned by a supervised `TableOwner`.
  - **Memory plugin re-initialized its ETS store every agent run** — losing all memories across runs and leaking tables. Now reuses existing `store_state`.
  - **AgentServer subscribed to wrong PubSub topic** — anyone publishing via `Nous.PubSub.agent_topic/1` never reached it.
  - **AgentServer didn't cancel in-flight LLM streams on shutdown** — streams kept consuming tokens after the server was gone.

  ## Behavior-changing decisions

  - **Stream backend default:** added backpressure guard to Req (chosen over flipping the default to Hackney).
  - **Public API:** kept four orphaned functions, marked `@deprecated` (no removal in 0.x).
  - **Telemetry:** emit the missing events AND document the existing ones (reconcile both ways).

  ## Test plan

  - [x] `mix test` — 1754 / 1754 passing (3 doctests + 1751 tests, 101 excluded), ~4.2s
  - [x] `mix compile --warnings-as-errors` — clean in dev env
  - [x] `MIX_ENV=test mix compile --warnings-as-errors` — clean in test env
  - [x] 17 new regression tests written via TDD (Gemini name, OpenAI bad-JSON, checkpoint survival, memory re-init, Gemini stream id, validator enum, hook `fail_closed`,
  scratch cleanup, llm error emit)
  - [ ] Manual smoke test against a real Gemini API (the `functionResponse.name` fix is the highest-impact item)
  - [ ] Dialyzer (not run — no cached PLT; would take 10+ min to rebuild)