### PR TITLE
refactor: consolidate OpenAI-compatible provider chat into Nous.Provider macro

### DIFF
--- a/lib/nous/provider.ex
+++ b/lib/nous/provider.ex
@@ -129,6 +129,11 @@ defmodule Nous.Provider do
     default_base_url = Keyword.fetch!(opts, :default_base_url)
     default_env_key = Keyword.fetch!(opts, :default_env_key)
 
+    # Optionally inject the shared OpenAI-compatible `chat/2` + `chat_stream/2`
+    # implementations (plus base-URL resolution and header helpers). Providers
+    # that pass a `:chat` config get them; everyone else implements their own.
+    {chat_code, chat_overridable} = chat_ast(opts)
+
     quote do
       @behaviour Nous.Provider
 
@@ -492,12 +497,188 @@ defmodule Nous.Provider do
         end
       end
 
-      defoverridable count_tokens: 1,
-                     request: 3,
-                     request_stream: 3,
-                     build_request_params: 3,
-                     build_provider_opts: 1,
-                     default_stream_normalizer: 0
+      unquote(chat_code)
+
+      defoverridable unquote(
+                       [
+                         count_tokens: 1,
+                         request: 3,
+                         request_stream: 3,
+                         build_request_params: 3,
+                         build_provider_opts: 1,
+                         default_stream_normalizer: 0
+                       ] ++ chat_overridable
+                     )
     end
   end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Shared OpenAI-compatible chat injection
+  #
+  # Many providers (vLLM, SGLang, LM Studio, Mistral, OpenAI-compatible, Custom)
+  # speak the same OpenAI `/chat/completions` dialect. Their `chat/2` and
+  # `chat_stream/2` bodies are identical except for three axes, all expressed
+  # through the `:chat` option of `use Nous.Provider`:
+  #
+  #   * `:base_url` resolution strategy — `:plain | :local | :required`
+  #   * `:headers` style — `:bearer | :bearer_org`
+  #   * `:timeout` / `:stream_timeout` request timeouts
+  #
+  # Returns `{quoted_code, overridable_specs}` so the caller can both inject the
+  # functions and mark them overridable.
+  # ──────────────────────────────────────────────────────────────────────────
+  @doc false
+  def chat_ast(opts) do
+    case Keyword.get(opts, :chat) do
+      nil ->
+        {nil, []}
+
+      chat_opts ->
+        id = Keyword.fetch!(opts, :id)
+        timeout = Keyword.get(chat_opts, :timeout, 180_000)
+        stream_timeout = Keyword.get(chat_opts, :stream_timeout, 300_000)
+        base_strategy = Keyword.get(chat_opts, :base_url, :plain)
+        header_style = Keyword.get(chat_opts, :headers, :bearer)
+        display_name = Keyword.get(opts, :display_name) || default_display_name(id)
+        base_env = base_url_env(id)
+
+        resolver = resolve_base_url_ast(base_strategy, id, base_env, display_name)
+        headers = build_headers_ast(header_style)
+
+        ast =
+          quote do
+            @impl Nous.Provider
+            def chat(params, opts \\ []) do
+              with {:ok, base} <- chat_resolve_base_url(opts) do
+                url = "#{base}/chat/completions"
+                headers = chat_build_headers(api_key(opts), opts)
+                timeout = Keyword.get(opts, :timeout, unquote(timeout))
+
+                Nous.Providers.HTTP.post(url, params, headers, timeout: timeout)
+              end
+            end
+
+            @impl Nous.Provider
+            def chat_stream(params, opts \\ []) do
+              with {:ok, base} <- chat_resolve_base_url(opts) do
+                url = "#{base}/chat/completions"
+                headers = chat_build_headers(api_key(opts), opts)
+                timeout = Keyword.get(opts, :timeout, unquote(stream_timeout))
+                finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
+                params = Map.put(params, "stream", true)
+
+                Nous.Providers.HTTP.stream(url, params, headers,
+                  timeout: timeout,
+                  finch_name: finch_name
+                )
+              end
+            end
+
+            unquote(resolver)
+            unquote(headers)
+          end
+
+        {ast, [chat: 2, chat_stream: 2]}
+    end
+  end
+
+  # `:plain` — trust the resolved base URL as-is (used by hosted OpenAI-compatible
+  # endpoints like Mistral that take an https URL). Never fails.
+  defp resolve_base_url_ast(:plain, _id, _base_env, _display) do
+    quote do
+      defp chat_resolve_base_url(opts), do: {:ok, base_url(opts)}
+    end
+  end
+
+  # `:local` — local-by-default servers (vLLM/SGLang/LM Studio). Reads a
+  # `<PROVIDER>_BASE_URL` env override and validates through `UrlGuard` with
+  # `allow_private_hosts: true` so localhost works but `file://` etc. is rejected.
+  defp resolve_base_url_ast(:local, _id, base_env, display) do
+    quote do
+      defp chat_resolve_base_url(opts) do
+        base =
+          Keyword.get(opts, :base_url) ||
+            System.get_env(unquote(base_env)) ||
+            base_url(opts)
+
+        case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
+          {:ok, _uri} ->
+            {:ok, base}
+
+          {:error, reason} ->
+            {:error,
+             {:invalid_config,
+              unquote(display) <>
+                " base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
+        end
+      end
+    end
+  end
+
+  # `:required` — user-supplied base URL is mandatory (Custom provider). Validated
+  # through `UrlGuard` for SSRF protection; `allow_private_hosts` is opt-in via
+  # opts or app config for local development.
+  defp resolve_base_url_ast(:required, id, base_env, display) do
+    quote do
+      defp chat_resolve_base_url(opts) do
+        base =
+          Keyword.get(opts, :base_url) ||
+            System.get_env(unquote(base_env)) ||
+            get_in(Application.get_env(:nous, unquote(id), []), [:base_url])
+
+        if is_nil(base) or base == "" do
+          {:error,
+           {:invalid_config,
+            unquote(display) <>
+              " requires a base_url. Set one of: " <>
+              "Nous.new(\"#{unquote(id)}:model\", base_url: \"http://...\"), " <>
+              unquote(base_env) <>
+              " env var, or " <>
+              "config :nous, #{inspect(unquote(id))}, base_url: \"http://...\""}}
+        else
+          allow_private =
+            Keyword.get(opts, :allow_private_hosts) ||
+              get_in(Application.get_env(:nous, unquote(id), []), [:allow_private_hosts]) ||
+              false
+
+          case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: allow_private) do
+            {:ok, _uri} ->
+              {:ok, base}
+
+            {:error, reason} ->
+              {:error,
+               {:invalid_config,
+                unquote(display) <>
+                  " base_url failed SSRF validation: #{reason}. " <>
+                  "Set `allow_private_hosts: true` for local dev if intentional."}}
+          end
+        end
+      end
+    end
+  end
+
+  # `:bearer` — JSON + bearer token. `HTTP.bearer_auth_header/1` returns `[]` for
+  # nil / empty / "not-needed", so the local-server "not-needed" sentinel is kept.
+  defp build_headers_ast(:bearer) do
+    quote do
+      defp chat_build_headers(api_key, _opts) do
+        Nous.Providers.HTTP.json_headers() ++ Nous.Providers.HTTP.bearer_auth_header(api_key)
+      end
+    end
+  end
+
+  # `:bearer_org` — adds the OpenAI `openai-organization` header when present.
+  defp build_headers_ast(:bearer_org) do
+    quote do
+      defp chat_build_headers(api_key, opts) do
+        Nous.Providers.HTTP.json_headers() ++
+          Nous.Providers.HTTP.bearer_auth_header(api_key) ++
+          Nous.Providers.HTTP.organization_header(Keyword.get(opts, :organization))
+      end
+    end
+  end
+
+  defp base_url_env(id), do: (id |> Atom.to_string() |> String.upcase()) <> "_BASE_URL"
+
+  defp default_display_name(id), do: id |> Atom.to_string() |> String.capitalize()
 end

--- a/lib/nous/providers/custom.ex
+++ b/lib/nous/providers/custom.ex
@@ -130,87 +130,15 @@ defmodule Nous.Providers.Custom do
   See `Nous.Providers.OpenAICompatible` for implementation details.
   """
 
+  # The custom provider accepts a user-supplied base URL, so `chat/2` and
+  # `chat_stream/2` are injected by `Nous.Provider` with the `:required` base-URL
+  # strategy: the URL is mandatory and validated through UrlGuard for SSRF
+  # protection (set `allow_private_hosts: true` in opts or app config for local
+  # dev). `bearer_org` headers support the optional `openai-organization` header.
   use Nous.Provider,
     id: :custom,
+    display_name: "Custom provider",
     default_base_url: "",
-    default_env_key: "CUSTOM_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  @default_timeout 120_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts), opts)
-      timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-      HTTP.post(url, params, headers, timeout: timeout)
-    end
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts), opts)
-      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-      finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
-
-      params = Map.put(params, "stream", true)
-
-      HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
-    end
-  end
-
-  # Get base URL from opts, env var, or config (required for custom provider).
-  # The custom provider accepts user-supplied base_url, so the URL is
-  # validated through UrlGuard for SSRF protection. Set
-  # `allow_private_hosts: true` in opts (or :allow_private_hosts in app
-  # config) for local development against private services. Returns
-  # `{:ok, base}` on success or `{:error, {:invalid_config, reason}}` so
-  # callers can pattern-match without rescuing exceptions.
-  defp get_base_url(opts) do
-    base =
-      Keyword.get(opts, :base_url) ||
-        System.get_env("CUSTOM_BASE_URL") ||
-        get_in(Application.get_env(:nous, :custom, []), [:base_url])
-
-    cond do
-      is_nil(base) or base == "" ->
-        {:error,
-         {:invalid_config,
-          "Custom provider requires a base_url. Set one of: " <>
-            "Nous.new(\"custom:model\", base_url: \"http://...\"), " <>
-            "CUSTOM_BASE_URL env var, or " <>
-            "config :nous, :custom, base_url: \"http://...\""}}
-
-      true ->
-        allow_private =
-          Keyword.get(opts, :allow_private_hosts) ||
-            get_in(Application.get_env(:nous, :custom, []), [:allow_private_hosts]) ||
-            false
-
-        case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: allow_private) do
-          {:ok, _uri} ->
-            {:ok, base}
-
-          {:error, reason} ->
-            {:error,
-             {:invalid_config,
-              "Custom provider base_url failed SSRF validation: #{reason}. " <>
-                "Set `allow_private_hosts: true` for local dev if intentional."}}
-        end
-    end
-  end
-
-  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed",
-  # so the "not-needed" sentinel for local servers is preserved.
-  defp build_headers(api_key, opts) do
-    HTTP.json_headers() ++
-      HTTP.bearer_auth_header(api_key) ++
-      HTTP.organization_header(Keyword.get(opts, :organization))
-  end
+    default_env_key: "CUSTOM_API_KEY",
+    chat: [base_url: :required, headers: :bearer_org, timeout: 120_000, stream_timeout: 300_000]
 end

--- a/lib/nous/providers/lmstudio.ex
+++ b/lib/nous/providers/lmstudio.ex
@@ -37,67 +37,16 @@ defmodule Nous.Providers.LMStudio do
 
   """
 
+  # LM Studio is local-by-default and speaks the OpenAI `/chat/completions`
+  # dialect, so `chat/2` and `chat_stream/2` are injected by `Nous.Provider`.
+  # The `:local` strategy reads `LMSTUDIO_BASE_URL` and validates via UrlGuard
+  # with `allow_private_hosts: true` (rejects `file://` etc. while allowing
+  # localhost); auth is optional (`bearer` headers). Local models may be slower,
+  # hence the longer timeouts.
   use Nous.Provider,
     id: :lmstudio,
+    display_name: "LM Studio",
     default_base_url: "http://localhost:1234/v1",
-    default_env_key: "LMSTUDIO_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  # Local models may be slower
-  @default_timeout 120_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-      HTTP.post(url, params, headers, timeout: timeout)
-    end
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-
-      params = Map.put(params, "stream", true)
-
-      HTTP.stream(url, params, headers, timeout: timeout)
-    end
-  end
-
-  # Resolve and validate the base URL. The resolved URL goes through
-  # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (LM Studio is
-  # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default. Returns `{:ok, base}` on success
-  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
-  # without rescuing exceptions.
-  defp get_base_url(opts) do
-    base =
-      Keyword.get(opts, :base_url) ||
-        System.get_env("LMSTUDIO_BASE_URL") ||
-        base_url(opts)
-
-    case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
-      {:ok, _uri} ->
-        {:ok, base}
-
-      {:error, reason} ->
-        {:error,
-         {:invalid_config,
-          "LM Studio base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
-    end
-  end
-
-  # LM Studio doesn't require auth, but we support it if configured.
-  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
-  defp build_headers(api_key) do
-    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
-  end
+    default_env_key: "LMSTUDIO_API_KEY",
+    chat: [base_url: :local, headers: :bearer, timeout: 120_000, stream_timeout: 300_000]
 end

--- a/lib/nous/providers/mistral.ex
+++ b/lib/nous/providers/mistral.ex
@@ -38,38 +38,13 @@ defmodule Nous.Providers.Mistral do
 
   """
 
+  # Mistral is a hosted OpenAI-compatible endpoint, so `chat/2` and
+  # `chat_stream/2` are injected by `Nous.Provider` (`:plain` base URL,
+  # `bearer` auth). Mistral-specific params (`reasoning_mode`, `safe_prompt`,
+  # …) are passed through in the request body unchanged.
   use Nous.Provider,
     id: :mistral,
     default_base_url: "https://api.mistral.ai/v1",
-    default_env_key: "MISTRAL_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  @default_timeout 180_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    url = "#{base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-    HTTP.post(url, params, headers, timeout: timeout)
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    url = "#{base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts))
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-    finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
-
-    params = Map.put(params, "stream", true)
-
-    HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
-  end
-
-  defp build_headers(api_key) do
-    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
-  end
+    default_env_key: "MISTRAL_API_KEY",
+    chat: [base_url: :plain, headers: :bearer, timeout: 180_000, stream_timeout: 300_000]
 end

--- a/lib/nous/providers/openai_compatible.ex
+++ b/lib/nous/providers/openai_compatible.ex
@@ -125,43 +125,14 @@ defmodule Nous.Providers.OpenAICompatible do
   See `Nous.Providers.Custom` for the dedicated custom provider implementation.
   """
 
+  # Generic OpenAI-compatible endpoint: `chat/2` and `chat_stream/2` are
+  # injected by `Nous.Provider` (`:plain` base URL, `bearer_org` headers so the
+  # optional `openai-organization` header is supported). `HTTP.bearer_auth_header/1`
+  # returns `[]` for nil / empty / "not-needed", preserving the local-server
+  # "not-needed" sentinel.
   use Nous.Provider,
     id: :openai_compatible,
     default_base_url: "https://api.openai.com/v1",
-    default_env_key: "OPENAI_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  @default_timeout 180_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    url = "#{base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts), opts)
-    timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-    HTTP.post(url, params, headers, timeout: timeout)
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    url = "#{base_url(opts)}/chat/completions"
-    headers = build_headers(api_key(opts), opts)
-    timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-    finch_name = Keyword.get(opts, :finch_name, Nous.Finch)
-
-    # Ensure stream is enabled
-    params = Map.put(params, "stream", true)
-
-    HTTP.stream(url, params, headers, timeout: timeout, finch_name: finch_name)
-  end
-
-  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed",
-  # so the "not-needed" sentinel for local servers is preserved.
-  defp build_headers(api_key, opts) do
-    HTTP.json_headers() ++
-      HTTP.bearer_auth_header(api_key) ++
-      HTTP.organization_header(Keyword.get(opts, :organization))
-  end
+    default_env_key: "OPENAI_API_KEY",
+    chat: [base_url: :plain, headers: :bearer_org, timeout: 180_000, stream_timeout: 300_000]
 end

--- a/lib/nous/providers/sglang.ex
+++ b/lib/nous/providers/sglang.ex
@@ -46,65 +46,15 @@ defmodule Nous.Providers.SGLang do
 
   """
 
+  # SGLang is local-by-default and speaks the OpenAI `/chat/completions` dialect,
+  # so `chat/2` and `chat_stream/2` are injected by `Nous.Provider`. The
+  # `:local` strategy reads `SGLANG_BASE_URL` and validates via UrlGuard with
+  # `allow_private_hosts: true` (rejects `file://` etc. while allowing
+  # localhost); auth is optional (`bearer` headers).
   use Nous.Provider,
     id: :sglang,
+    display_name: "SGLang",
     default_base_url: "http://localhost:30000/v1",
-    default_env_key: "SGLANG_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  @default_timeout 120_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-      HTTP.post(url, params, headers, timeout: timeout)
-    end
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-
-      params = Map.put(params, "stream", true)
-
-      HTTP.stream(url, params, headers, timeout: timeout)
-    end
-  end
-
-  # Resolve and validate the base URL. The resolved URL goes through
-  # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (SGLang is
-  # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default. Returns `{:ok, base}` on success
-  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
-  # without rescuing exceptions.
-  defp get_base_url(opts) do
-    base =
-      Keyword.get(opts, :base_url) ||
-        System.get_env("SGLANG_BASE_URL") ||
-        base_url(opts)
-
-    case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
-      {:ok, _uri} ->
-        {:ok, base}
-
-      {:error, reason} ->
-        {:error,
-         {:invalid_config, "SGLang base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
-    end
-  end
-
-  # SGLang doesn't require auth by default, but we support it if configured.
-  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
-  defp build_headers(api_key) do
-    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
-  end
+    default_env_key: "SGLANG_API_KEY",
+    chat: [base_url: :local, headers: :bearer, timeout: 120_000, stream_timeout: 300_000]
 end

--- a/lib/nous/providers/vllm.ex
+++ b/lib/nous/providers/vllm.ex
@@ -46,65 +46,15 @@ defmodule Nous.Providers.VLLM do
 
   """
 
+  # vLLM is local-by-default and speaks the OpenAI `/chat/completions` dialect,
+  # so `chat/2` and `chat_stream/2` are injected by `Nous.Provider`. The
+  # `:local` strategy reads `VLLM_BASE_URL` and validates via UrlGuard with
+  # `allow_private_hosts: true` (rejects `file://` etc. while allowing
+  # localhost); auth is optional (`bearer` headers).
   use Nous.Provider,
     id: :vllm,
+    display_name: "vLLM",
     default_base_url: "http://localhost:8000/v1",
-    default_env_key: "VLLM_API_KEY"
-
-  alias Nous.Providers.HTTP
-
-  @default_timeout 120_000
-  @streaming_timeout 300_000
-
-  @impl Nous.Provider
-  def chat(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @default_timeout)
-
-      HTTP.post(url, params, headers, timeout: timeout)
-    end
-  end
-
-  @impl Nous.Provider
-  def chat_stream(params, opts \\ []) do
-    with {:ok, base} <- get_base_url(opts) do
-      url = "#{base}/chat/completions"
-      headers = build_headers(api_key(opts))
-      timeout = Keyword.get(opts, :timeout, @streaming_timeout)
-
-      params = Map.put(params, "stream", true)
-
-      HTTP.stream(url, params, headers, timeout: timeout)
-    end
-  end
-
-  # Resolve and validate the base URL. The resolved URL goes through
-  # `Nous.Tools.UrlGuard` with `allow_private_hosts: true` (vLLM is
-  # local-by-default) to reject malformed schemes (`file://` etc.) while
-  # still allowing the localhost default. Returns `{:ok, base}` on success
-  # or `{:error, {:invalid_config, reason}}` so callers can pattern-match
-  # without rescuing exceptions.
-  defp get_base_url(opts) do
-    base =
-      Keyword.get(opts, :base_url) ||
-        System.get_env("VLLM_BASE_URL") ||
-        base_url(opts)
-
-    case Nous.Tools.UrlGuard.validate(base, allow_private_hosts: true) do
-      {:ok, _uri} ->
-        {:ok, base}
-
-      {:error, reason} ->
-        {:error,
-         {:invalid_config, "vLLM base_url failed validation: #{reason}. Got: #{inspect(base)}"}}
-    end
-  end
-
-  # vLLM doesn't require auth by default, but we support it if configured.
-  # `HTTP.bearer_auth_header/1` returns `[]` for nil / empty / "not-needed".
-  defp build_headers(api_key) do
-    HTTP.json_headers() ++ HTTP.bearer_auth_header(api_key)
-  end
+    default_env_key: "VLLM_API_KEY",
+    chat: [base_url: :local, headers: :bearer, timeout: 120_000, stream_timeout: 300_000]
 end


### PR DESCRIPTION
## Summary

  Six providers — **vLLM, SGLang, LM Studio, Mistral, OpenAICompatible, Custom** —
  carried near-identical `chat/2` + `chat_stream/2` implementations. The local trio
  (vLLM/SGLang/LM Studio) were byte-for-byte structurally identical except for an
  `id`, base URL, env prefix, and display name (a clear three-strikes duplication).

  This extends `use Nous.Provider` with an opt-in `chat:` config that injects the
  shared `chat/2`, `chat_stream/2`, base-URL resolver, and header helpers. The
  duplication reduces to three variation axes:

  | Option | Values | Used by |
  |---|---|---|
  | `base_url:` | `:plain` · `:local` · `:required` | hosted · local servers · user-supplied URL |
  | `headers:` | `:bearer` · `:bearer_org` | with/without `openai-organization` |
  | `timeout:` / `stream_timeout:` | ints | replaces duplicated `@default_timeout`/`@streaming_timeout` |

  Each provider collapses to a moduledoc + a single `use` block. Adding a new
  OpenAI-compatible provider is now just the `chat:` option.

  ## Changes

  - `Nous.Provider` macro: new `chat_ast/1` injects overridable `chat/2`,
    `chat_stream/2`, `chat_resolve_base_url/1`, and `chat_build_headers/2`.
  - vLLM / SGLang / LM Studio / Mistral / OpenAICompatible / Custom: removed
    duplicated bodies, replaced with `chat:` config.

  `7 files changed, 233 insertions(+), 329 deletions(-)` — ~250 lines of
  copy-pasted logic replaced by ~190 lines of reusable macro.

  ## Behavior preservation

  This is a behavior-preserving refactor:

  - Error message strings reproduced **exactly** (generated from `id`/env where
    they were provider-specific — e.g. Custom's SSRF and "requires a base_url"
    messages).
  - One deliberate consistency fix: the local trio now forwards `finch_name` in
    `chat_stream`, matching the convention already used by the **7 other providers**.
    Previously they silently dropped it — they were the outliers.

  ## Verification

  - ✅ Provider tests: **197 passed**
  - ✅ Full suite: **1896 passed**, 102 excluded
  - ✅ `mix credo --strict`: 0 issues
  - ✅ `mix compile --warnings-as-errors`: clean
  - ✅ `mix format --check-formatted`: clean
