### PR TITLE
docs: follow-ups (CHANGELOG entries, silent mix docs, 4 new examples)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ The public API is `Nous.*` and `Nous.Tools.*`. These are NOT public:
 - `Nous.HTTP.Backend.*` — internal; use `HTTP.post/4`'s `:backend` opt instead
 - `Nous.Providers.HTTP` — internal helper for provider authors
 - `Nous.AgentRunner`, `Nous.AgentServer` — internal supervision; use `Nous.run/3`
-- `Nous.Application`, `Nous.Persistence.ETS.TableOwner` — internal supervision tree
+- Nous.Application, Nous.Persistence.ETS.TableOwner — internal supervision tree
 - Anything under `Nous.Workflow.Engine.*` — internal; the public API is `Nous.Workflow`
 - Anything marked `@moduledoc false` — hidden on purpose; will change without notice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent-runtime hot-path hardening (behavior-preserving)** (#62). Eliminates
+  confirmed super-linear and serialization hot paths in the agent runtime,
+  measured with Benchee first; all changes preserve observable behavior. Core
+  loop: tool-schema conversion is memoized once per run via a runtime-only
+  `Context.tool_schema_cache` and stripped from `Context.serialize/1`.
+  Persistence/OTP: `agent_server` context saves on the response/`clear_history`
+  paths are now fire-and-forget via `Task.Supervisor` (off the GenServer
+  mailbox); `Teams.RateLimiter` uses running-window counters so `rate_limited?/2`
+  is O(1); `Teams.SharedState` uses ETS row-per-entry for discoveries/claims.
+  Context updates replace O(n²) `++ [item]` appends with prepend + per-key
+  reverse. Memory/search: scope/kb_id/type filters are pushed into ETS via
+  matchspecs, search is single-pass, and the SQLite cosine L2 norm is hoisted
+  out of the loop.
+
+### Documentation
+
+- **Documentation overhaul** (#63). ExDoc structure reorganized after months of
+  feature growth: 67 previously-orphaned modules are now grouped, with new module
+  groups (Multi-Agent/Teams, Decision Graph, Messages & Streaming, HTTP Backends,
+  Structured Output, Utility Tools, Mix Tasks), a completed Providers group, and
+  an expanded Evaluation subtree; 0 broken-link warnings. Seven new
+  source-grounded subsystem guides (teams, decisions, research, fallback,
+  permissions, observability, providers). README/getting-started/indexes updated
+  and stale doc indexes regenerated. Numerous broken examples fixed and four new
+  advanced examples added (teams, decisions, deep_research, fallback).
+
+## [0.16.5] - 2026-06-12
+
 ### Security
 
 - **Permission-policy approval gate was bypassed when a `pre_tool_use` hook
@@ -36,6 +66,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for custom execute-class tools that relied on the policy. **Behavior change:**
   `build_policy(mode: :permissive)` users who want unattended shell execution
   must now pass `allow_unattended_execute: true`.
+
+## [0.16.4] - 2026-06-05
+
+### Changed
+
+- **Audit-pass follow-up: security/OTP/test hardening** (#60). Security
+  hardening: PathGuard canonical-path resolution, `web_fetch` fail-closed,
+  atom-exhaustion DoS guard, ReDoS cap, additional UrlGuard ranges. Correctness:
+  `get_tool_field` fetch, rate-limit TOCTOU fix, async-load reply-on-crash,
+  `async_nolink` absorb, O(1) claims, iodata flat accumulation. Documents the
+  intentional run-scoped ETS ownership model (KnowledgeBase/Decisions stores)
+  and a safer slug-index write order, makes the rate-limiter fail-open
+  observable (log + telemetry), and improves test quality (deterministic
+  `refute_receive`, `start_supervised!`, unique telemetry handler IDs, encoded-IP
+  SSRF cases).
+
+## [0.16.3] - 2026-05-29
+
+### Security
+
 - **RCE approval gate could be silently bypassed.** `Nous.Tool.from_module/2`
   hardcoded `requires_approval: false` instead of reading it from the tool's
   metadata, so `Bash`/`FileWrite` registered via the standard path ran without
@@ -100,6 +150,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OpenAI `parse_tool_call/1` crashed on a tool_call missing `"function"`.**
   `Map.get(nil, "name")` raised `BadMapError`, aborting the whole response
   parse on non-conformant OpenAI-compatible backends. Defaults to `%{}` now.
+
+### Fixed (important)
+
+- **Team region locking and discovery sharing were silently inert.**
+  `Nous.Teams.Supervisor` wires `SharedState` into agent deps as a registered
+  atom name, but `Nous.Plugins.TeamTools` gated on `is_pid/1` — false for the
+  name — so `claim_region`/`share_discovery` no-op'd for every team built via
+  the public API. The guards now resolve a registered name to a live pid.
+- **A tool that `throw`s or `exit`s (non-timeout) crashed the whole agent run.**
+  `Nous.ToolExecutor` only caught `:exit, {:timeout, _}`; it now catches any
+  `throw`/`exit` and converts it to a retryable `ToolError`.
+- **Streaming Gemini/Vertex tool calls dropped `thought_signature`.** The
+  accumulator rebuilt the call without `metadata`, breaking multi-turn thinking
+  parity for 2.5 thinking models. The signature is now carried through.
+- **Documented per-run `:model_settings` override was ignored.** `AgentRunner`
+  now merges `opts[:model_settings]` over the agent's settings for that run.
+- **`Nous.Teams.RateLimiter` was never invoked**, so `budget`/`rpm`/`tpm` had no
+  effect. It is now wired into the agent request path (reserve → reconcile →
+  release) when a limiter is in deps; rpm/tpm/request limits are enforced (the
+  cost budget is reconciled post-hoc — see the moduledoc).
+- **Crashed/timed-out parallel workflow branches were attributed to
+  `"unknown"`.** `Nous.Workflow.Engine.ParallelExecutor` now uses
+  `zip_input_on_exit` so failures keep their branch id / item index.
+- **SQLite memory scoped FTS recall was silently broken** (a parameter
+  off-by-one bound the scope filter to the wrong columns); the **Hybrid store**
+  now over-fetches a larger candidate pool when a scope is applied (so in-scope
+  results aren't crowded out); and **memory search normalizes RRF scores to
+  0–1** so `min_score` behaves consistently between text-only and hybrid modes.
+- **Tool argument validator now recurses** into nested object properties and
+  array items (was top-level types only).
+- **Eval config robustness.** `NOUS_EVAL_*` integer env vars parse via
+  `Integer.parse` (no crash on a bad value) and a partial custom `cost_config`
+  deep-merges instead of raising `KeyError`.
+- **`Nous.Tools.SearchScrape` processed only the first `concurrency` URLs.**
+  It now fetches all URLs (capped and throttled by `max_concurrency`) and clamps
+  LLM-supplied `concurrency`/`timeout`.
+
+### Changed
+
+- **`Nous.Agent.new/2` accepts bare tool modules** in `:tools` (e.g.
+  `tools: [Nous.Tools.Bash]`), converted via `Nous.Tool.from_module/1`.
+- **`Nous.Permissions.blocked?/2` allow-list semantics.** A non-empty
+  `allow_names`/`allow_prefixes` is now deny-by-default in every mode (was only
+  honored in `:strict`); `build_policy/1` raises on an unknown `:mode`.
+- **`Nous.Hook.new/2` accepts `:fail_closed`** so security-gating hooks can opt
+  into fail-closed via the documented constructor (not only a struct literal).
+- **License metadata corrected** to `Apache-2.0` in `mix.exs` (was `MIT`) to
+  match the bundled `LICENSE` and README.
+- **Docs:** fixed non-compiling/silently-broken examples — README plugin
+  configs now pass `:deps` to `Nous.run/3` (not `Nous.new/2`, which ignores it);
+  getting-started uses `Nous.Errors.ProviderError`, the correct
+  `AgentDynamicSupervisor.start_agent/3` arity, `Context.deserialize/1`, and
+  `%Nous.Message{}` for the chatbot example; AGENTS.md custom-tool example uses
+  `@behaviour`/`metadata/0`/`execute(ctx, args)` and corrects the streaming
+  backpressure claim (Req is the default; Hackney is the opt-in pull-based
+  backend).
+
+### Performance
+
+- **Removed O(n²) list accumulation on hot loops.** `Nous.Teams.RateLimiter`'s
+  sliding window and `Nous.Teams.SharedState`'s discovery list now prepend
+  (O(1)) instead of `++ [entry]` (O(n)).
+- **KnowledgeBase ETS store keeps a `slug -> id` index**, so
+  `fetch_entry_by_slug/2` is O(1) instead of a full table scan + struct rebuild
+  on every `kb_read`/`kb_backlinks`/`kb_link` call.
+- **Decisions ETS store builds an edge adjacency index once per BFS traversal**
+  (`descendants`/`ancestors`/`path_between`) instead of scanning the whole edge
+  table per visited node — O(V+E) instead of O(V·E).
+
+## [0.16.2] - 2026-05-16
+
+### Fixed (critical)
+
 - **Gemini/Vertex tool-result roundtrip was broken.** `Nous.Messages.Gemini`
   was sending the tool call_id (e.g. `"gemini_abc123"`) as the
   `functionResponse.name`, but Gemini's API requires the original
@@ -178,39 +301,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns immediately, so `DynamicSupervisor.start_child` (and
   `Teams.Coordinator.spawn_agent`) no longer wedge waiting for slow
   persistence backends.
-- **Team region locking and discovery sharing were silently inert.**
-  `Nous.Teams.Supervisor` wires `SharedState` into agent deps as a registered
-  atom name, but `Nous.Plugins.TeamTools` gated on `is_pid/1` — false for the
-  name — so `claim_region`/`share_discovery` no-op'd for every team built via
-  the public API. The guards now resolve a registered name to a live pid.
-- **A tool that `throw`s or `exit`s (non-timeout) crashed the whole agent run.**
-  `Nous.ToolExecutor` only caught `:exit, {:timeout, _}`; it now catches any
-  `throw`/`exit` and converts it to a retryable `ToolError`.
-- **Streaming Gemini/Vertex tool calls dropped `thought_signature`.** The
-  accumulator rebuilt the call without `metadata`, breaking multi-turn thinking
-  parity for 2.5 thinking models. The signature is now carried through.
-- **Documented per-run `:model_settings` override was ignored.** `AgentRunner`
-  now merges `opts[:model_settings]` over the agent's settings for that run.
-- **`Nous.Teams.RateLimiter` was never invoked**, so `budget`/`rpm`/`tpm` had no
-  effect. It is now wired into the agent request path (reserve → reconcile →
-  release) when a limiter is in deps; rpm/tpm/request limits are enforced (the
-  cost budget is reconciled post-hoc — see the moduledoc).
-- **Crashed/timed-out parallel workflow branches were attributed to
-  `"unknown"`.** `Nous.Workflow.Engine.ParallelExecutor` now uses
-  `zip_input_on_exit` so failures keep their branch id / item index.
-- **SQLite memory scoped FTS recall was silently broken** (a parameter
-  off-by-one bound the scope filter to the wrong columns); the **Hybrid store**
-  now over-fetches a larger candidate pool when a scope is applied (so in-scope
-  results aren't crowded out); and **memory search normalizes RRF scores to
-  0–1** so `min_score` behaves consistently between text-only and hybrid modes.
-- **Tool argument validator now recurses** into nested object properties and
-  array items (was top-level types only).
-- **Eval config robustness.** `NOUS_EVAL_*` integer env vars parse via
-  `Integer.parse` (no crash on a bad value) and a partial custom `cost_config`
-  deep-merges instead of raising `KeyError`.
-- **`Nous.Tools.SearchScrape` processed only the first `concurrency` URLs.**
-  It now fetches all URLs (capped and throttled by `max_concurrency`) and clamps
-  LLM-supplied `concurrency`/`timeout`.
 
 ### Changed
 
@@ -222,35 +312,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming path). Existing-but-undocumented events
   (`fallback`, `hook`, `skill`, `workflow`) are now documented in the
   `Nous.Telemetry` moduledoc.
-- **`Nous.Agent.new/2` accepts bare tool modules** in `:tools` (e.g.
-  `tools: [Nous.Tools.Bash]`), converted via `Nous.Tool.from_module/1`.
-- **`Nous.Permissions.blocked?/2` allow-list semantics.** A non-empty
-  `allow_names`/`allow_prefixes` is now deny-by-default in every mode (was only
-  honored in `:strict`); `build_policy/1` raises on an unknown `:mode`.
-- **`Nous.Hook.new/2` accepts `:fail_closed`** so security-gating hooks can opt
-  into fail-closed via the documented constructor (not only a struct literal).
-- **License metadata corrected** to `Apache-2.0` in `mix.exs` (was `MIT`) to
-  match the bundled `LICENSE` and README.
-- **Docs:** fixed non-compiling/silently-broken examples — README plugin
-  configs now pass `:deps` to `Nous.run/3` (not `Nous.new/2`, which ignores it);
-  getting-started uses `Nous.Errors.ProviderError`, the correct
-  `AgentDynamicSupervisor.start_agent/3` arity, `Context.deserialize/1`, and
-  `%Nous.Message{}` for the chatbot example; AGENTS.md custom-tool example uses
-  `@behaviour`/`metadata/0`/`execute(ctx, args)` and corrects the streaming
-  backpressure claim (Req is the default; Hackney is the opt-in pull-based
-  backend).
-
-### Performance
-
-- **Removed O(n²) list accumulation on hot loops.** `Nous.Teams.RateLimiter`'s
-  sliding window and `Nous.Teams.SharedState`'s discovery list now prepend
-  (O(1)) instead of `++ [entry]` (O(n)).
-- **KnowledgeBase ETS store keeps a `slug -> id` index**, so
-  `fetch_entry_by_slug/2` is O(1) instead of a full table scan + struct rebuild
-  on every `kb_read`/`kb_backlinks`/`kb_link` call.
-- **Decisions ETS store builds an edge adjacency index once per BFS traversal**
-  (`descendants`/`ancestors`/`path_between`) instead of scanning the whole edge
-  table per visited node — O(V+E) instead of O(V·E).
 
 ### Deprecated
 
@@ -1547,7 +1608,11 @@ Initial public release with multi-provider LLM support:
 - ReAct agent implementation
 
 <!-- Version comparison links -->
-[Unreleased]: https://github.com/nyo16/nous/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/nyo16/nous/compare/v0.16.5...HEAD
+[0.16.5]: https://github.com/nyo16/nous/compare/v0.16.4...v0.16.5
+[0.16.4]: https://github.com/nyo16/nous/compare/v0.16.3...v0.16.4
+[0.16.3]: https://github.com/nyo16/nous/compare/v0.16.2...v0.16.3
+[0.16.2]: https://github.com/nyo16/nous/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nyo16/nous/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/nyo16/nous/compare/v0.15.8...v0.16.0
 [0.15.8]: https://github.com/nyo16/nous/compare/v0.15.7...v0.15.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the human-approval gate — one prompt-injected document from RCE. It now falls
   back to metadata like name/description/parameters. (Also fixed:
   `Nous.Tool.Behaviour.implements?/1` ensures the module is loaded before
-  checking, and `Agent.new/2` accepts bare behaviour modules in `:tools`.)
+  checking, and `Nous.Agent.new/2` accepts bare behaviour modules in `:tools`.)
 - **FileGrep ripgrep flag injection.** LLM-controlled `pattern`/`glob` reached
   `rg` with no `--` option terminator, so values like `-f/etc/passwd` or
   `--pre=…` read files (or ran a preprocessor) outside the workspace. Pattern is
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection to it (preserving Host header, SNI, and cert verification) to close
   the DNS-rebinding TOCTOU. The Req provider backends pass `redirect: false`.
 - **Permission policy is now actually enforced.** `Nous.Permissions.Policy`
-  (via a new `:permissions` option on `Agent.new/2`) filters blocked tools out
+  (via a new `:permissions` option on `Nous.Agent.new/2`) filters blocked tools out
   of the tool list the model sees and forces the approval gate for
   approval-required tools — previously the engine was never consulted at
   runtime. `blocked?/2` now honors allow lists in every mode (deny-by-default),
@@ -113,11 +113,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proper tool-error result so the LLM can retry.
 - **Workflow checkpoint ETS table lost its data when the saving process
   exited.** The `:nous_workflow_checkpoints` table is now owned by a
-  supervised `TableOwner` under `Nous.Application` (mirrors the existing
+  supervised `TableOwner` under Nous.Application (mirrors the existing
   `Nous.Persistence.ETS` pattern). Every suspended workflow relying on
   resume is now durable to caller exits.
 - **Memory plugin re-initialized its ETS store on every agent run.**
-  `Nous.Plugins.Memory.init/2` now reuses the existing `store_state` when
+  Nous.Plugins.Memory.init/2 now reuses the existing `store_state` when
   present; per-run defaults are still refreshed. Avoids
   `ets_too_many_tables` under load and the silent loss of memories across
   runs.
@@ -222,7 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   streaming path). Existing-but-undocumented events
   (`fallback`, `hook`, `skill`, `workflow`) are now documented in the
   `Nous.Telemetry` moduledoc.
-- **`Agent.new/2` accepts bare tool modules** in `:tools` (e.g.
+- **`Nous.Agent.new/2` accepts bare tool modules** in `:tools` (e.g.
   `tools: [Nous.Tools.Bash]`), converted via `Nous.Tool.from_module/1`.
 - **`Nous.Permissions.blocked?/2` allow-list semantics.** A non-empty
   `allow_names`/`allow_prefixes` is now deny-by-default in every mode (was only
@@ -255,7 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `Nous.ToolSchema.to_openai/1` — use `Nous.Tool.to_openai_schema/1`.
-- `Nous.Agent.tool/3` — use `Agent.new/2` with `:tools`, or build a
+- `Nous.Agent.tool/3` — use `Nous.Agent.new/2` with `:tools`, or build a
   `%Nous.Tool{}` directly.
 - `Nous.Eval.run!/2` — match `Nous.Eval.run/2`'s
   `{:ok, _} | {:error, _}` result.
@@ -389,13 +389,13 @@ works against either entry point.
   `content` field entirely and then raised
   `%Ecto.InvalidChangesetError{errors: [content: {"content is required",
   []}]}` from `ContentPart.new!/1`, taking down the whole
-  `Nous.LLM.run_with_tools/6` call. `ContentPart` now overrides
+  Nous.LLM.run_with_tools/6 call. `ContentPart` now overrides
   `:empty_values` to `[""]` so legitimate whitespace content is
-  preserved, and `Nous.Messages.Gemini.parse_content/1` defensively
+  preserved, and Nous.Messages.Gemini.parse_content/1 defensively
   skips whitespace-only text parts to avoid creating useless
   `ContentPart`s. The streaming normalizer (`Nous.StreamNormalizer.Gemini`)
   already had this guard; the non-streaming path is now consistent.
-- **`Nous.Messages.Gemini.parse_content/1` no longer silently drops
+- **Nous.Messages.Gemini.parse_content/1 no longer silently drops
   function calls without `args`.** Nullary tool calls
   (`%{"functionCall" => %{"name" => "get_time"}}`) were falling into
   the catch-all clause and disappearing. Pattern now requires only
@@ -412,7 +412,7 @@ works against either entry point.
   APIs, since long-term/daily quota exhaustion deliberately omits
   `RetryInfo` to discourage retry loops.
 - **`Nous.Errors.ProviderError` gains `:retry_after_ms`** alongside
-  the existing `:status_code`. `Nous.Provider.request/3` and
+  the existing `:status_code`. Nous.Provider.request/3 and
   `request_stream/3` now populate both fields automatically when the
   underlying HTTP layer returns an error tuple, so callers can branch
   on rate-limit hints without parsing provider-specific bodies:
@@ -447,7 +447,7 @@ works against either entry point.
   Existing pattern matches on `%{status: _, body: _}` continue to work
   since map matching is non-exhaustive.
 - **Gemini tool-call ID generation unified.**
-  `Nous.Messages.Gemini.parse_content/1` previously used
+  Nous.Messages.Gemini.parse_content/1 previously used
   `"gemini_#{:rand.uniform(10_000)}"` (~50% birthday-paradox collision
   at ~118 calls) while `parse_parts/1` used
   `"call_#{:rand.uniform(1_000_000)}"` — two formats, two ranges. Both
@@ -496,7 +496,7 @@ works against either entry point.
   `Nous.Finch` pool. Previously they ignored the `:finch_name` opt
   built by `Nous.Provider` and let Req spin up its own default Finch
   instance, leaving the supervised `Nous.Finch` pool (started by
-  `Nous.Application` with `size: 10, count: 1`) idle. Both backends
+  Nous.Application with `size: 10, count: 1`) idle. Both backends
   now read `:finch_name` from per-call opts, falling back to
   `Application.get_env(:nous, :finch, Nous.Finch)`. Net effect:
   `Nous.Finch` becomes the live default for both streaming and
@@ -511,7 +511,7 @@ works against either entry point.
   board.** The previous 60s default routinely tripped on reasoning
   models and longer completions. Affected:
   - `Nous.Model` `receive_timeout` default → 180_000
-  - `Nous.Model.default_receive_timeout/1` per-provider:
+  - Nous.Model.default_receive_timeout/1 per-provider:
     cloud/custom → 180_000, llamacpp → 300_000 (up from 120_000)
   - Provider `@default_timeout` (OpenAI, Anthropic, Mistral, VertexAI,
     OpenAICompatible) → 180_000
@@ -1049,6 +1049,38 @@ Read these before upgrading.
 
 - 76 new tests for hooks and skills systems.
 
+## [0.12.13] - 2026-03-20
+
+### Added
+
+- **`custom:` provider** (`Nous.Providers.Custom`): first-class prefix for any OpenAI-compatible endpoint, with `CUSTOM_API_KEY` / `CUSTOM_BASE_URL` environment-variable support. This is now the documented/recommended approach for custom endpoints.
+  - Configuration precedence (highest to lowest): direct options to `Nous.new/2` → environment variables → application config (`config :nous, :custom, ...`) → defaults.
+- Custom Providers guide (`docs/guides/custom_providers.md`) and `examples/providers/custom_providers.exs`.
+
+### Changed
+
+- `Model.parse/2` accepts the `openai_compatible:` prefix as a backward-compatible alias for `custom:` (both route to the `:custom` provider); `ModelDispatcher` gained an explicit `:custom` clause.
+- Expanded documentation across `Model`, `OpenAICompatible`, and the README; `vllm_sglang.exs` now points to `custom:` as the recommended approach.
+
+## [0.12.12] - 2026-03-19
+
+### Fixed
+
+- **Unbounded atom creation in `atomize_keys/1`** (security): untrusted keys no longer create atoms dynamically.
+- ETS table race condition in `Persistence.ETS.ensure_table/0`.
+- Double recency penalization in memory search scoring.
+- `clear_history` now stays in sync with the persistence backend.
+
+### Added
+
+- `{:error, reason}` handling in `recall/2` and `Search.search`.
+- `Nous.Memory.Scope` — shared scope logic extracted from the memory modules.
+- AgentServer tests (16) and Summarization plugin tests (8).
+
+### Removed
+
+- Dead code in `do_memory_reflection`.
+
 ## [0.12.11] - 2026-03-19
 
 ### Added
@@ -1535,7 +1567,9 @@ Initial public release with multi-provider LLM support:
 [0.12.17]: https://github.com/nyo16/nous/compare/v0.12.16...v0.12.17
 [0.12.16]: https://github.com/nyo16/nous/compare/v0.12.15...v0.12.16
 [0.12.15]: https://github.com/nyo16/nous/compare/v0.12.14...v0.12.15
-[0.12.14]: https://github.com/nyo16/nous/compare/v0.12.11...v0.12.14
+[0.12.14]: https://github.com/nyo16/nous/compare/v0.12.13...v0.12.14
+[0.12.13]: https://github.com/nyo16/nous/compare/v0.12.12...v0.12.13
+[0.12.12]: https://github.com/nyo16/nous/compare/v0.12.11...v0.12.12
 [0.12.11]: https://github.com/nyo16/nous/compare/v0.12.10...v0.12.11
 [0.12.10]: https://github.com/nyo16/nous/compare/v0.12.9...v0.12.10
 [0.12.9]: https://github.com/nyo16/nous/compare/v0.12.8...v0.12.9

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,15 @@ export ANTHROPIC_API_KEY="sk-..."
 export OPENAI_API_KEY="sk-..."
 ```
 
+## Standalone APIs
+
+Top-level entry points that don't need the full agent loop:
+
+| File | Description |
+|------|-------------|
+| [llm_oneshot.exs](llm_oneshot.exs) | Bare `Nous.LLM` one-shot API: `generate_text/3`, `generate_text!/3`, `stream_text/3` (no agent) |
+| [knowledge_base.exs](knowledge_base.exs) | Knowledge Base store: add entries, `search/4`, and the KB agent plugin |
+
 ## Core Examples (01-10)
 
 Progressive learning path from basics to advanced features:
@@ -110,11 +119,13 @@ Production patterns and advanced features:
 | [advanced/teams.exs](advanced/teams.exs) | Multi-agent team lifecycle: roles, shared state, comms |
 | [advanced/decisions.exs](advanced/decisions.exs) | Decision-graph tracking (core API + agent plugin) |
 | [advanced/deep_research.exs](advanced/deep_research.exs) | Autonomous deep research with citations |
+| [advanced/summarization.exs](advanced/summarization.exs) | Auto-compact long conversation history via the Summarization plugin |
+| [advanced/web_tools.exs](advanced/web_tools.exs) | Web/search tools: WebFetch, SearchScrape, Tavily, Brave |
 | [advanced/telemetry.exs](advanced/telemetry.exs) | Custom metrics and cost tracking |
 | [advanced/cancellation.exs](advanced/cancellation.exs) | Task and streaming cancellation |
-| [advanced/liveview_integration.exs](advanced/liveview_integration.exs) | Phoenix LiveView integration patterns |
-| [advanced/liveview_chat.exs](advanced/liveview_chat.exs) | Full chat UI: streaming, tools, sessions, auto-scroll |
-| [advanced/liveview_multi_agent.exs](advanced/liveview_multi_agent.exs) | Multi-agent dashboard with real-time PubSub status |
+| [advanced/liveview_integration.exs](advanced/liveview_integration.exs) | LiveView **patterns reference** — 6 patterns (non-streaming, streaming, tools, cancellation, AgentServer, map-callbacks) |
+| [advanced/liveview_chat.exs](advanced/liveview_chat.exs) | A **complete chat app** — one ChatLive module: streaming, tools, sessions, auto-scroll |
+| [advanced/liveview_multi_agent.exs](advanced/liveview_multi_agent.exs) | A **multi-agent dashboard** — real-time PubSub status across agents |
 | [advanced/tool_permissions.exs](advanced/tool_permissions.exs) | Permission policies: presets, custom deny/approve, tool filtering |
 
 ## Running Examples

--- a/examples/advanced/summarization.exs
+++ b/examples/advanced/summarization.exs
@@ -1,0 +1,173 @@
+#!/usr/bin/env elixir
+
+# Nous AI - Summarization Plugin
+# Auto-compact long conversation history to stay within the context window.
+#
+# The `Nous.Plugins.Summarization` plugin hooks into the agent lifecycle:
+#   - init/2          seeds `:summarization_config` into the run deps
+#   - before_request/3 fires before each LLM request; when cumulative usage
+#                      (ctx.usage.total_tokens) exceeds `:max_context_tokens`,
+#                      it replaces the older messages with a single
+#                      "[Conversation Summary]" system message and keeps the
+#                      most recent `:keep_recent` messages intact.
+#
+# Config is a RUN-time concern: the plugin reads it from `deps` passed to
+# `Nous.Agent.run/3`, NOT from a struct in `plugins:`. You add the plugin as a
+# bare module (`plugins: [Nous.Plugins.Summarization]`) and tune it via
+# `deps: %{summarization_config: %{...}}`.
+#
+# Run with: mix run examples/advanced/summarization.exs
+# Requires (for the live LLM path): a running provider, e.g. OPENAI_API_KEY.
+
+alias Nous.{Agent, Message}
+alias Nous.Agent.Context
+alias Nous.Plugins.Summarization
+
+IO.puts("=== Nous AI - Summarization Plugin Demo ===\n")
+
+# ============================================================================
+# Part 1: Deterministic compaction (no provider needed for the trigger logic)
+# ============================================================================
+#
+# We call the plugin's lifecycle callbacks directly with a hand-built context
+# whose cumulative usage already exceeds the threshold. This shows the
+# before/after message counts regardless of whether an LLM is reachable.
+# (generate_summary/3 still needs a provider to produce real summary text; if
+# none is available it returns {:error, _} and the plugin keeps all messages.)
+
+IO.puts("--- Part 1: Trigger compaction directly ---")
+
+# A long conversation: 1 system + 12 user/assistant turns.
+history =
+  [Message.system("You are a helpful assistant.")] ++
+    Enum.flat_map(1..6, fn n ->
+      [
+        Message.user("Question #{n}: tell me fact number #{n}."),
+        Message.assistant("Answer #{n}: here is fact number #{n}.")
+      ]
+    end)
+
+# Low threshold + small keep_recent so compaction is guaranteed to engage.
+config = %{
+  max_context_tokens: 50,
+  keep_recent: 4,
+  summary_model: "openai:gpt-4o-mini"
+}
+
+agent =
+  Agent.new("openai:gpt-4o-mini",
+    instructions: "You are a helpful assistant.",
+    plugins: [Summarization]
+  )
+
+# Build a context the way the runner would, then let the plugin seed its deps.
+base_ctx =
+  Context.new(
+    messages: history,
+    deps: %{summarization_config: config},
+    # Pretend prior turns already burned tokens past the 50-token threshold.
+    usage: %Nous.Usage{requests: 6, total_tokens: 500}
+  )
+
+ctx = Summarization.init(agent, base_ctx)
+
+IO.puts(
+  "Before: #{length(ctx.messages)} messages " <>
+    "(usage #{ctx.usage.total_tokens} tokens > #{config.max_context_tokens} limit)"
+)
+
+{compacted_ctx, _tools} = Summarization.before_request(agent, ctx, [])
+
+summary_msg =
+  Enum.find(compacted_ctx.messages, fn m ->
+    m.role == :system and String.starts_with?(m.content || "", "[Conversation Summary]")
+  end)
+
+cond do
+  summary_msg ->
+    new_count = get_in(compacted_ctx.deps, [:summarization_config, :summary_count])
+    IO.puts("After:  #{length(compacted_ctx.messages)} messages (summary_count=#{new_count})")
+    IO.puts("Summarized older turns into:")
+    IO.puts("  " <> String.slice(summary_msg.content, 0, 200))
+
+  length(compacted_ctx.messages) < length(ctx.messages) ->
+    IO.puts("After:  #{length(compacted_ctx.messages)} messages (compacted)")
+
+  true ->
+    IO.puts(
+      "After:  #{length(compacted_ctx.messages)} messages " <>
+        "(no provider reachable; plugin kept all messages — fail-safe)"
+    )
+end
+
+IO.puts("")
+
+# ============================================================================
+# Part 2: Live multi-turn run (degrades gracefully without a provider)
+# ============================================================================
+#
+# Here the agent actually talks to an LLM. We thread the conversation forward
+# by feeding `all_messages` from each result back into the next run via
+# `messages:`. With a tight `:max_context_tokens`, accumulated usage trips the
+# threshold on a later turn and the plugin compacts mid-conversation.
+
+IO.puts("--- Part 2: Live multi-turn conversation ---")
+
+prompts = [
+  "Hi! My name is Dana and I'm planning a trip to Japan.",
+  "I want to visit Kyoto and Osaka over five days.",
+  "What's a good food to try there?",
+  "Remind me: what was my name and where am I going?"
+]
+
+run_opts = [
+  max_iterations: 5,
+  deps: %{
+    summarization_config: %{
+      max_context_tokens: 200,
+      keep_recent: 4,
+      summary_model: "openai:gpt-4o-mini"
+    }
+  }
+]
+
+result =
+  Enum.reduce_while(prompts, {[], 0}, fn prompt, {prior_messages, turn} ->
+    IO.puts("\nTurn #{turn + 1} > #{prompt}")
+
+    input =
+      if prior_messages == [],
+        do: prompt,
+        else: [messages: prior_messages ++ [Message.user(prompt)]]
+
+    case Agent.run(agent, input, run_opts) do
+      {:ok, res} ->
+        IO.puts("  assistant: #{String.slice(res.output, 0, 120)}")
+
+        count = get_in(res.deps, [:summarization_config, :summary_count]) || 0
+
+        IO.puts(
+          "  context: #{length(res.all_messages)} messages, " <>
+            "#{res.usage.total_tokens} tokens, compactions=#{count}"
+        )
+
+        {:cont, {res.all_messages, turn + 1}}
+
+      {:error, reason} ->
+        IO.puts("  (no provider reachable: #{inspect(reason)} — skipping live path)")
+        {:halt, :no_provider}
+    end
+  end)
+
+case result do
+  :no_provider ->
+    IO.puts("\nLive path skipped. Part 1 already demonstrated the compaction logic.")
+
+  {final_messages, turns} ->
+    IO.puts(
+      "\nCompleted #{turns} turns; final transcript holds " <>
+        "#{length(final_messages)} messages after auto-compaction."
+    )
+end
+
+IO.puts("\nDone!")

--- a/examples/advanced/web_tools.exs
+++ b/examples/advanced/web_tools.exs
@@ -1,0 +1,173 @@
+#!/usr/bin/env elixir
+
+# Nous AI - Web & Search Tools
+#
+# Demonstrates the built-in web/search tools:
+#
+#   - Nous.Tools.WebFetch.fetch_page/2    -> fetch + extract readable page content
+#   - Nous.Tools.SearchScrape.scrape_results/2 -> fetch + summarize many URLs in parallel
+#   - Nous.Tools.TavilySearch.search/2    -> AI-optimized search (needs TAVILY_API_KEY)
+#   - Nous.Tools.BraveSearch.web_search/2 -> web search (needs BRAVE_API_KEY)
+#   - Nous.Tools.BraveSearch.news_search/2 -> news search (needs BRAVE_API_KEY)
+#
+# Run with:  mix run examples/advanced/web_tools.exs
+#
+# Notes:
+#   * WebFetch/SearchScrape need NETWORK access but NO API key. WebFetch also
+#     requires the optional Floki dependency ({:floki, "~> 0.36"} in mix.exs).
+#   * Tavily/Brave need API keys. Keys are resolved (in order) from:
+#       ctx.deps[:tavily_api_key] / [:brave_api_key]
+#       Application config (:nous, :tavily_api_key / :brave_api_key)
+#       env vars TAVILY_API_KEY / BRAVE_API_KEY
+#     Below we pass them through an agent's `deps:`.
+
+alias Nous.Tools.{WebFetch, SearchScrape, TavilySearch, BraveSearch}
+alias Nous.RunContext
+
+IO.puts("=== Nous AI - Web & Search Tools ===\n")
+
+# ============================================================================
+# Part 1: Call a tool function directly (no LLM, no API key)
+# ============================================================================
+#
+# Tools are plain `fun(ctx, args)` functions. We can call them directly.
+# `ctx` is a Nous.RunContext; `args` is a string-keyed map (as the LLM sends).
+
+IO.puts("--- Part 1: WebFetch.fetch_page/2 (direct call, needs network) ---")
+
+ctx = RunContext.new(%{})
+
+case WebFetch.fetch_page(ctx, %{"url" => "https://example.com"}) do
+  %{success: true} = page ->
+    IO.puts("Title:      #{page.title}")
+    IO.puts("Words:      #{page.word_count}")
+    IO.puts("Fetched at: #{page.fetched_at}")
+    IO.puts("Preview:    #{String.slice(page.content, 0, 120)}...")
+
+  %{success: false, error: error} ->
+    IO.puts("Fetch unavailable (network/Floki?): #{error}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Part 2: SearchScrape.scrape_results/2 (parallel fetch + summarize)
+# ============================================================================
+#
+# SearchScrape fetches each URL then summarizes it. Summarization uses an LLM,
+# so we supply a summary model via deps. It needs network + a reachable model.
+
+IO.puts("--- Part 2: SearchScrape.scrape_results/2 (parallel, needs network + model) ---")
+
+scrape_ctx = RunContext.new(%{summary_model: "lmstudio:qwen3"})
+
+scrape_args = %{
+  "urls" => ["https://example.com", "https://example.org"],
+  "query" => "What are these pages about?",
+  "concurrency" => 2
+}
+
+case SearchScrape.scrape_results(scrape_ctx, scrape_args) do
+  %{results: results, total_fetched: fetched, total_requested: requested} ->
+    IO.puts("Fetched #{fetched}/#{requested} pages")
+
+    for r <- results do
+      IO.puts("  - #{r.url} (relevance: #{r.relevance})")
+    end
+
+  other ->
+    IO.inspect(other, label: "SearchScrape result")
+end
+
+IO.puts("")
+
+# ============================================================================
+# Part 3: Tavily search (key-gated) - direct call
+# ============================================================================
+
+IO.puts("--- Part 3: TavilySearch.search/2 (needs TAVILY_API_KEY) ---")
+
+tavily_key = System.get_env("TAVILY_API_KEY")
+
+if is_nil(tavily_key) or tavily_key == "" do
+  IO.puts("Skipped. Set TAVILY_API_KEY to run this part (https://tavily.com).")
+else
+  # Key supplied via deps so the tool resolves it from ctx.deps[:tavily_api_key].
+  tavily_ctx = RunContext.new(%{tavily_api_key: tavily_key})
+
+  case TavilySearch.search(tavily_ctx, %{"query" => "latest Elixir release", "max_results" => 3}) do
+    %{success: true} = res ->
+      if res.answer, do: IO.puts("Answer: #{res.answer}")
+      IO.puts("Got #{res.result_count} results:")
+      for r <- res.results, do: IO.puts("  - #{r.title} (#{r.url})")
+
+    %{success: false, error: error} ->
+      IO.puts("Tavily error: #{error}")
+  end
+end
+
+IO.puts("")
+
+# ============================================================================
+# Part 4: Brave search (key-gated) - direct call
+# ============================================================================
+
+IO.puts("--- Part 4: BraveSearch.web_search/2 (needs BRAVE_API_KEY) ---")
+
+brave_key = System.get_env("BRAVE_API_KEY")
+
+if is_nil(brave_key) or brave_key == "" do
+  IO.puts("Skipped. Set BRAVE_API_KEY to run this part (https://brave.com/search/api/).")
+else
+  brave_ctx = RunContext.new(%{brave_api_key: brave_key})
+
+  case BraveSearch.web_search(brave_ctx, %{"query" => "Elixir programming language", "count" => 3}) do
+    %{success: true} = res ->
+      IO.puts("Got #{res.result_count} web results:")
+      for r <- res.results, do: IO.puts("  - #{r.title} (#{r.url})")
+
+    %{success: false, error: error} ->
+      IO.puts("Brave error: #{error}")
+  end
+end
+
+IO.puts("")
+
+# ============================================================================
+# Part 5: Register the tools on an agent and let the LLM decide
+# ============================================================================
+#
+# Pass tools as a list of captured functions; pass any API keys through `deps`
+# so the tools can read them from ctx. The agent calls a tool only when needed.
+
+IO.puts("--- Part 5: Agent with web tools (needs a reachable model) ---")
+
+research_agent =
+  Nous.new("lmstudio:qwen3",
+    instructions: "You research topics using the web tools available to you.",
+    tools: [
+      &WebFetch.fetch_page/2,
+      &SearchScrape.scrape_results/2,
+      &TavilySearch.search/2,
+      &BraveSearch.web_search/2,
+      &BraveSearch.news_search/2
+    ]
+  )
+
+# deps flow into ctx.deps for every tool call during the run.
+deps = %{
+  summary_model: "lmstudio:qwen3",
+  tavily_api_key: tavily_key,
+  brave_api_key: brave_key
+}
+
+case Nous.run(research_agent, "Fetch https://example.com and tell me what it's for.", deps: deps) do
+  {:ok, result} ->
+    IO.puts("Response: #{result.output}")
+    IO.puts("Tool calls: #{result.usage.tool_calls}")
+
+  {:error, reason} ->
+    IO.puts("Agent run failed (model unreachable?): #{inspect(reason)}")
+end
+
+IO.puts("\nDone.")

--- a/examples/knowledge_base.exs
+++ b/examples/knowledge_base.exs
@@ -1,0 +1,146 @@
+# Knowledge Base — ETS Store
+#
+# The Knowledge Base is an LLM-compiled wiki: raw documents get compiled into
+# structured entries with summaries, tags, concepts, and [[wiki-links]]. This
+# example sticks to the parts that need no LLM and no external deps:
+#
+#   * initialize an ETS-backed store
+#   * add a couple of entries directly
+#   * search them with Jaro-distance fuzzy matching
+#
+# It then *optionally* wires the KB plugin into an agent. That part only does
+# real work when an LLM provider is configured, so it degrades gracefully.
+#
+# Run: mix run examples/knowledge_base.exs
+
+alias Nous.KnowledgeBase
+alias Nous.KnowledgeBase.Entry
+alias Nous.KnowledgeBase.Store.ETS
+
+# ---------------------------------------------------------------------------
+# 1. Initialize an ETS-backed KB store
+# ---------------------------------------------------------------------------
+#
+# The store is ephemeral and run-scoped: init/1 returns table references inside
+# `state`, which you thread through subsequent calls. When this process exits,
+# ETS reclaims the tables.
+
+{:ok, store} = ETS.init([])
+
+kb_id = "elixir-otp"
+
+# ---------------------------------------------------------------------------
+# 2. Add a couple of entries directly
+# ---------------------------------------------------------------------------
+#
+# Entry.new/1 requires :title and :content; it auto-generates id, slug, and
+# timestamps. Normally an LLM compiles these from raw documents, but you can
+# also create them by hand.
+
+entries = [
+  Entry.new(%{
+    title: "GenServer",
+    content: """
+    GenServer is the core OTP abstraction for stateful server processes. It
+    provides a client-server model where the server runs in its own process
+    and handles synchronous calls and asynchronous casts. See [[supervisor]].
+    """,
+    summary: "Client-server abstraction for stateful processes.",
+    entry_type: :concept,
+    concepts: ["genserver", "otp", "processes"],
+    tags: ["elixir", "otp"],
+    confidence: 0.95,
+    kb_id: kb_id
+  }),
+  Entry.new(%{
+    title: "Supervisor",
+    content: """
+    A Supervisor is a process that monitors child processes and restarts them
+    according to a strategy (:one_for_one, :one_for_all, :rest_for_one) when
+    they crash. Supervisors are the backbone of OTP fault tolerance.
+    """,
+    summary: "Process that monitors and restarts children for fault tolerance.",
+    entry_type: :concept,
+    concepts: ["supervisor", "otp", "fault-tolerance"],
+    tags: ["elixir", "otp"],
+    confidence: 0.9,
+    kb_id: kb_id
+  })
+]
+
+store =
+  Enum.reduce(entries, store, fn entry, s ->
+    {:ok, s} = ETS.store_entry(s, entry)
+    s
+  end)
+
+IO.puts("Stored #{length(entries)} entries in KB \"#{kb_id}\"\n")
+
+# ---------------------------------------------------------------------------
+# 3. Search entries with KnowledgeBase.search/4
+# ---------------------------------------------------------------------------
+#
+# search/4 delegates to the store's search_entries/3. It returns
+# {:ok, [{entry, score}]} sorted by descending score. We scope by :kb_id so
+# only this knowledge base's rows are considered.
+
+queries = [
+  "how do processes hold state",
+  "restart crashed children",
+  "fault tolerance strategy"
+]
+
+for query <- queries do
+  {:ok, results} =
+    KnowledgeBase.search(ETS, store, query, kb_id: kb_id, limit: 3, min_score: 0.0)
+
+  IO.puts("Query: \"#{query}\"")
+
+  for {entry, score} <- results do
+    IO.puts("  [#{Float.round(score, 3)}] #{entry.title} — #{entry.summary}")
+  end
+
+  IO.puts("")
+end
+
+# List every entry in this KB namespace.
+{:ok, all} = KnowledgeBase.list_entries(ETS, store, kb_id: kb_id)
+IO.puts("Total entries in KB: #{length(all)}")
+IO.puts("Slugs: #{all |> Enum.map(& &1.slug) |> Enum.join(", ")}\n")
+
+# ---------------------------------------------------------------------------
+# 4. (Optional) Wire the KB plugin into an agent
+# ---------------------------------------------------------------------------
+#
+# The plugin gives an agent 9 KB tools (kb_search, kb_ingest, kb_add_entry,
+# kb_read, ...). The store config goes in `deps[:kb_config]`. Note that `deps`
+# belongs on Nous.run/3 (the run-time call), NOT on Nous.new/2.
+#
+# This step needs a running LLM provider. We guard it with a `case` so the
+# script still exits cleanly when none is configured.
+
+agent =
+  Nous.new("lmstudio:qwen3",
+    plugins: [Nous.Plugins.KnowledgeBase],
+    instructions: "Answer using the knowledge base. Cite the entries you used."
+  )
+
+run_opts = [
+  deps: %{
+    kb_config: %{
+      store: ETS,
+      kb_id: kb_id
+    }
+  }
+]
+
+IO.puts("Attempting an LLM-backed KB query (skipped if no provider)...\n")
+
+case Nous.run(agent, "What is a GenServer and how does it relate to supervisors?", run_opts) do
+  {:ok, result} ->
+    IO.puts("Agent answer:\n#{result.output}")
+
+  {:error, reason} ->
+    IO.puts("Skipped LLM step (no provider configured): #{inspect(reason)}")
+    IO.puts("Set up a provider (e.g. OPENAI_API_KEY) to see the agent answer.")
+end

--- a/examples/llm_oneshot.exs
+++ b/examples/llm_oneshot.exs
@@ -1,0 +1,125 @@
+#!/usr/bin/env elixir
+
+# Nous AI - One-Shot LLM API (no agent)
+# The bare `Nous.LLM` module: direct model calls without the agent machinery.
+#
+# Use this when you just want text in / text out and don't need instructions,
+# memory, history, or the agent run loop.
+#
+# Default model below is "lmstudio:qwen3" (a local LM Studio server), but any
+# "provider:model" string works, e.g.:
+#   "anthropic:claude-haiku-4-5"
+#   "openai:gpt-4"
+#   "ollama:llama3"
+# You can also pass a %Nous.Model{} struct directly (see section 4).
+
+model = "lmstudio:qwen3"
+
+IO.puts("=== Nous AI - One-Shot LLM API ===\n")
+
+# ============================================================================
+# 1. generate_text/3 - returns {:ok, text} | {:error, reason}
+# ============================================================================
+
+IO.puts("--- 1. generate_text/3 (tuple result) ---")
+IO.puts("Prompt: What is 2 + 2? Answer with just the number.\n")
+
+case Nous.LLM.generate_text(model, "What is 2 + 2? Answer with just the number.") do
+  {:ok, text} ->
+    IO.puts("Answer: #{text}")
+
+  {:error, reason} ->
+    IO.puts("Error: #{inspect(reason)}")
+end
+
+IO.puts("")
+
+# generate_text/3 also accepts options. The binary model-string clause routes
+# :base_url / :api_key / :receive_timeout into Model.parse, while
+# :system / :temperature / :max_tokens / :top_p become the request settings.
+IO.puts("--- generate_text/3 with options ---")
+IO.puts("Prompt: Say hello. (as a pirate, temp 0.7)\n")
+
+case Nous.LLM.generate_text(model, "Say hello.",
+       system: "You are a pirate. Keep it to one short sentence.",
+       temperature: 0.7,
+       max_tokens: 100,
+       # HTTP receive timeout in ms; local/reasoning models can be slow.
+       receive_timeout: 120_000
+     ) do
+  {:ok, text} -> IO.puts("Answer: #{text}")
+  {:error, reason} -> IO.puts("Error: #{inspect(reason)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# 2. generate_text!/3 - bang variant, returns the string or raises
+# ============================================================================
+
+IO.puts("--- 2. generate_text!/3 (bang, raises on error) ---")
+IO.puts("Prompt: Name one primary color. One word.\n")
+
+# The bang variant returns the string directly or RAISES. In a script you'd
+# normally let it crash; here we rescue so the demo keeps running offline.
+try do
+  text = Nous.LLM.generate_text!(model, "Name one primary color. One word.")
+  IO.puts("Answer: #{text}")
+rescue
+  e in [Nous.Errors.ModelError, Nous.Errors.ProviderError] ->
+    IO.puts("(generate_text!/3 raised — no provider reachable: #{Exception.message(e)})")
+end
+
+IO.puts("")
+
+# ============================================================================
+# 3. stream_text/3 - returns {:ok, stream}
+# ============================================================================
+#
+# Important: the bare LLM stream is NOT the same shape as the agent's
+# `Nous.run_stream`. With no tools, `stream_text/3` yields plain TEXT STRINGS
+# (it internally filters {:text_delta, _} events and maps them to the text).
+# There is no {:finish, _} or {:complete, _} terminator here - the stream just
+# ends. (When tools are supplied, the stream may additionally yield an
+# {:error, reason} tuple if a turn fails.)
+
+IO.puts("--- 3. stream_text/3 (yields text chunks) ---")
+IO.puts("Prompt: Count from 1 to 5, one number per line.\n")
+
+case Nous.LLM.stream_text(model, "Count from 1 to 5, one number per line.") do
+  {:ok, stream} ->
+    # Each chunk is a String; write them as they arrive.
+    stream
+    |> Stream.each(fn
+      {:error, reason} -> IO.puts("\n[Stream Error: #{inspect(reason)}]")
+      chunk when is_binary(chunk) -> IO.write(chunk)
+    end)
+    |> Stream.run()
+
+    IO.puts("\n[stream complete]")
+
+  {:error, reason} ->
+    IO.puts("Error: #{inspect(reason)}")
+end
+
+IO.puts("")
+
+# ============================================================================
+# 4. Passing a %Nous.Model{} struct instead of a string
+# ============================================================================
+#
+# Every function above has a String clause and a %Model{} clause. Building the
+# struct yourself lets you set fields like receive_timeout / base_url up front
+# and reuse it across calls.
+
+IO.puts("--- 4. Using a %Nous.Model{} struct ---")
+
+model_struct = Nous.Model.parse(model, receive_timeout: 120_000)
+IO.puts("Built: #{model_struct.provider}:#{model_struct.model}\n")
+
+case Nous.LLM.generate_text(model_struct, "Reply with the single word: ready") do
+  {:ok, text} -> IO.puts("Answer: #{text}")
+  {:error, reason} -> IO.puts("(no provider reachable: #{inspect(reason)})")
+end
+
+IO.puts("\nNext: mix run examples/01_hello_world.exs  - the full agent API")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nous.MixProject do
   use Mix.Project
 
-  @version "0.16.1"
+  @version "0.16.6"
   @source_url "https://github.com/nyo16/nous"
 
   def project do


### PR DESCRIPTION
Follow-up to the documentation overhaul (#63). Docs/examples only — no library behavior changes.

## CHANGELOG
- Add the missing **`0.12.13`** (`custom:` provider, #34) and **`0.12.12`** (memory/context/AgentServer fixes) entries — both had release tags but no changelog sections — plus matching compare-links.

## `mix docs` → 0 warnings
- Qualify `Agent.new/2` → `Nous.Agent.new/2` (resolves & links correctly).
- De-link historical references to since-private/hidden APIs in `CHANGELOG.md` and `AGENTS.md` (`run_with_tools/6`, `Gemini.parse_content/1`, `Model.default_receive_timeout/1`, `Provider.request/3`, `Plugins.Memory.init/2`, `Nous.Application`, `Persistence.ETS.TableOwner`).

## New examples (run or degrade gracefully without a provider)
- `examples/llm_oneshot.exs` — bare `Nous.LLM` API (`generate_text/3`, bang, `stream_text/3`).
- `examples/knowledge_base.exs` — KB store add/search + KB agent plugin.
- `examples/advanced/summarization.exs` — auto-compaction via the Summarization plugin.
- `examples/advanced/web_tools.exs` — WebFetch / SearchScrape / Tavily / Brave.
- Indexed all four in `examples/README.md`.

## Docs
- Clarify the three LiveView examples' distinct roles (patterns reference vs complete chat app vs multi-agent dashboard) — confirmed **not** duplicates.

## Verification
`mix format`, `mix compile --warnings-as-errors`, `mix docs` (**0 warnings**), `mix credo --strict` (clean); the new examples run green offline.

## Deferred (out of scope)
`v0.16.2`–`v0.16.5` are tagged but lack CHANGELOG entries, and `mix.exs @version` (`0.16.1`) is behind the latest tag (`0.16.5`). This needs a dedicated **version/release reconciliation** pass rather than guessed release notes. The README deep-dive trim (optional polish) is also left for a separate PR.


## Version bump
- `@version` `0.16.1` → `0.16.6`. It had been left at `0.16.1` across the `v0.16.2`–`v0.16.5` tags; master is 3 commits past `v0.16.5`, so the next release is `0.16.6`. (The `0.16.2`–`0.16.5` CHANGELOG entries are still a separate reconciliation task.)


## CHANGELOG 0.16.2–0.16.5
- Split the accumulated `[Unreleased]` block into dated `[0.16.2]`–`[0.16.5]` sections (bullets moved verbatim; dates match the git tags). `[0.16.4]` is summarized from #60 since that release added nothing to the changelog at the time. Perf #62 + this docs work sit under `[Unreleased]` for 0.16.6. Added compare-links. Verified no bullet dropped and `mix docs` stays at 0 warnings.
