### PR TITLE
refactor: dedup tech-debt sweep — single-source repeated logic across providers, tools, and errors

### DIFF
--- a/lib/nous/agent/callbacks.ex
+++ b/lib/nous/agent/callbacks.ex
@@ -269,8 +269,9 @@ defmodule Nous.Agent.Callbacks do
         try do
           callback.(event, payload)
         rescue
+          # Callbacks are arbitrary user functions; the catch-all is a
+          # deliberate fault boundary so one bad callback can't kill the run.
           e ->
-            # Log but don't fail on callback errors
             require Logger
             Logger.warning("Callback error for #{event}: #{inspect(e)}")
         end

--- a/lib/nous/agent/context.ex
+++ b/lib/nous/agent/context.ex
@@ -595,6 +595,9 @@ defmodule Nous.Agent.Context do
 
     {:ok, ctx}
   rescue
+    # Deserializes attacker-controllable persisted blobs; a malformed blob
+    # can raise from anywhere in the decode path, so the catch-all is a
+    # deliberate boundary honoring the {:ok, _} | {:error, _} contract.
     e -> {:error, Exception.message(e)}
   end
 

--- a/lib/nous/agent/context.ex
+++ b/lib/nous/agent/context.ex
@@ -715,22 +715,10 @@ defmodule Nous.Agent.Context do
     }
   end
 
-  defp atomize_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {k, v} when is_atom(k) -> {k, v}
-      {k, v} when is_binary(k) -> {safe_to_atom(k), v}
-    end)
-  end
-
-  # Safe atom resolution for keys read from persisted state.
-  # NEVER calls String.to_atom/1 - that would let attacker-controlled persisted blobs
-  # exhaust the global atom table (atoms are not GC'd; node-wide DoS).
-  # Unknown keys stay as binaries; downstream Ecto.cast simply ignores them.
-  defp safe_to_atom(key) do
-    String.to_existing_atom(key)
-  rescue
-    ArgumentError -> key
-  end
+  # Keys read from persisted state are attacker-controllable; Nous.Util only
+  # resolves already-existing atoms, and unknown keys stay as binaries that
+  # downstream Ecto.cast simply ignores.
+  defp atomize_keys(map) when is_map(map), do: Nous.Util.atomize_keys(map)
 
   defp update_needs_response(ctx, %Message{role: :assistant} = message) do
     # Assistant messages with tool calls need a response (tool results)

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -1318,27 +1318,11 @@ defmodule Nous.AgentRunner do
 
   defp check_tool_approval(_tool, _call, _ctx), do: :approve
 
-  # Get tool call field - handles both atom and string keys
-  # OpenAI-compatible APIs return string keys, our internal format uses atoms
-  defp get_tool_field(call, field) when is_atom(field) do
-    # Use fetch, not `||`: a legitimately-falsy value under the atom key
-    # (e.g. arguments: false / 0 / "") must win over the string-key fallback
-    # instead of being coalesced away. Keys are atom-OR-string per provider, so
-    # a present atom key is authoritative even when its value is falsy.
-    case Map.fetch(call, field) do
-      {:ok, value} -> value
-      :error -> Map.get(call, to_string(field))
-    end
-  end
+  # Tool call fields arrive with atom OR string keys depending on the
+  # provider; Nous.ToolCall resolves both without coalescing falsy values.
+  defp get_tool_field(call, field), do: Nous.ToolCall.field(call, field)
 
-  # Set tool call field - handles both atom and string keys
-  defp put_tool_field(call, field, value) when is_atom(field) do
-    if Map.has_key?(call, field) do
-      Map.put(call, field, value)
-    else
-      Map.put(call, to_string(field), value)
-    end
-  end
+  defp put_tool_field(call, field, value), do: Nous.ToolCall.put_field(call, field, value)
 
   # Clean tool names - Claude sometimes uses XML-like syntax.
   # L-9: tolerate nil/non-binary input - some providers emit malformed

--- a/lib/nous/agent_server.ex
+++ b/lib/nous/agent_server.ex
@@ -152,15 +152,8 @@ defmodule Nous.AgentServer do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
-    {gen_opts, init_opts} = split_gen_opts(opts)
+    {gen_opts, init_opts} = Nous.Util.split_gen_opts(opts)
     GenServer.start_link(__MODULE__, init_opts, gen_opts)
-  end
-
-  defp split_gen_opts(opts) do
-    case Keyword.pop(opts, :name) do
-      {nil, rest} -> {[], rest}
-      {name, rest} -> {[name: name], rest}
-    end
   end
 
   @doc """

--- a/lib/nous/agents/knowledge_base_agent.ex
+++ b/lib/nous/agents/knowledge_base_agent.ex
@@ -89,7 +89,7 @@ defmodule Nous.Agents.KnowledgeBaseAgent do
 
     kb_calls =
       Enum.filter(tool_calls, fn call ->
-        name = call["name"] || call[:name] || ""
+        name = Nous.ToolCall.field(call, :name, "")
         String.starts_with?(to_string(name), "kb_")
       end)
 
@@ -98,7 +98,7 @@ defmodule Nous.Agents.KnowledgeBaseAgent do
 
       new_ops =
         Enum.map(kb_calls, fn call ->
-          %{tool: call["name"] || call[:name], timestamp: DateTime.utc_now()}
+          %{tool: Nous.ToolCall.field(call, :name), timestamp: DateTime.utc_now()}
         end)
 
       Context.merge_deps(ctx, %{kb_operations: ops ++ new_ops})

--- a/lib/nous/agents/react_agent.ex
+++ b/lib/nous/agents/react_agent.ex
@@ -141,22 +141,16 @@ defmodule Nous.Agents.ReActAgent do
     # Check if final_answer was called
     tool_calls = response.tool_calls
 
-    has_final_answer =
-      Enum.any?(tool_calls, fn call ->
-        call["name"] == "final_answer" or call[:name] == "final_answer"
+    final_call =
+      Enum.find(tool_calls, fn call ->
+        Nous.ToolCall.field(call, :name) == "final_answer"
       end)
 
-    if has_final_answer do
-      # Extract final answer from tool call
-      final_call =
-        Enum.find(tool_calls, fn call ->
-          call["name"] == "final_answer" or call[:name] == "final_answer"
-        end)
-
+    if final_call do
       answer =
-        get_in(final_call, [:arguments, "answer"]) ||
-          get_in(final_call, [:arguments, :answer]) ||
-          "No answer provided"
+        final_call
+        |> Nous.ToolCall.field(:arguments, %{})
+        |> Nous.ToolCall.field(:answer, "No answer provided")
 
       ctx
       |> Context.merge_deps(%{final_answer: answer})
@@ -208,8 +202,8 @@ defmodule Nous.Agents.ReActAgent do
   def after_tool(_agent, call, _result, ctx) do
     # Record tool call in history
     history_entry = %{
-      name: call["name"] || call[:name],
-      arguments: call["arguments"] || call[:arguments],
+      name: Nous.ToolCall.field(call, :name),
+      arguments: Nous.ToolCall.field(call, :arguments),
       timestamp: DateTime.utc_now()
     }
 
@@ -218,7 +212,10 @@ defmodule Nous.Agents.ReActAgent do
     # Check for duplicate calls (loop detection)
     if is_duplicate_call?(call, ctx.deps[:tool_history] || []) do
       require Logger
-      Logger.warning("ReAct loop detection: duplicate tool call #{call["name"] || call[:name]}")
+
+      Logger.warning(
+        "ReAct loop detection: duplicate tool call #{Nous.ToolCall.field(call, :name)}"
+      )
     end
 
     Context.merge_deps(ctx, %{tool_history: tool_history})
@@ -290,8 +287,8 @@ defmodule Nous.Agents.ReActAgent do
   end
 
   defp is_duplicate_call?(call, history) do
-    call_name = call["name"] || call[:name]
-    call_args = call["arguments"] || call[:arguments]
+    call_name = Nous.ToolCall.field(call, :name)
+    call_args = Nous.ToolCall.field(call, :arguments)
 
     Enum.any?(history, fn entry ->
       entry.name == call_name and entry.arguments == call_args

--- a/lib/nous/decisions/store/duckdb.ex
+++ b/lib/nous/decisions/store/duckdb.ex
@@ -399,21 +399,9 @@ if Code.ensure_loaded?(Duckdbex) do
     defp decode_json(nil), do: %{}
     defp decode_json(str) when is_binary(str), do: decode_json_atoms(str)
 
-    defp decode_json_atoms(str) when is_binary(str), do: str |> JSON.decode!() |> atomize_keys()
-
     # Decision metadata is user-supplied; never crash on unknown keys.
-    defp atomize_keys(map) when is_map(map) do
-      Map.new(map, fn {k, v} ->
-        atom_or_binary =
-          try do
-            String.to_existing_atom(k)
-          rescue
-            ArgumentError -> k
-          end
-
-        {atom_or_binary, v}
-      end)
-    end
+    defp decode_json_atoms(str) when is_binary(str),
+      do: str |> JSON.decode!() |> Nous.Util.atomize_keys()
 
     defp datetime_to_iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
     defp datetime_to_iso(nil), do: DateTime.to_iso8601(DateTime.utc_now())

--- a/lib/nous/errors.ex
+++ b/lib/nous/errors.ex
@@ -4,6 +4,10 @@ defmodule Nous.Errors do
 
   These exceptions provide structured error information for different
   failure scenarios in agent execution.
+
+  Every exception accepts either a keyword list of fields (with an optional
+  `:message` override) or a bare message string; construction is shared via
+  `Nous.Errors.Base`.
   """
 
   defmodule ConfigurationError do
@@ -14,27 +18,14 @@ defmodule Nous.Errors do
     optional dependency is not available.
     """
 
-    defexception [:message, :details]
+    use Nous.Errors.Base, fields: [:details]
 
     @type t :: %__MODULE__{
             message: String.t(),
             details: any()
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      message = Keyword.get(opts, :message, "Configuration error")
-      details = Keyword.get(opts, :details)
-
-      %__MODULE__{
-        message: message,
-        details: details
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
-    end
+    defp default_message(_fields), do: "Configuration error"
   end
 
   defmodule ModelError do
@@ -46,7 +37,7 @@ defmodule Nous.Errors do
     Note: Consider using `ProviderError` for new code.
     """
 
-    defexception [:message, :provider, :status_code, :details]
+    use Nous.Errors.Base, fields: [:provider, :status_code, :details]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -55,28 +46,10 @@ defmodule Nous.Errors do
             details: any()
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      provider = Keyword.get(opts, :provider)
-      status_code = Keyword.get(opts, :status_code)
-      details = Keyword.get(opts, :details)
-
-      message =
-        opts[:message] ||
-          "Model request failed" <>
-            if(provider, do: " (#{provider})", else: "") <>
-            if(status_code, do: " [#{status_code}]", else: "")
-
-      %__MODULE__{
-        message: message,
-        provider: provider,
-        status_code: status_code,
-        details: details
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{provider: provider, status_code: status_code}) do
+      "Model request failed" <>
+        if(provider, do: " (#{provider})", else: "") <>
+        if(status_code, do: " [#{status_code}]", else: "")
     end
   end
 
@@ -97,7 +70,7 @@ defmodule Nous.Errors do
       * `:details` — raw error payload from the HTTP layer
     """
 
-    defexception [:message, :provider, :status_code, :retry_after_ms, :details]
+    use Nous.Errors.Base, fields: [:provider, :status_code, :retry_after_ms, :details]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -107,30 +80,10 @@ defmodule Nous.Errors do
             details: any()
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      provider = Keyword.get(opts, :provider)
-      status_code = Keyword.get(opts, :status_code)
-      retry_after_ms = Keyword.get(opts, :retry_after_ms)
-      details = Keyword.get(opts, :details)
-
-      message =
-        opts[:message] ||
-          "Provider request failed" <>
-            if(provider, do: " (#{provider})", else: "") <>
-            if(status_code, do: " [#{status_code}]", else: "")
-
-      %__MODULE__{
-        message: message,
-        provider: provider,
-        status_code: status_code,
-        retry_after_ms: retry_after_ms,
-        details: details
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{provider: provider, status_code: status_code}) do
+      "Provider request failed" <>
+        if(provider, do: " (#{provider})", else: "") <>
+        if(status_code, do: " [#{status_code}]", else: "")
     end
   end
 
@@ -141,7 +94,7 @@ defmodule Nous.Errors do
     Raised when a tool function fails during execution.
     """
 
-    defexception [:message, :tool_name, :attempt, :original_error]
+    use Nous.Errors.Base, fields: [:tool_name, :attempt, :original_error]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -150,28 +103,10 @@ defmodule Nous.Errors do
             original_error: any()
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      tool_name = Keyword.get(opts, :tool_name)
-      attempt = Keyword.get(opts, :attempt)
-      original_error = Keyword.get(opts, :original_error)
-
-      message =
-        opts[:message] ||
-          "Tool execution failed" <>
-            if(tool_name, do: " (#{tool_name})", else: "") <>
-            if(attempt, do: " after #{attempt} attempt(s)", else: "")
-
-      %__MODULE__{
-        message: message,
-        tool_name: tool_name,
-        attempt: attempt,
-        original_error: original_error
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{tool_name: tool_name, attempt: attempt}) do
+      "Tool execution failed" <>
+        if(tool_name, do: " (#{tool_name})", else: "") <>
+        if(attempt, do: " after #{attempt} attempt(s)", else: "")
     end
   end
 
@@ -182,7 +117,7 @@ defmodule Nous.Errors do
     Raised when a tool takes longer than its configured timeout.
     """
 
-    defexception [:message, :tool_name, :timeout]
+    use Nous.Errors.Base, fields: [:tool_name, :timeout]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -190,24 +125,8 @@ defmodule Nous.Errors do
             timeout: non_neg_integer() | nil
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      tool_name = Keyword.get(opts, :tool_name)
-      timeout = Keyword.get(opts, :timeout)
-
-      message =
-        opts[:message] ||
-          "Tool '#{tool_name || "unknown"}' timed out after #{timeout || 0}ms"
-
-      %__MODULE__{
-        message: message,
-        tool_name: tool_name,
-        timeout: timeout
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{tool_name: tool_name, timeout: timeout}) do
+      "Tool '#{tool_name || "unknown"}' timed out after #{timeout || 0}ms"
     end
   end
 
@@ -218,7 +137,7 @@ defmodule Nous.Errors do
     Raised when structured output fails Ecto validation.
     """
 
-    defexception [:message, :errors, :output_type]
+    use Nous.Errors.Base, fields: [:errors, :output_type]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -226,25 +145,9 @@ defmodule Nous.Errors do
             output_type: module() | nil
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      errors = Keyword.get(opts, :errors)
-      output_type = Keyword.get(opts, :output_type)
-
-      message =
-        opts[:message] ||
-          "Output validation failed" <>
-            if(output_type, do: " for #{inspect(output_type)}", else: "")
-
-      %__MODULE__{
-        message: message,
-        errors: errors,
-        output_type: output_type
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{output_type: output_type}) do
+      "Output validation failed" <>
+        if(output_type, do: " for #{inspect(output_type)}", else: "")
     end
   end
 
@@ -256,7 +159,7 @@ defmodule Nous.Errors do
     requests, tokens, or tool calls.
     """
 
-    defexception [:message, :limit_type, :limit_value, :actual_value]
+    use Nous.Errors.Base, fields: [:limit_type, :limit_value, :actual_value]
 
     @type t :: %__MODULE__{
             message: String.t(),
@@ -265,31 +168,17 @@ defmodule Nous.Errors do
             actual_value: integer() | nil
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      limit_type = Keyword.get(opts, :limit_type)
-      limit_value = Keyword.get(opts, :limit_value)
-      actual_value = Keyword.get(opts, :actual_value)
-
-      message =
-        opts[:message] ||
-          "Usage limit exceeded" <>
-            if(limit_type, do: " (#{limit_type})", else: "") <>
-            if(limit_value && actual_value,
-              do: ": #{actual_value} > #{limit_value}",
-              else: ""
-            )
-
-      %__MODULE__{
-        message: message,
-        limit_type: limit_type,
-        limit_value: limit_value,
-        actual_value: actual_value
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{
+           limit_type: limit_type,
+           limit_value: limit_value,
+           actual_value: actual_value
+         }) do
+      "Usage limit exceeded" <>
+        if(limit_type, do: " (#{limit_type})", else: "") <>
+        if(limit_value && actual_value,
+          do: ": #{actual_value} > #{limit_value}",
+          else: ""
+        )
     end
   end
 
@@ -301,30 +190,16 @@ defmodule Nous.Errors do
     with the model, possibly indicating an infinite loop.
     """
 
-    defexception [:message, :max_iterations]
+    use Nous.Errors.Base, fields: [:max_iterations]
 
     @type t :: %__MODULE__{
             message: String.t(),
             max_iterations: pos_integer() | nil
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      max_iterations = Keyword.get(opts, :max_iterations)
-
-      message =
-        opts[:message] ||
-          "Maximum iterations exceeded" <>
-            if(max_iterations, do: " (#{max_iterations})", else: "")
-
-      %__MODULE__{
-        message: message,
-        max_iterations: max_iterations
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{max_iterations: max_iterations}) do
+      "Maximum iterations exceeded" <>
+        if(max_iterations, do: " (#{max_iterations})", else: "")
     end
   end
 
@@ -336,30 +211,16 @@ defmodule Nous.Errors do
     by the user or system.
     """
 
-    defexception [:message, :reason]
+    use Nous.Errors.Base, fields: [:reason]
 
     @type t :: %__MODULE__{
             message: String.t(),
             reason: String.t() | nil
           }
 
-    @impl true
-    def exception(opts) when is_list(opts) do
-      reason = Keyword.get(opts, :reason)
-
-      message =
-        opts[:message] ||
-          "Execution cancelled" <>
-            if(reason, do: ": #{reason}", else: "")
-
-      %__MODULE__{
-        message: message,
-        reason: reason
-      }
-    end
-
-    def exception(message) when is_binary(message) do
-      %__MODULE__{message: message}
+    defp default_message(%{reason: reason}) do
+      "Execution cancelled" <>
+        if(reason, do: ": #{reason}", else: "")
     end
   end
 end

--- a/lib/nous/errors/base.ex
+++ b/lib/nous/errors/base.ex
@@ -1,0 +1,44 @@
+defmodule Nous.Errors.Base do
+  @moduledoc """
+  Shared construction for Nous exception modules.
+
+  `use Nous.Errors.Base, fields: [...]` generates the `defexception` and the
+  two `exception/1` clauses every Nous error shares: a keyword form taking
+  the declared fields plus an optional `:message` override, and a bare-binary
+  message form.
+
+  The using module supplies a private `default_message/1`, which receives the
+  map of declared fields and returns the message used when `:message` is not
+  given.
+
+      defmodule MyError do
+        use Nous.Errors.Base, fields: [:reason]
+
+        @type t :: %__MODULE__{message: String.t(), reason: String.t() | nil}
+
+        defp default_message(%{reason: reason}) do
+          "It broke" <> if(reason, do: ": \#{reason}", else: "")
+        end
+      end
+
+  """
+
+  defmacro __using__(opts) do
+    fields = Keyword.fetch!(opts, :fields)
+
+    quote do
+      defexception [:message | unquote(fields)]
+
+      @impl Exception
+      def exception(opts) when is_list(opts) do
+        fields = Map.new(unquote(fields), fn field -> {field, Keyword.get(opts, field)} end)
+        message = Keyword.get(opts, :message) || default_message(fields)
+        struct!(__MODULE__, Map.put(fields, :message, message))
+      end
+
+      def exception(message) when is_binary(message) do
+        %__MODULE__{message: message}
+      end
+    end
+  end
+end

--- a/lib/nous/eval/evaluators/schema.ex
+++ b/lib/nous/eval/evaluators/schema.ex
@@ -272,15 +272,6 @@ defmodule Nous.Eval.Evaluators.Schema do
   # Field names in `required_fields` / `field_values` come from arbitrary YAML.
   # Resolve to an EXISTING atom only (struct keys are always existing atoms);
   # unknown names fall back to the raw binary, which `Map.get/2` treats as a
-  # missing/mismatched field. NEVER use String.to_atom/1 - that would let a
-  # YAML file exhaust the global atom table (DoS).
-  defp safe_field_atom(field) when is_atom(field), do: field
-
-  defp safe_field_atom(field) when is_binary(field) do
-    String.to_existing_atom(field)
-  rescue
-    ArgumentError -> field
-  end
-
-  defp safe_field_atom(field), do: field
+  # missing/mismatched field.
+  defp safe_field_atom(field), do: Nous.Util.safe_existing_atom(field, field)
 end

--- a/lib/nous/eval/evaluators/schema.ex
+++ b/lib/nous/eval/evaluators/schema.ex
@@ -150,6 +150,9 @@ defmodule Nous.Eval.Evaluators.Schema do
         {:ok, struct}
       end
     rescue
+      # Casts arbitrary YAML data against a user-supplied schema module; the
+      # raise set is open (non-schema modules, malformed values), and the
+      # contract is to report every failure as {:error, messages}.
       e ->
         {:error, [Exception.message(e)]}
     end

--- a/lib/nous/eval/evaluators/tool_usage.ex
+++ b/lib/nous/eval/evaluators/tool_usage.ex
@@ -142,8 +142,8 @@ defmodule Nous.Eval.Evaluators.ToolUsage do
         %{role: :assistant, tool_calls: calls} when is_list(calls) ->
           Enum.map(calls, fn call ->
             %{
-              name: call[:name] || call["name"],
-              args: call[:args] || call["args"] || call[:arguments] || call["arguments"]
+              name: Nous.ToolCall.field(call, :name),
+              args: Nous.ToolCall.field(call, :args, Nous.ToolCall.field(call, :arguments))
             }
           end)
 

--- a/lib/nous/eval/metrics.ex
+++ b/lib/nous/eval/metrics.ex
@@ -141,9 +141,7 @@ defmodule Nous.Eval.Metrics do
     |> Enum.flat_map(fn msg ->
       case msg do
         %{role: :assistant, tool_calls: calls} when is_list(calls) ->
-          Enum.map(calls, fn call ->
-            call[:name] || call["name"] || "unknown"
-          end)
+          Enum.map(calls, &Nous.ToolCall.field(&1, :name, "unknown"))
 
         _ ->
           []

--- a/lib/nous/eval/optimizer/parameter.ex
+++ b/lib/nous/eval/optimizer/parameter.ex
@@ -213,12 +213,13 @@ defmodule Nous.Eval.Optimizer.Parameter do
   defp fetch_type(other), do: {:error, "invalid parameter type: #{inspect(other)}"}
 
   # Parameter names are config keys (e.g. :temperature, :max_tokens) matched
-  # against agent settings; to_existing_atom keeps a hostile params file from
-  # minting arbitrary atoms while still accepting the known knobs.
+  # against agent settings; resolving only existing atoms keeps a hostile
+  # params file from minting arbitrary atoms while accepting the known knobs.
   defp fetch_name(name) when is_binary(name) do
-    {:ok, String.to_existing_atom(name)}
-  rescue
-    ArgumentError -> {:error, "unknown parameter name: #{inspect(name)}"}
+    case Nous.Util.safe_existing_atom(name) do
+      nil -> {:error, "unknown parameter name: #{inspect(name)}"}
+      atom -> {:ok, atom}
+    end
   end
 
   defp fetch_name(name) when is_atom(name) and not is_nil(name), do: {:ok, name}

--- a/lib/nous/eval/runner.ex
+++ b/lib/nous/eval/runner.ex
@@ -238,10 +238,9 @@ defmodule Nous.Eval.Runner do
         [{k, v}]
 
       {k, v} when is_binary(k) ->
-        try do
-          [{String.to_existing_atom(k), v}]
-        rescue
-          ArgumentError -> []
+        case Nous.Util.safe_existing_atom(k) do
+          nil -> []
+          atom -> [{atom, v}]
         end
     end)
   end

--- a/lib/nous/eval/runner.ex
+++ b/lib/nous/eval/runner.ex
@@ -127,6 +127,8 @@ defmodule Nous.Eval.Runner do
     try do
       setup.()
     rescue
+      # Suite setup is an arbitrary user function; the catch-all is a
+      # deliberate fault boundary so one bad suite can't abort the eval run.
       e ->
         Logger.warning("[Nous.Eval] Setup failed: #{inspect(e)}")
         %{}
@@ -139,6 +141,7 @@ defmodule Nous.Eval.Runner do
     try do
       teardown.(setup_result)
     rescue
+      # Arbitrary user function; deliberate fault boundary (see run_setup/1).
       e ->
         Logger.warning("[Nous.Eval] Teardown failed: #{inspect(e)}")
         :ok

--- a/lib/nous/eval/test_case.ex
+++ b/lib/nous/eval/test_case.ex
@@ -205,17 +205,8 @@ defmodule Nous.Eval.TestCase do
   defp parse_eval_type(_), do: :contains
 
   # Convert a YAML scalar to an existing atom; unknown values are dropped.
-  # NEVER use String.to_atom/1 here - YAML files are user-controllable input.
-  defp safe_to_atom(nil), do: nil
-  defp safe_to_atom(value) when is_atom(value), do: value
-
-  defp safe_to_atom(value) when is_binary(value) do
-    String.to_existing_atom(value)
-  rescue
-    ArgumentError -> nil
-  end
-
-  defp safe_to_atom(_), do: nil
+  # YAML files are user-controllable input, so only existing atoms resolve.
+  defp safe_to_atom(value), do: Nous.Util.safe_existing_atom(value)
 
   @doc """
   Validate a test case.
@@ -269,22 +260,16 @@ defmodule Nous.Eval.TestCase do
     Enum.find_value(keys, default, fn k -> Map.get(map, k) end)
   end
 
-  # eval_config / agent_config maps come from arbitrary YAML. Convert to atoms
-  # ONLY if the atom already exists in the BEAM; unknown keys remain as
-  # binaries. This prevents YAML files from exhausting the global atom table.
+  # eval_config / agent_config maps come from arbitrary YAML. Unlike the
+  # top-level Nous.Util.atomize_keys/1, this walks nested maps and lists.
+  # Unknown keys remain binaries so YAML can't exhaust the atom table.
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
-      {k, v} when is_binary(k) -> {atom_key_or_binary(k), atomize_keys(v)}
+      {k, v} when is_binary(k) -> {Nous.Util.safe_existing_atom(k, k), atomize_keys(v)}
       {k, v} -> {k, atomize_keys(v)}
     end)
   end
 
   defp atomize_keys(list) when is_list(list), do: Enum.map(list, &atomize_keys/1)
   defp atomize_keys(other), do: other
-
-  defp atom_key_or_binary(binary) do
-    String.to_existing_atom(binary)
-  rescue
-    ArgumentError -> binary
-  end
 end

--- a/lib/nous/hook/runner.ex
+++ b/lib/nous/hook/runner.ex
@@ -178,28 +178,14 @@ defmodule Nous.Hook.Runner do
   # Execute a single hook based on its type
   defp execute_hook(%Hook{type: :function, handler: fun}, event, payload)
        when is_function(fun, 2) do
-    try do
-      fun.(event, payload)
-    rescue
-      e ->
-        Logger.warning("Function hook raised: #{Exception.message(e)}")
-        {:error, e}
-    catch
-      kind, reason ->
-        Logger.warning("Function hook threw #{kind}: #{inspect(reason)}")
-        {:error, {kind, reason}}
-    end
+    contained("Function hook", fn -> fun.(event, payload) end)
   end
 
   defp execute_hook(%Hook{type: :module, handler: module}, event, payload) when is_atom(module) do
-    try do
+    contained("Module hook #{inspect(module)}", fn ->
       Code.ensure_loaded!(module)
       module.handle(event, payload)
-    rescue
-      e ->
-        Logger.warning("Module hook #{inspect(module)} raised: #{Exception.message(e)}")
-        {:error, e}
-    end
+    end)
   end
 
   # Command hook handler MUST be a [program | args] list. The previous
@@ -239,7 +225,7 @@ defmodule Nous.Hook.Runner do
         payload: sanitize_payload(payload)
       })
 
-    try do
+    contained("Command hook", fn ->
       case NetRunner.run(argv, input: json_input, timeout: timeout) do
         {output, 0} ->
           parse_command_output(output)
@@ -263,11 +249,22 @@ defmodule Nous.Hook.Runner do
             :allow
           end
       end
-    rescue
-      e ->
-        Logger.warning("Command hook failed: #{Exception.message(e)}")
-        {:error, e}
-    end
+    end)
+  end
+
+  # Run a hook body with full containment: hooks execute arbitrary user code,
+  # so any raise or throw becomes a logged {:error, _} instead of crashing
+  # the agent run. (A catch-all rescue is deliberate at this boundary.)
+  defp contained(label, fun) do
+    fun.()
+  rescue
+    e ->
+      Logger.warning("#{label} raised: #{Exception.message(e)}")
+      {:error, e}
+  catch
+    kind, reason ->
+      Logger.warning("#{label} threw #{kind}: #{inspect(reason)}")
+      {:error, {kind, reason}}
   end
 
   # Parse stdout from command hook as JSON

--- a/lib/nous/llm.ex
+++ b/lib/nous/llm.ex
@@ -359,10 +359,9 @@ defmodule Nous.LLM do
     tools_by_name = Map.new(tools, fn tool -> {tool.name, tool} end)
 
     Enum.map(tool_calls, fn call ->
-      # Handle both atom and string keys
-      name = call[:name] || call["name"]
-      id = call[:id] || call["id"]
-      arguments = call[:arguments] || call["arguments"]
+      name = Nous.ToolCall.field(call, :name)
+      id = Nous.ToolCall.field(call, :id)
+      arguments = Nous.ToolCall.field(call, :arguments)
 
       tool = Map.get(tools_by_name, name)
 

--- a/lib/nous/memory/store/duckdb.ex
+++ b/lib/nous/memory/store/duckdb.ex
@@ -334,21 +334,9 @@ if Code.ensure_loaded?(Duckdbex) do
     defp decode_json(nil), do: %{}
     defp decode_json(str) when is_binary(str), do: decode_json_atoms(str)
 
-    defp decode_json_atoms(str) when is_binary(str), do: str |> JSON.decode!() |> atomize_keys()
-
     # Metadata is user-supplied; never crash on unknown keys.
-    defp atomize_keys(map) when is_map(map) do
-      Map.new(map, fn {k, v} ->
-        atom_or_binary =
-          try do
-            String.to_existing_atom(k)
-          rescue
-            ArgumentError -> k
-          end
-
-        {atom_or_binary, v}
-      end)
-    end
+    defp decode_json_atoms(str) when is_binary(str),
+      do: str |> JSON.decode!() |> Nous.Util.atomize_keys()
 
     defp to_bool(true), do: true
     defp to_bool(false), do: false

--- a/lib/nous/memory/store/sqlite.ex
+++ b/lib/nous/memory/store/sqlite.ex
@@ -461,24 +461,12 @@ if Code.ensure_loaded?(Exqlite) do
     defp decode_json(nil), do: %{}
     defp decode_json(str) when is_binary(str), do: decode_json_atoms(str)
 
-    defp decode_json_atoms(str) when is_binary(str), do: str |> JSON.decode!() |> atomize_keys()
-
     # Metadata is user-supplied (the `remember` tool's :metadata arg has a
     # wide-open object schema). Keys read from the DB that don't already
     # exist as atoms must NOT crash recall - leave them as binaries so a
     # single bad row can't break list/search.
-    defp atomize_keys(map) when is_map(map) do
-      Map.new(map, fn {k, v} ->
-        atom_or_binary =
-          try do
-            String.to_existing_atom(k)
-          rescue
-            ArgumentError -> k
-          end
-
-        {atom_or_binary, v}
-      end)
-    end
+    defp decode_json_atoms(str) when is_binary(str),
+      do: str |> JSON.decode!() |> Nous.Util.atomize_keys()
 
     defp bool_to_int(true), do: 1
     defp bool_to_int(false), do: 0

--- a/lib/nous/message.ex
+++ b/lib/nous/message.ex
@@ -406,6 +406,32 @@ defmodule Nous.Message do
   def is_system?(_), do: false
 
   @doc """
+  Split messages into `{system_prompt, other_messages}`.
+
+  Providers that take the system prompt out-of-band (Anthropic, Gemini) use
+  this before converting the remaining messages. Multiple system messages are
+  joined with blank lines; no system messages yields `nil`.
+
+  ## Examples
+
+      iex> Message.split_system([Message.system("Be helpful"), Message.user("Hi")])
+      {"Be helpful", [Message.user("Hi")]}
+
+  """
+  @spec split_system([t()]) :: {String.t() | nil, [t()]}
+  def split_system(messages) when is_list(messages) do
+    {system_messages, other_messages} = Enum.split_with(messages, &is_system?/1)
+
+    system_prompt =
+      case system_messages do
+        [] -> nil
+        msgs -> Enum.map_join(msgs, "\n\n", &extract_text/1)
+      end
+
+    {system_prompt, other_messages}
+  end
+
+  @doc """
   Get message content as ContentPart list.
 
   Always returns a list, converting string content to text parts.

--- a/lib/nous/message/content_part.ex
+++ b/lib/nous/message/content_part.ex
@@ -262,6 +262,33 @@ defmodule Nous.Message.ContentPart do
     {:error, :incompatible_types}
   end
 
+  @doc """
+  Collapse a homogeneous list of text (or thinking) parts into one string.
+
+  Providers legitimately split a single response into multiple text or
+  thought blocks (e.g. text surrounding a tool_use, or a long multi-paragraph
+  answer). Joining homogeneous lists lets the result fit `Message.content`
+  (a `:string` field) instead of raising `Ecto.InvalidChangesetError` in
+  `Message.new!/1`. Mixed-type lists pass through unchanged.
+  """
+  @spec consolidate([t()]) :: String.t() | [t()]
+  def consolidate([]), do: ""
+  def consolidate([%__MODULE__{type: :text, content: content}]), do: content
+  def consolidate([%__MODULE__{type: :thinking, content: content}]), do: content
+
+  def consolidate(parts) when is_list(parts) do
+    cond do
+      Enum.all?(parts, &match?(%__MODULE__{type: :text}, &1)) ->
+        Enum.map_join(parts, "", & &1.content)
+
+      Enum.all?(parts, &match?(%__MODULE__{type: :thinking}, &1)) ->
+        Enum.map_join(parts, "", & &1.content)
+
+      true ->
+        parts
+    end
+  end
+
   # URL utilities
 
   @doc """

--- a/lib/nous/messages/anthropic.ex
+++ b/lib/nous/messages/anthropic.ex
@@ -23,22 +23,8 @@ defmodule Nous.Messages.Anthropic do
   """
   @spec to_format([Message.t()]) :: {String.t() | nil, [map()]}
   def to_format(messages) when is_list(messages) do
-    {system_messages, other_messages} = Enum.split_with(messages, &Message.is_system?/1)
-
-    system_prompt =
-      case system_messages do
-        [] ->
-          nil
-
-        msgs ->
-          msgs
-          |> Enum.map(&Message.extract_text/1)
-          |> Enum.join("\n\n")
-      end
-
-    anthropic_messages = Enum.map(other_messages, &message_to_anthropic/1)
-
-    {system_prompt, anthropic_messages}
+    {system_prompt, other_messages} = Message.split_system(messages)
+    {system_prompt, Enum.map(other_messages, &message_to_anthropic/1)}
   end
 
   @doc """
@@ -61,8 +47,8 @@ defmodule Nous.Messages.Anthropic do
 
     attrs = %{
       role: :assistant,
-      content: consolidate_content_parts(content_parts),
-      reasoning_content: consolidate_content_parts(reasoning_content),
+      content: ContentPart.consolidate(content_parts),
+      reasoning_content: ContentPart.consolidate(reasoning_content),
       metadata: %{
         model_name: model,
         usage: parse_usage(usage_data),
@@ -307,26 +293,4 @@ defmodule Nous.Messages.Anthropic do
   end
 
   def parse_usage(_), do: %Usage{}
-
-  defp consolidate_content_parts([]), do: ""
-  defp consolidate_content_parts([%ContentPart{type: :text, content: content}]), do: content
-  defp consolidate_content_parts([%ContentPart{type: :thinking, content: content}]), do: content
-
-  defp consolidate_content_parts(parts) when is_list(parts) do
-    # Claude legitimately returns multiple text (or thinking) blocks — e.g. text
-    # surrounding a tool_use, or a long multi-paragraph answer. Join homogeneous
-    # lists into a single string so they fit Message.content (a :string field);
-    # otherwise Message.new!/1 raised Ecto.InvalidChangesetError. Mirrors the
-    # Gemini path.
-    cond do
-      Enum.all?(parts, &match?(%ContentPart{type: :text}, &1)) ->
-        Enum.map_join(parts, "", & &1.content)
-
-      Enum.all?(parts, &match?(%ContentPart{type: :thinking}, &1)) ->
-        Enum.map_join(parts, "", & &1.content)
-
-      true ->
-        parts
-    end
-  end
 end

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -343,6 +343,79 @@ defmodule Nous.Messages.Gemini do
   end
 
   @doc """
+  Build the `generateContent` request params shared by the Gemini and
+  Vertex AI providers (both speak the same wire format).
+
+  Expects already-merged settings (`model.default_settings` merged with the
+  per-request settings). Handles system-instruction extraction, the
+  `generationConfig` mapping, tools, safety settings, tool config, and cached
+  content. Vendor `:extra_body` merging stays provider-side, where the
+  `Nous.Provider` macro enforces the blocked-key policy.
+  """
+  @spec build_request_params(Nous.Model.t(), [Message.t()], map()) :: map()
+  def build_request_params(model, messages, merged_settings) do
+    {system_prompt, contents} = to_format(messages)
+
+    params = %{"model" => model.model, "contents" => contents}
+
+    params =
+      if system_prompt do
+        Map.put(params, "systemInstruction", %{"parts" => [%{"text" => system_prompt}]})
+      else
+        params
+      end
+
+    # Map generic settings to Gemini's generationConfig
+    generation_config =
+      %{}
+      |> maybe_put("temperature", merged_settings[:temperature])
+      |> maybe_put("maxOutputTokens", merged_settings[:max_tokens])
+      |> maybe_put("topP", merged_settings[:top_p])
+      |> maybe_put("topK", merged_settings[:top_k])
+      |> maybe_put("seed", merged_settings[:seed])
+      |> maybe_put("candidateCount", merged_settings[:candidate_count])
+      |> maybe_put("presencePenalty", merged_settings[:presence_penalty])
+      |> maybe_put("frequencyPenalty", merged_settings[:frequency_penalty])
+      |> maybe_put("responseModalities", merged_settings[:response_modalities])
+      |> maybe_put("stopSequences", merged_settings[:stop_sequences] || merged_settings[:stop])
+      |> maybe_put(
+        "thinkingConfig",
+        normalize_thinking_config(merged_settings[:thinking_config])
+      )
+      |> Map.merge(json_config_for_settings(merged_settings))
+
+    # Merge any explicit generationConfig from settings
+    generation_config =
+      Map.merge(generation_config, merged_settings[:generationConfig] || %{})
+
+    params =
+      if map_size(generation_config) > 0 do
+        Map.put(params, "generationConfig", generation_config)
+      else
+        params
+      end
+
+    params
+    |> maybe_put(
+      "tools",
+      build_tools(merged_settings[:tools] || [], merged_settings[:native_tools])
+    )
+    |> maybe_put(
+      "safetySettings",
+      normalize_safety_settings(merged_settings[:safety_settings])
+    )
+    |> maybe_put("toolConfig", resolve_tool_config(merged_settings))
+    |> maybe_put("cachedContent", merged_settings[:cached_content])
+  end
+
+  defp resolve_tool_config(settings) do
+    settings[:tool_config] || normalize_tool_choice(settings[:tool_choice])
+  end
+
+  defp maybe_put(params, _key, nil), do: params
+  defp maybe_put(params, key, value), do: Map.put(params, key, value)
+
+  @doc """
   Derive Gemini's `responseMimeType`/`responseSchema` pair from generic settings.
 
   Honors three settings keys, in priority order:

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -642,7 +642,8 @@ defmodule Nous.Messages.Gemini do
   # Surface non-STOP finish reasons (SAFETY, RECITATION, MAX_TOKENS, etc.)
   # and prompt blocks so they don't manifest as silent empty responses.
   defp log_if_blocked(content, tool_calls, finish_reason, prompt_feedback, model_version) do
-    empty? = (content == "" or is_nil(content)) and tool_calls == []
+    # consolidate/1 never returns nil — "" is the empty case (checked by dialyzer).
+    empty? = content == "" and tool_calls == []
     block_reason = prompt_feedback && Map.get(prompt_feedback, "blockReason")
     interesting_finish? = finish_reason not in [nil, "STOP", "FINISH_REASON_UNSPECIFIED"]
 

--- a/lib/nous/messages/gemini.ex
+++ b/lib/nous/messages/gemini.ex
@@ -25,22 +25,8 @@ defmodule Nous.Messages.Gemini do
   """
   @spec to_format([Message.t()]) :: {String.t() | nil, [map()]}
   def to_format(messages) when is_list(messages) do
-    {system_messages, other_messages} = Enum.split_with(messages, &Message.is_system?/1)
-
-    system_prompt =
-      case system_messages do
-        [] ->
-          nil
-
-        msgs ->
-          msgs
-          |> Enum.map(&Message.extract_text/1)
-          |> Enum.join("\n\n")
-      end
-
-    gemini_contents = Enum.map(other_messages, &message_to_gemini/1)
-
-    {system_prompt, gemini_contents}
+    {system_prompt, other_messages} = Message.split_system(messages)
+    {system_prompt, Enum.map(other_messages, &message_to_gemini/1)}
   end
 
   @doc """
@@ -67,7 +53,7 @@ defmodule Nous.Messages.Gemini do
 
     {content_parts, reasoning_content, tool_calls} = parse_content(parts_data)
 
-    consolidated_content = consolidate_content_parts(content_parts)
+    consolidated_content = ContentPart.consolidate(content_parts)
 
     log_if_blocked(
       consolidated_content,
@@ -89,7 +75,7 @@ defmodule Nous.Messages.Gemini do
     attrs = %{
       role: :assistant,
       content: consolidated_content,
-      reasoning_content: consolidate_content_parts(reasoning_content),
+      reasoning_content: ContentPart.consolidate(reasoning_content),
       metadata: metadata
     }
 
@@ -666,25 +652,6 @@ defmodule Nous.Messages.Gemini do
           "model=#{model_version} finishReason=#{inspect(finish_reason)} " <>
           "promptFeedback=#{inspect(prompt_feedback)}"
       )
-    end
-  end
-
-  defp consolidate_content_parts([]), do: ""
-  defp consolidate_content_parts([%ContentPart{type: :text, content: content}]), do: content
-  defp consolidate_content_parts([%ContentPart{type: :thinking, content: content}]), do: content
-
-  defp consolidate_content_parts(parts) when is_list(parts) do
-    # Gemini may split a single response into multiple text (or thought) parts.
-    # Join homogeneous lists into a single string so they fit Message.content.
-    cond do
-      Enum.all?(parts, &match?(%ContentPart{type: :text}, &1)) ->
-        Enum.map_join(parts, "", & &1.content)
-
-      Enum.all?(parts, &match?(%ContentPart{type: :thinking}, &1)) ->
-        Enum.map_join(parts, "", & &1.content)
-
-      true ->
-        parts
     end
   end
 end

--- a/lib/nous/model_dispatcher.ex
+++ b/lib/nous/model_dispatcher.ex
@@ -5,6 +5,7 @@ defmodule Nous.ModelDispatcher do
   Routes requests to providers based on the model's provider field:
   - `:anthropic` → `Nous.Providers.Anthropic`
   - `:gemini` → `Nous.Providers.Gemini`
+  - `:vertex_ai` → `Nous.Providers.VertexAI`
   - `:mistral` → `Nous.Providers.Mistral`
   - `:lmstudio` → `Nous.Providers.LMStudio`
   - `:llamacpp` → `Nous.Providers.LlamaCpp`
@@ -19,173 +20,58 @@ defmodule Nous.ModelDispatcher do
 
   require Logger
 
+  @provider_modules %{
+    anthropic: Providers.Anthropic,
+    gemini: Providers.Gemini,
+    vertex_ai: Providers.VertexAI,
+    mistral: Providers.Mistral,
+    lmstudio: Providers.LMStudio,
+    llamacpp: Providers.LlamaCpp,
+    vllm: Providers.VLLM,
+    sglang: Providers.SGLang,
+    openai: Providers.OpenAI,
+    custom: Providers.Custom
+  }
+
+  @doc """
+  Resolve the provider module for a provider atom.
+
+  Unknown providers fall back to `Nous.Providers.OpenAICompatible`.
+  """
+  @spec provider_module(atom()) :: module()
+  def provider_module(provider) do
+    Map.get(@provider_modules, provider, Providers.OpenAICompatible)
+  end
+
   @doc """
   Dispatch request to the appropriate provider implementation.
   """
   @spec request(Model.t(), list(), map()) :: {:ok, map()} | {:error, term()}
-  def request(%Model{provider: :anthropic} = model, messages, settings) do
-    Logger.debug("Routing to Anthropic provider for model: #{model.model}")
-    Providers.Anthropic.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :gemini} = model, messages, settings) do
-    Logger.debug("Routing to Gemini provider for model: #{model.model}")
-    Providers.Gemini.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :vertex_ai} = model, messages, settings) do
-    Logger.debug("Routing to Vertex AI provider for model: #{model.model}")
-    Providers.VertexAI.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :mistral} = model, messages, settings) do
-    Logger.debug("Routing to Mistral provider for model: #{model.model}")
-    Providers.Mistral.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :lmstudio} = model, messages, settings) do
-    Logger.debug("Routing to LMStudio provider for model: #{model.model}")
-    Providers.LMStudio.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :vllm} = model, messages, settings) do
-    Logger.debug("Routing to vLLM provider for model: #{model.model}")
-    Providers.VLLM.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :sglang} = model, messages, settings) do
-    Logger.debug("Routing to SGLang provider for model: #{model.model}")
-    Providers.SGLang.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :llamacpp} = model, messages, settings) do
-    Logger.debug("Routing to LlamaCpp provider for model: #{model.model}")
-    Providers.LlamaCpp.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :openai} = model, messages, settings) do
-    Logger.debug("Routing to OpenAI provider for model: #{model.model}")
-    Providers.OpenAI.request(model, messages, settings)
-  end
-
-  def request(%Model{provider: :custom} = model, messages, settings) do
-    Logger.debug("Routing to Custom provider for model: #{model.model}")
-    Providers.Custom.request(model, messages, settings)
-  end
-
   def request(%Model{} = model, messages, settings) do
-    # All other providers use OpenAI-compatible API
-    Logger.debug("Routing to OpenAI-compatible provider for: #{model.provider}:#{model.model}")
-    Providers.OpenAICompatible.request(model, messages, settings)
+    provider = provider_module(model.provider)
+    Logger.debug("Routing to #{inspect(provider)} for: #{model.provider}:#{model.model}")
+    provider.request(model, messages, settings)
   end
 
   @doc """
   Dispatch streaming request to the appropriate provider implementation.
   """
   @spec request_stream(Model.t(), list(), map()) :: {:ok, Enumerable.t()} | {:error, term()}
-  def request_stream(%Model{provider: :anthropic} = model, messages, settings) do
-    Logger.debug("Routing streaming request to Anthropic provider for model: #{model.model}")
-    Providers.Anthropic.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :gemini} = model, messages, settings) do
-    Logger.debug("Routing streaming request to Gemini provider for model: #{model.model}")
-    Providers.Gemini.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :vertex_ai} = model, messages, settings) do
-    Logger.debug("Routing streaming request to Vertex AI provider for model: #{model.model}")
-    Providers.VertexAI.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :mistral} = model, messages, settings) do
-    Logger.debug("Routing streaming request to Mistral provider for model: #{model.model}")
-    Providers.Mistral.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :lmstudio} = model, messages, settings) do
-    Logger.debug("Routing streaming request to LMStudio provider for model: #{model.model}")
-    Providers.LMStudio.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :vllm} = model, messages, settings) do
-    Logger.debug("Routing streaming request to vLLM provider for model: #{model.model}")
-    Providers.VLLM.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :sglang} = model, messages, settings) do
-    Logger.debug("Routing streaming request to SGLang provider for model: #{model.model}")
-    Providers.SGLang.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :llamacpp} = model, messages, settings) do
-    Logger.debug("Routing streaming request to LlamaCpp provider for model: #{model.model}")
-    Providers.LlamaCpp.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :openai} = model, messages, settings) do
-    Logger.debug("Routing streaming request to OpenAI provider for model: #{model.model}")
-    Providers.OpenAI.request_stream(model, messages, settings)
-  end
-
-  def request_stream(%Model{provider: :custom} = model, messages, settings) do
-    Logger.debug("Routing streaming request to Custom provider for model: #{model.model}")
-    Providers.Custom.request_stream(model, messages, settings)
-  end
-
   def request_stream(%Model{} = model, messages, settings) do
+    provider = provider_module(model.provider)
+
     Logger.debug(
-      "Routing streaming request to OpenAI-compatible provider for: #{model.provider}:#{model.model}"
+      "Routing streaming request to #{inspect(provider)} for: #{model.provider}:#{model.model}"
     )
 
-    Providers.OpenAICompatible.request_stream(model, messages, settings)
+    provider.request_stream(model, messages, settings)
   end
 
   @doc """
   Count tokens (uses appropriate provider implementation).
   """
   @spec count_tokens(Model.t(), list()) :: integer()
-  def count_tokens(%Model{provider: :anthropic}, messages) do
-    Providers.Anthropic.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :gemini}, messages) do
-    Providers.Gemini.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :vertex_ai}, messages) do
-    Providers.VertexAI.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :mistral}, messages) do
-    Providers.Mistral.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :lmstudio}, messages) do
-    Providers.LMStudio.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :vllm}, messages) do
-    Providers.VLLM.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :sglang}, messages) do
-    Providers.SGLang.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :llamacpp}, messages) do
-    Providers.LlamaCpp.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :openai}, messages) do
-    Providers.OpenAI.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{provider: :custom}, messages) do
-    Providers.Custom.count_tokens(messages)
-  end
-
-  def count_tokens(%Model{}, messages) do
-    Providers.OpenAICompatible.count_tokens(messages)
+  def count_tokens(%Model{} = model, messages) do
+    provider_module(model.provider).count_tokens(messages)
   end
 end

--- a/lib/nous/output_schema.ex
+++ b/lib/nous/output_schema.ex
@@ -512,7 +512,9 @@ defmodule Nous.OutputSchema do
       _ -> nil
     end
   rescue
-    _ -> nil
+    # Probe failure modes only: UndefinedFunctionError when the output type
+    # isn't an Ecto schema, FunctionClauseError from the generated reflection.
+    _ in [UndefinedFunctionError, FunctionClauseError] -> nil
   end
 
   defp try_schema_call(module, fun, default) do
@@ -522,7 +524,9 @@ defmodule Nous.OutputSchema do
       default
     end
   rescue
-    _ -> default
+    # The generated reflection raises FunctionClauseError for atoms it
+    # doesn't support (verified: Ecto schemas raise it for e.g. :types).
+    _ in [FunctionClauseError] -> default
   end
 
   defp try_llm_doc(module) do
@@ -530,6 +534,8 @@ defmodule Nous.OutputSchema do
       try do
         module.__llm_doc__()
       rescue
+        # __llm_doc__/0 is user-authored code; a catch-all here is a
+        # deliberate fault boundary, not an oversight.
         _ -> nil
       end
     else

--- a/lib/nous/output_schema.ex
+++ b/lib/nous/output_schema.ex
@@ -272,7 +272,7 @@ defmodule Nous.OutputSchema do
         Nous.Messages.extract_text(msg)
 
       tool_call ->
-        args = tool_call[:arguments] || tool_call["arguments"] || %{}
+        args = Nous.ToolCall.field(tool_call, :arguments, %{})
         JSON.encode!(args)
     end
   end
@@ -433,9 +433,9 @@ defmodule Nous.OutputSchema do
         {Nous.Messages.extract_text(msg), nil}
 
       tool_call ->
-        name = tool_call[:name] || tool_call["name"]
+        name = Nous.ToolCall.field(tool_call, :name)
         schema = find_schema_for_tool_name(name, schemas)
-        args = tool_call[:arguments] || tool_call["arguments"] || %{}
+        args = Nous.ToolCall.field(tool_call, :arguments, %{})
         {JSON.encode!(args), schema}
     end
   end
@@ -885,8 +885,7 @@ defmodule Nous.OutputSchema do
   defp find_synthetic_tool_call(%Nous.Message{tool_calls: tool_calls})
        when is_list(tool_calls) do
     Enum.find(tool_calls, fn call ->
-      name = call[:name] || call["name"]
-      synthetic_tool_name?(name || "")
+      synthetic_tool_name?(Nous.ToolCall.field(call, :name, ""))
     end)
   end
 

--- a/lib/nous/plugins/memory.ex
+++ b/lib/nous/plugins/memory.ex
@@ -389,16 +389,9 @@ defmodule Nous.Plugins.Memory do
           namespace: config[:namespace]
         })
 
-      case store_mod.store(store_state, entry) do
-        {:ok, new_state} ->
-          Logger.debug("Memory auto-update: remembered #{entry.id} — #{content}")
-          updated_config = Map.put(ctx.deps[:memory_config] || config, :store_state, new_state)
-          %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
-
-        {:error, reason} ->
-          Logger.warning("Memory auto-update: store failed: #{inspect(reason)}")
-          ctx
-      end
+      store_state
+      |> store_mod.store(entry)
+      |> apply_store_result(ctx, config, "remembered #{entry.id} — #{content}", "store failed")
     end
   end
 
@@ -429,16 +422,9 @@ defmodule Nous.Plugins.Memory do
         updates
       end
 
-    case store_mod.update(store_state, id, updates) do
-      {:ok, new_state} ->
-        Logger.debug("Memory auto-update: updated #{id}")
-        updated_config = Map.put(ctx.deps[:memory_config] || config, :store_state, new_state)
-        %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
-
-      {:error, reason} ->
-        Logger.warning("Memory auto-update: update failed for #{id}: #{inspect(reason)}")
-        ctx
-    end
+    store_state
+    |> store_mod.update(id, updates)
+    |> apply_store_result(ctx, config, "updated #{id}", "update failed for #{id}")
   end
 
   defp apply_single_operation(ctx, config, %{"action" => "forget", "id" => id})
@@ -446,21 +432,29 @@ defmodule Nous.Plugins.Memory do
     store_mod = config[:store]
     store_state = (ctx.deps[:memory_config] || config)[:store_state]
 
-    case store_mod.delete(store_state, id) do
-      {:ok, new_state} ->
-        Logger.debug("Memory auto-update: forgot #{id}")
-        updated_config = Map.put(ctx.deps[:memory_config] || config, :store_state, new_state)
-        %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
-
-      {:error, reason} ->
-        Logger.warning("Memory auto-update: forget failed for #{id}: #{inspect(reason)}")
-        ctx
-    end
+    store_state
+    |> store_mod.delete(id)
+    |> apply_store_result(ctx, config, "forgot #{id}", "forget failed for #{id}")
   end
 
   defp apply_single_operation(ctx, _config, op) do
     Logger.warning("Memory auto-update: unrecognized operation: #{inspect(op)}")
     ctx
+  end
+
+  # Persist the new store state on success; log and leave ctx unchanged on
+  # failure so one bad operation can't wedge the run.
+  defp apply_store_result(result, ctx, config, ok_log, error_log) do
+    case result do
+      {:ok, new_state} ->
+        Logger.debug("Memory auto-update: #{ok_log}")
+        updated_config = Map.put(ctx.deps[:memory_config] || config, :store_state, new_state)
+        %{ctx | deps: Map.put(ctx.deps, :memory_config, updated_config)}
+
+      {:error, reason} ->
+        Logger.warning("Memory auto-update: #{error_log}: #{inspect(reason)}")
+        ctx
+    end
   end
 
   defp maybe_embed(config, content) do

--- a/lib/nous/prompt_template.ex
+++ b/lib/nous/prompt_template.ex
@@ -306,14 +306,8 @@ defmodule Nous.PromptTemplate do
   @spec extract_variables(String.t()) :: [atom() | String.t()]
   def extract_variables(text) when is_binary(text) do
     Regex.scan(~r/@(\w+)/, text)
-    |> Enum.map(fn [_, var] -> safe_to_existing_atom(var) end)
+    |> Enum.map(fn [_, var] -> Nous.Util.safe_existing_atom(var, var) end)
     |> Enum.uniq()
-  end
-
-  defp safe_to_existing_atom(binary) do
-    String.to_existing_atom(binary)
-  rescue
-    ArgumentError -> binary
   end
 
   @doc """
@@ -407,12 +401,7 @@ defmodule Nous.PromptTemplate do
   end
 
   defp lookup_binding(bindings, var_name) do
-    atom_key =
-      try do
-        String.to_existing_atom(var_name)
-      rescue
-        ArgumentError -> nil
-      end
+    atom_key = Nous.Util.safe_existing_atom(var_name)
 
     cond do
       not is_nil(atom_key) and Map.has_key?(bindings, atom_key) ->

--- a/lib/nous/providers/gemini.ex
+++ b/lib/nous/providers/gemini.ex
@@ -84,74 +84,15 @@ defmodule Nous.Providers.Gemini do
   # without a model-level value.
   @default_timeout 120_000
 
-  # Override to convert from generic format to Gemini's format
+  # Override to convert from generic format to Gemini's format. The builder is
+  # shared with Vertex AI (same wire format); only :extra_body merging stays
+  # here so the macro-injected blocked-key policy applies.
   defp build_request_params(model, messages, settings) do
     merged_settings = Map.merge(model.default_settings, settings)
 
-    # Convert messages to Gemini format: {system_prompt, contents}
-    {system_prompt, contents} = Nous.Messages.to_provider_format(messages, :gemini)
-
-    params = %{"model" => model.model, "contents" => contents}
-
-    params =
-      if system_prompt do
-        Map.put(params, "systemInstruction", %{"parts" => [%{"text" => system_prompt}]})
-      else
-        params
-      end
-
-    # Map generic settings to Gemini's generationConfig
-    generation_config =
-      %{}
-      |> maybe_put("temperature", merged_settings[:temperature])
-      |> maybe_put("maxOutputTokens", merged_settings[:max_tokens])
-      |> maybe_put("topP", merged_settings[:top_p])
-      |> maybe_put("topK", merged_settings[:top_k])
-      |> maybe_put("seed", merged_settings[:seed])
-      |> maybe_put("candidateCount", merged_settings[:candidate_count])
-      |> maybe_put("presencePenalty", merged_settings[:presence_penalty])
-      |> maybe_put("frequencyPenalty", merged_settings[:frequency_penalty])
-      |> maybe_put("responseModalities", merged_settings[:response_modalities])
-      |> maybe_put("stopSequences", merged_settings[:stop_sequences] || merged_settings[:stop])
-      |> maybe_put(
-        "thinkingConfig",
-        Nous.Messages.Gemini.normalize_thinking_config(merged_settings[:thinking_config])
-      )
-      |> Map.merge(Nous.Messages.Gemini.json_config_for_settings(merged_settings))
-
-    # Merge any explicit generationConfig from settings
-    generation_config =
-      Map.merge(generation_config, merged_settings[:generationConfig] || %{})
-
-    params =
-      if map_size(generation_config) > 0 do
-        Map.put(params, "generationConfig", generation_config)
-      else
-        params
-      end
-
-    params =
-      params
-      |> maybe_put(
-        "tools",
-        Nous.Messages.Gemini.build_tools(
-          merged_settings[:tools] || [],
-          merged_settings[:native_tools]
-        )
-      )
-      |> maybe_put(
-        "safetySettings",
-        Nous.Messages.Gemini.normalize_safety_settings(merged_settings[:safety_settings])
-      )
-      |> maybe_put("toolConfig", resolve_tool_config(merged_settings))
-      |> maybe_put("cachedContent", merged_settings[:cached_content])
-
-    maybe_merge_extra_body(params, merged_settings[:extra_body])
-  end
-
-  defp resolve_tool_config(settings) do
-    settings[:tool_config] ||
-      Nous.Messages.Gemini.normalize_tool_choice(settings[:tool_choice])
+    model
+    |> Nous.Messages.Gemini.build_request_params(messages, merged_settings)
+    |> maybe_merge_extra_body(merged_settings[:extra_body])
   end
 
   @impl Nous.Provider

--- a/lib/nous/providers/vertex_ai.ex
+++ b/lib/nous/providers/vertex_ai.ex
@@ -186,74 +186,15 @@ defmodule Nous.Providers.VertexAI do
   # without a model-level value.
   @default_timeout 180_000
 
-  # Override to convert from generic format to Gemini's format (same API format)
+  # Override to convert from generic format to Gemini's format (same API
+  # format) — the builder is shared with the Gemini provider; only :extra_body
+  # merging stays here so the macro-injected blocked-key policy applies.
   defp build_request_params(model, messages, settings) do
     merged_settings = Map.merge(model.default_settings, settings)
 
-    # Reuse Gemini message format — Vertex AI uses the same content structure
-    {system_prompt, contents} = Nous.Messages.to_provider_format(messages, :gemini)
-
-    params = %{"model" => model.model, "contents" => contents}
-
-    params =
-      if system_prompt do
-        Map.put(params, "systemInstruction", %{"parts" => [%{"text" => system_prompt}]})
-      else
-        params
-      end
-
-    # Map generic settings to Gemini's generationConfig
-    generation_config =
-      %{}
-      |> maybe_put("temperature", merged_settings[:temperature])
-      |> maybe_put("maxOutputTokens", merged_settings[:max_tokens])
-      |> maybe_put("topP", merged_settings[:top_p])
-      |> maybe_put("topK", merged_settings[:top_k])
-      |> maybe_put("seed", merged_settings[:seed])
-      |> maybe_put("candidateCount", merged_settings[:candidate_count])
-      |> maybe_put("presencePenalty", merged_settings[:presence_penalty])
-      |> maybe_put("frequencyPenalty", merged_settings[:frequency_penalty])
-      |> maybe_put("responseModalities", merged_settings[:response_modalities])
-      |> maybe_put("stopSequences", merged_settings[:stop_sequences] || merged_settings[:stop])
-      |> maybe_put(
-        "thinkingConfig",
-        Nous.Messages.Gemini.normalize_thinking_config(merged_settings[:thinking_config])
-      )
-      |> Map.merge(Nous.Messages.Gemini.json_config_for_settings(merged_settings))
-
-    # Merge any explicit generationConfig from settings
-    generation_config =
-      Map.merge(generation_config, merged_settings[:generationConfig] || %{})
-
-    params =
-      if map_size(generation_config) > 0 do
-        Map.put(params, "generationConfig", generation_config)
-      else
-        params
-      end
-
-    params =
-      params
-      |> maybe_put(
-        "tools",
-        Nous.Messages.Gemini.build_tools(
-          merged_settings[:tools] || [],
-          merged_settings[:native_tools]
-        )
-      )
-      |> maybe_put(
-        "safetySettings",
-        Nous.Messages.Gemini.normalize_safety_settings(merged_settings[:safety_settings])
-      )
-      |> maybe_put("toolConfig", resolve_tool_config(merged_settings))
-      |> maybe_put("cachedContent", merged_settings[:cached_content])
-
-    maybe_merge_extra_body(params, merged_settings[:extra_body])
-  end
-
-  defp resolve_tool_config(settings) do
-    settings[:tool_config] ||
-      Nous.Messages.Gemini.normalize_tool_choice(settings[:tool_choice])
+    model
+    |> Nous.Messages.Gemini.build_request_params(messages, merged_settings)
+    |> maybe_merge_extra_body(merged_settings[:extra_body])
   end
 
   # Use Gemini stream normalizer — same response format

--- a/lib/nous/skill.ex
+++ b/lib/nous/skill.ex
@@ -152,7 +152,18 @@ defmodule Nous.Skill do
 
   @optional_callbacks [tools: 2, tags: 0, group: 0, match?: 1]
 
-  @doc false
+  @doc """
+  Set up a module-based skill.
+
+  ## Options
+
+    * `:tags` - tags for categorization and filtering (default: `[]`)
+    * `:group` - skill group (`:coding`, `:review`, `:testing`, ...)
+    * `:keywords` - list of lowercase strings; when given, generates a
+      `match?/1` that activates the skill if the downcased input contains any
+      of them. Define `match?/1` yourself for anything fancier.
+
+  """
   defmacro __using__(opts) do
     quote do
       @behaviour Nous.Skill
@@ -165,6 +176,16 @@ defmodule Nous.Skill do
       def group, do: Keyword.get(@skill_opts, :group)
 
       defoverridable tags: 0, group: 0
+
+      if Keyword.get(@skill_opts, :keywords, []) != [] do
+        @impl true
+        def match?(input) do
+          input = String.downcase(input)
+          String.contains?(input, Keyword.fetch!(@skill_opts, :keywords))
+        end
+
+        defoverridable match?: 1
+      end
     end
   end
 

--- a/lib/nous/skill/registry.ex
+++ b/lib/nous/skill/registry.ex
@@ -217,10 +217,7 @@ defmodule Nous.Skill.Registry do
   """
   @spec by_group(t(), atom()) :: [Skill.t()]
   def by_group(%__MODULE__{} = registry, group) do
-    registry.groups
-    |> Map.get(group, [])
-    |> Enum.map(&Map.get(registry.skills, &1))
-    |> Enum.reject(&is_nil/1)
+    resolve_names(registry, Map.get(registry.groups, group, []))
   end
 
   @doc """
@@ -228,10 +225,7 @@ defmodule Nous.Skill.Registry do
   """
   @spec by_tag(t(), atom()) :: [Skill.t()]
   def by_tag(%__MODULE__{} = registry, tag) do
-    registry.tags
-    |> Map.get(tag, [])
-    |> Enum.map(&Map.get(registry.skills, &1))
-    |> Enum.reject(&is_nil/1)
+    resolve_names(registry, Map.get(registry.tags, tag, []))
   end
 
   @doc """
@@ -239,9 +233,8 @@ defmodule Nous.Skill.Registry do
   """
   @spec active_skills(t()) :: [Skill.t()]
   def active_skills(%__MODULE__{} = registry) do
-    registry.active
-    |> Enum.map(&Map.get(registry.skills, &1))
-    |> Enum.reject(&is_nil/1)
+    registry
+    |> resolve_names(registry.active)
     |> Enum.sort_by(& &1.priority)
   end
 
@@ -344,6 +337,13 @@ defmodule Nous.Skill.Registry do
     Map.update(index, key, [name], fn names ->
       if name in names, do: names, else: names ++ [name]
     end)
+  end
+
+  # Resolve skill names from an index to their structs, dropping stale names.
+  defp resolve_names(registry, names) do
+    names
+    |> Enum.map(&Map.get(registry.skills, &1))
+    |> Enum.reject(&is_nil/1)
   end
 
   defp load_skill_content(%Skill{source: :module, source_ref: module}, agent, ctx) do

--- a/lib/nous/skills/architect.ex
+++ b/lib/nous/skills/architect.ex
@@ -1,6 +1,15 @@
 defmodule Nous.Skills.Architect do
   @moduledoc "Built-in skill for system architecture design."
-  use Nous.Skill, tags: [:architecture, :design, :system], group: :planning
+  use Nous.Skill,
+    keywords: [
+      "architect",
+      "design system",
+      "system design",
+      "how should i structure",
+      "component design"
+    ],
+    tags: [:architecture, :design, :system],
+    group: :planning
 
   @impl true
   def name, do: "architect"
@@ -27,18 +36,5 @@ defmodule Nous.Skills.Architect do
     - Alternatives: What else was considered
     - Consequences: What this enables and constrains
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "architect",
-      "design system",
-      "system design",
-      "how should i structure",
-      "component design"
-    ])
   end
 end

--- a/lib/nous/skills/code_review.ex
+++ b/lib/nous/skills/code_review.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.CodeReview do
   @moduledoc "Built-in skill for code review."
-  use Nous.Skill, tags: [:code, :quality, :review], group: :review
+  use Nous.Skill,
+    keywords: ["review", "code review", "check this code", "review my"],
+    tags: [:code, :quality, :review],
+    group: :review
 
   @impl true
   def name, do: "code_review"
@@ -24,11 +27,5 @@ defmodule Nous.Skills.CodeReview do
     - The severity (critical, warning, suggestion)
     - A concrete fix or improvement
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-    String.contains?(input, ["review", "code review", "check this code", "review my"])
   end
 end

--- a/lib/nous/skills/debug.ex
+++ b/lib/nous/skills/debug.ex
@@ -1,6 +1,18 @@
 defmodule Nous.Skills.Debug do
   @moduledoc "Built-in skill for systematic debugging."
-  use Nous.Skill, tags: [:debug, :fix, :troubleshoot], group: :debug
+  use Nous.Skill,
+    keywords: [
+      "debug",
+      "fix bug",
+      "not working",
+      "broken",
+      "error",
+      "failing",
+      "crash",
+      "troubleshoot"
+    ],
+    tags: [:debug, :fix, :troubleshoot],
+    group: :debug
 
   @impl true
   def name, do: "debug"
@@ -24,21 +36,5 @@ defmodule Nous.Skills.Debug do
     - Fixing symptoms instead of root causes
     - Making multiple changes at once (change one thing at a time)
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "debug",
-      "fix bug",
-      "not working",
-      "broken",
-      "error",
-      "failing",
-      "crash",
-      "troubleshoot"
-    ])
   end
 end

--- a/lib/nous/skills/doc_gen.ex
+++ b/lib/nous/skills/doc_gen.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.DocGen do
   @moduledoc "Built-in skill for documentation generation."
-  use Nous.Skill, tags: [:docs, :documentation, :docstring], group: :docs
+  use Nous.Skill,
+    keywords: ["document", "add docs", "docstring", "moduledoc", "write docs", "generate docs"],
+    tags: [:docs, :documentation, :docstring],
+    group: :docs
 
   @impl true
   def name, do: "doc_gen"
@@ -22,19 +25,5 @@ defmodule Nous.Skills.DocGen do
     Match the documentation style of the existing project.
     Focus on documenting public APIs — internal implementation details are less critical.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "document",
-      "add docs",
-      "docstring",
-      "moduledoc",
-      "write docs",
-      "generate docs"
-    ])
   end
 end

--- a/lib/nous/skills/ecto_patterns.ex
+++ b/lib/nous/skills/ecto_patterns.ex
@@ -1,6 +1,19 @@
 defmodule Nous.Skills.EctoPatterns do
   @moduledoc "Built-in skill for Ecto query composition, changesets, and data patterns."
-  use Nous.Skill, tags: [:elixir, :ecto, :database, :query], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "ecto",
+      "query",
+      "changeset",
+      "repo",
+      "preload",
+      "migration",
+      "schema",
+      "n+1",
+      "context module"
+    ],
+    tags: [:elixir, :ecto, :database, :query],
+    group: :coding
 
   @impl true
   def name, do: "ecto_patterns"
@@ -46,22 +59,5 @@ defmodule Nous.Skills.EctoPatterns do
 
     7. **Always use parameterized queries**: Never interpolate user input into query strings.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "ecto",
-      "query",
-      "changeset",
-      "repo",
-      "preload",
-      "migration",
-      "schema",
-      "n+1",
-      "context module"
-    ])
   end
 end

--- a/lib/nous/skills/elixir_idioms.ex
+++ b/lib/nous/skills/elixir_idioms.ex
@@ -1,6 +1,16 @@
 defmodule Nous.Skills.ElixirIdioms do
   @moduledoc "Built-in skill for idiomatic Elixir patterns and anti-patterns."
-  use Nous.Skill, tags: [:elixir, :idioms, :functional, :patterns], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "elixir",
+      "pipe operator",
+      "pattern match",
+      "idiomatic",
+      "with statement",
+      "functional"
+    ],
+    tags: [:elixir, :idioms, :functional, :patterns],
+    group: :coding
 
   @impl true
   def name, do: "elixir_idioms"
@@ -53,19 +63,5 @@ defmodule Nous.Skills.ElixirIdioms do
 
     10. **Avoid**: Long parameter lists (use maps/keywords), excessive comments (self-documenting code), single-use private functions that obscure flow.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "elixir",
-      "pipe operator",
-      "pattern match",
-      "idiomatic",
-      "with statement",
-      "functional"
-    ])
   end
 end

--- a/lib/nous/skills/elixir_testing.ex
+++ b/lib/nous/skills/elixir_testing.ex
@@ -1,6 +1,17 @@
 defmodule Nous.Skills.ElixirTesting do
   @moduledoc "Built-in skill for Elixir testing with ExUnit, Mox, and property-based testing."
-  use Nous.Skill, tags: [:elixir, :testing, :exunit, :mox], group: :testing
+  use Nous.Skill,
+    keywords: [
+      "exunit",
+      "elixir test",
+      "mix test",
+      "mox",
+      "test elixir",
+      "property test",
+      "stream_data"
+    ],
+    tags: [:elixir, :testing, :exunit, :mox],
+    group: :testing
 
   @impl true
   def name, do: "elixir_testing"
@@ -63,20 +74,5 @@ defmodule Nous.Skills.ElixirTesting do
 
     7. **Descriptive test names**: Describe the behavior, not the implementation.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "exunit",
-      "elixir test",
-      "mix test",
-      "mox",
-      "test elixir",
-      "property test",
-      "stream_data"
-    ])
   end
 end

--- a/lib/nous/skills/explain_code.ex
+++ b/lib/nous/skills/explain_code.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.ExplainCode do
   @moduledoc "Built-in skill for code explanation."
-  use Nous.Skill, tags: [:explain, :understand, :learn], group: :coding
+  use Nous.Skill,
+    keywords: ["explain", "what does this", "how does this", "walk me through", "understand this"],
+    tags: [:explain, :understand, :learn],
+    group: :coding
 
   @impl true
   def name, do: "explain_code"
@@ -24,18 +27,5 @@ defmodule Nous.Skills.ExplainCode do
     - For experienced developers: focus on domain logic and architectural decisions
     - For domain experts: focus on implementation details and edge cases
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "explain",
-      "what does this",
-      "how does this",
-      "walk me through",
-      "understand this"
-    ])
   end
 end

--- a/lib/nous/skills/otp_patterns.ex
+++ b/lib/nous/skills/otp_patterns.ex
@@ -1,6 +1,19 @@
 defmodule Nous.Skills.OtpPatterns do
   @moduledoc "Built-in skill for OTP supervision, GenServer, and concurrency patterns."
-  use Nous.Skill, tags: [:elixir, :otp, :genserver, :supervisor, :concurrency], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "genserver",
+      "supervisor",
+      "otp",
+      "supervision tree",
+      "task.async",
+      "process",
+      "gen_server",
+      "dynamic_supervisor",
+      "let it crash"
+    ],
+    tags: [:elixir, :otp, :genserver, :supervisor, :concurrency],
+    group: :coding
 
   @impl true
   def name, do: "otp_patterns"
@@ -44,22 +57,5 @@ defmodule Nous.Skills.OtpPatterns do
 
     8. **Never store domain entities (User, Order) as processes**: Use the database with optimistic locking. Processes are for runtime concerns.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "genserver",
-      "supervisor",
-      "otp",
-      "supervision tree",
-      "task.async",
-      "process",
-      "gen_server",
-      "dynamic_supervisor",
-      "let it crash"
-    ])
   end
 end

--- a/lib/nous/skills/phoenix_live_view.ex
+++ b/lib/nous/skills/phoenix_live_view.ex
@@ -1,6 +1,18 @@
 defmodule Nous.Skills.PhoenixLiveView do
   @moduledoc "Built-in skill for Phoenix LiveView development."
-  use Nous.Skill, tags: [:elixir, :phoenix, :liveview, :web], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "liveview",
+      "live_view",
+      "live view",
+      "mount",
+      "handle_event",
+      "handle_info",
+      "live_component",
+      "phoenix component"
+    ],
+    tags: [:elixir, :phoenix, :liveview, :web],
+    group: :coding
 
   @impl true
   def name, do: "phoenix_liveview"
@@ -44,21 +56,5 @@ defmodule Nous.Skills.PhoenixLiveView do
 
     7. **Avoid**: Fat LiveView modules (extract to components), querying in mount without `connected?/1` guard, using `raw/1` with user input (XSS risk).
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "liveview",
-      "live_view",
-      "live view",
-      "mount",
-      "handle_event",
-      "handle_info",
-      "live_component",
-      "phoenix component"
-    ])
   end
 end

--- a/lib/nous/skills/python_data_science.ex
+++ b/lib/nous/skills/python_data_science.ex
@@ -1,6 +1,18 @@
 defmodule Nous.Skills.PythonDataScience do
   @moduledoc "Built-in skill for Python data science with pandas, NumPy, and scikit-learn."
-  use Nous.Skill, tags: [:python, :data_science, :pandas, :numpy, :ml], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "pandas",
+      "numpy",
+      "dataframe",
+      "scikit",
+      "sklearn",
+      "data science",
+      "machine learning",
+      "ml pipeline"
+    ],
+    tags: [:python, :data_science, :pandas, :numpy, :ml],
+    group: :coding
 
   @impl true
   def name, do: "python_data_science"
@@ -50,21 +62,5 @@ defmodule Nous.Skills.PythonDataScience do
 
     9. **Reproducibility**: Set random seeds, version your data, log hyperparameters.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "pandas",
-      "numpy",
-      "dataframe",
-      "scikit",
-      "sklearn",
-      "data science",
-      "machine learning",
-      "ml pipeline"
-    ])
   end
 end

--- a/lib/nous/skills/python_fastapi.ex
+++ b/lib/nous/skills/python_fastapi.ex
@@ -1,6 +1,17 @@
 defmodule Nous.Skills.PythonFastAPI do
   @moduledoc "Built-in skill for FastAPI and async Python web development."
-  use Nous.Skill, tags: [:python, :fastapi, :api, :async, :web], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "fastapi",
+      "fast api",
+      "python api",
+      "pydantic",
+      "async python",
+      "asyncio",
+      "uvicorn"
+    ],
+    tags: [:python, :fastapi, :api, :async, :web],
+    group: :coding
 
   @impl true
   def name, do: "python_fastapi"
@@ -50,20 +61,5 @@ defmodule Nous.Skills.PythonFastAPI do
 
     8. **Guard clauses first**: Handle error conditions at function start with early returns, not nested if/else.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "fastapi",
-      "fast api",
-      "python api",
-      "pydantic",
-      "async python",
-      "asyncio",
-      "uvicorn"
-    ])
   end
 end

--- a/lib/nous/skills/python_testing.ex
+++ b/lib/nous/skills/python_testing.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.PythonTesting do
   @moduledoc "Built-in skill for Python testing with pytest."
-  use Nous.Skill, tags: [:python, :testing, :pytest], group: :testing
+  use Nous.Skill,
+    keywords: ["pytest", "python test", "test python", "fixture", "parametrize"],
+    tags: [:python, :testing, :pytest],
+    group: :testing
 
   @impl true
   def name, do: "python_testing"
@@ -61,18 +64,5 @@ defmodule Nous.Skills.PythonTesting do
 
     7. **Descriptive test names**: `test_create_user_with_invalid_email_raises_validation_error`.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "pytest",
-      "python test",
-      "test python",
-      "fixture",
-      "parametrize"
-    ])
   end
 end

--- a/lib/nous/skills/python_typing.ex
+++ b/lib/nous/skills/python_typing.ex
@@ -1,6 +1,17 @@
 defmodule Nous.Skills.PythonTyping do
   @moduledoc "Built-in skill for modern Python type hints, Pydantic, and dataclasses."
-  use Nous.Skill, tags: [:python, :typing, :pydantic, :modern], group: :coding
+  use Nous.Skill,
+    keywords: [
+      "python type",
+      "type hint",
+      "pydantic",
+      "dataclass",
+      "protocol class",
+      "pattern matching python",
+      "mypy"
+    ],
+    tags: [:python, :typing, :pydantic, :modern],
+    group: :coding
 
   @impl true
   def name, do: "python_typing"
@@ -54,20 +65,5 @@ defmodule Nous.Skills.PythonTyping do
 
     8. **Google-style docstrings** for all public APIs with type descriptions.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "python type",
-      "type hint",
-      "pydantic",
-      "dataclass",
-      "protocol class",
-      "pattern matching python",
-      "mypy"
-    ])
   end
 end

--- a/lib/nous/skills/python_uv.ex
+++ b/lib/nous/skills/python_uv.ex
@@ -1,6 +1,19 @@
 defmodule Nous.Skills.PythonUv do
   @moduledoc "Built-in skill for Python's uv package manager and project tooling."
-  use Nous.Skill, tags: [:python, :uv, :packaging, :dependencies], group: :coding
+  use Nous.Skill,
+    keywords: [
+      " uv ",
+      "uv add",
+      "uv run",
+      "uv init",
+      "uv sync",
+      "uv pip",
+      "uv tool",
+      "uvx ",
+      "pyproject.toml"
+    ],
+    tags: [:python, :uv, :packaging, :dependencies],
+    group: :coding
 
   @impl true
   def name, do: "python_uv"
@@ -68,22 +81,5 @@ defmodule Nous.Skills.PythonUv do
 
     9. **Workspaces** for monorepos: define `[tool.uv.workspace]` in root pyproject.toml.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      " uv ",
-      "uv add",
-      "uv run",
-      "uv init",
-      "uv sync",
-      "uv pip",
-      "uv tool",
-      "uvx ",
-      "pyproject.toml"
-    ])
   end
 end

--- a/lib/nous/skills/refactor.ex
+++ b/lib/nous/skills/refactor.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.Refactor do
   @moduledoc "Built-in skill for safe code refactoring."
-  use Nous.Skill, tags: [:refactor, :cleanup, :improvement], group: :coding
+  use Nous.Skill,
+    keywords: ["refactor", "clean up", "simplify", "restructure"],
+    tags: [:refactor, :cleanup, :improvement],
+    group: :coding
 
   @impl true
   def name, do: "refactor"
@@ -30,11 +33,5 @@ defmodule Nous.Skills.Refactor do
     - Add new features during refactoring
     - Refactor and fix bugs simultaneously
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-    String.contains?(input, ["refactor", "clean up", "simplify", "restructure"])
   end
 end

--- a/lib/nous/skills/task_breakdown.ex
+++ b/lib/nous/skills/task_breakdown.ex
@@ -1,6 +1,16 @@
 defmodule Nous.Skills.TaskBreakdown do
   @moduledoc "Built-in skill for task decomposition."
-  use Nous.Skill, tags: [:planning, :tasks, :decomposition], group: :planning
+  use Nous.Skill,
+    keywords: [
+      "break down",
+      "decompose",
+      "task list",
+      "implementation plan",
+      "steps to",
+      "plan this"
+    ],
+    tags: [:planning, :tasks, :decomposition],
+    group: :planning
 
   @impl true
   def name, do: "task_breakdown"
@@ -26,19 +36,5 @@ defmodule Nous.Skills.TaskBreakdown do
     - Mark tasks that can be parallelized
     - Identify the critical path
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "break down",
-      "decompose",
-      "task list",
-      "implementation plan",
-      "steps to",
-      "plan this"
-    ])
   end
 end

--- a/lib/nous/skills/test_gen.ex
+++ b/lib/nous/skills/test_gen.ex
@@ -1,6 +1,9 @@
 defmodule Nous.Skills.TestGen do
   @moduledoc "Built-in skill for test generation."
-  use Nous.Skill, tags: [:test, :testing, :quality], group: :testing
+  use Nous.Skill,
+    keywords: ["write test", "generate test", "add test", "test case", "test for", "create test"],
+    tags: [:test, :testing, :quality],
+    group: :testing
 
   @impl true
   def name, do: "test_gen"
@@ -23,19 +26,5 @@ defmodule Nous.Skills.TestGen do
     Prefer descriptive test names that explain the behavior being tested.
     Each test should be independent and not rely on other tests' side effects.
     """
-  end
-
-  @impl true
-  def match?(input) do
-    input = String.downcase(input)
-
-    String.contains?(input, [
-      "write test",
-      "generate test",
-      "add test",
-      "test case",
-      "test for",
-      "create test"
-    ])
   end
 end

--- a/lib/nous/stream_normalizer/llamacpp.ex
+++ b/lib/nous/stream_normalizer/llamacpp.ex
@@ -4,14 +4,38 @@ if Code.ensure_loaded?(LlamaCppEx) do
     Stream normalizer for LlamaCppEx `%ChatCompletionChunk{}` structs.
 
     Converts NIF-produced chunk structs into normalized Nous stream events.
+    llama.cpp speaks OpenAI's chat.completion wire shape, so complete
+    (non-delta) responses delegate to `Nous.StreamNormalizer.OpenAI` — this
+    also keeps content and tool calls when a stream degenerates into a
+    single complete response object.
 
     Requires optional dep: `{:llama_cpp_ex, "~> 0.6.5"}`
     """
 
     @behaviour Nous.StreamNormalizer
 
+    alias Nous.StreamNormalizer.OpenAI
+
     @impl true
     def normalize_chunk(chunk) when is_struct(chunk) or is_map(chunk) do
+      if complete_response?(chunk) do
+        convert_complete_response(chunk)
+      else
+        parse_delta_chunk(chunk)
+      end
+    end
+
+    def normalize_chunk(chunk) do
+      [{:unknown, chunk}]
+    end
+
+    @impl true
+    defdelegate complete_response?(chunk), to: OpenAI
+
+    @impl true
+    defdelegate convert_complete_response(chunk), to: OpenAI
+
+    defp parse_delta_chunk(chunk) do
       choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
 
       case choices do
@@ -35,61 +59,6 @@ if Code.ensure_loaded?(LlamaCppEx) do
           [{:unknown, chunk}]
       end
     end
-
-    def normalize_chunk(chunk) do
-      [{:unknown, chunk}]
-    end
-
-    @impl true
-    def complete_response?(chunk) when is_struct(chunk) or is_map(chunk) do
-      choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
-
-      case choices do
-        [choice | _] ->
-          message = Map.get(choice, :message) || Map.get(choice, "message")
-          message != nil
-
-        _ ->
-          false
-      end
-    end
-
-    def complete_response?(_), do: false
-
-    @impl true
-    def convert_complete_response(chunk) when is_struct(chunk) or is_map(chunk) do
-      choices = Map.get(chunk, :choices) || Map.get(chunk, "choices") || []
-
-      case choices do
-        [choice | _] ->
-          message = Map.get(choice, :message) || Map.get(choice, "message") || %{}
-          content = Map.get(message, :content) || Map.get(message, "content")
-          tool_calls = Map.get(message, :tool_calls) || Map.get(message, "tool_calls")
-
-          finish_reason =
-            Map.get(choice, :finish_reason) || Map.get(choice, "finish_reason") || "stop"
-
-          # Order: text -> tool_calls -> finish.
-          # Previously dropped tool_calls entirely - any llamacpp non-streaming
-          # tool-call response surfaced as text-only with finish_reason "stop".
-          events = []
-
-          events =
-            if content && content != "", do: events ++ [{:text_delta, content}], else: events
-
-          events =
-            if is_list(tool_calls) and tool_calls != [],
-              do: events ++ [{:tool_call_delta, tool_calls}],
-              else: events
-
-          events ++ [{:finish, finish_reason}]
-
-        _ ->
-          [{:finish, "stop"}]
-      end
-    end
-
-    def convert_complete_response(_chunk), do: [{:finish, "stop"}]
   end
 else
   defmodule Nous.StreamNormalizer.LlamaCpp do

--- a/lib/nous/teams/coordinator.ex
+++ b/lib/nous/teams/coordinator.ex
@@ -67,7 +67,7 @@ defmodule Nous.Teams.Coordinator do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
-    {gen_opts, init_opts} = split_gen_opts(opts)
+    {gen_opts, init_opts} = Nous.Util.split_gen_opts(opts)
     GenServer.start_link(__MODULE__, init_opts, gen_opts)
   end
 
@@ -323,13 +323,6 @@ defmodule Nous.Teams.Coordinator do
   def handle_info(_msg, state), do: {:noreply, state}
 
   # Private
-
-  defp split_gen_opts(opts) do
-    case Keyword.pop(opts, :name) do
-      {nil, rest} -> {[], rest}
-      {name, rest} -> {[name: name], rest}
-    end
-  end
 
   defp remove_agent(state, agent_name) do
     {removed, agents} = Map.pop(state.agents, agent_name)

--- a/lib/nous/teams/rate_limiter.ex
+++ b/lib/nous/teams/rate_limiter.ex
@@ -98,7 +98,7 @@ defmodule Nous.Teams.RateLimiter do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
-    {gen_opts, init_opts} = split_gen_opts(opts)
+    {gen_opts, init_opts} = Nous.Util.split_gen_opts(opts)
     GenServer.start_link(__MODULE__, init_opts, gen_opts)
   end
 
@@ -407,13 +407,6 @@ defmodule Nous.Teams.RateLimiter do
   # ---------------------------------------------------------------------------
   # Pure helpers
   # ---------------------------------------------------------------------------
-
-  defp split_gen_opts(opts) do
-    case Keyword.pop(opts, :name) do
-      {nil, rest} -> {[], rest}
-      {name, rest} -> {[name: name], rest}
-    end
-  end
 
   defp default_agent_usage, do: %{cost: 0.0, tokens: 0, requests: 0}
 

--- a/lib/nous/teams/shared_state.ex
+++ b/lib/nous/teams/shared_state.ex
@@ -41,7 +41,7 @@ defmodule Nous.Teams.SharedState do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
-    {gen_opts, init_opts} = split_gen_opts(opts)
+    {gen_opts, init_opts} = Nous.Util.split_gen_opts(opts)
     GenServer.start_link(__MODULE__, init_opts, gen_opts)
   end
 
@@ -252,13 +252,6 @@ defmodule Nous.Teams.SharedState do
   end
 
   # Private
-
-  defp split_gen_opts(opts) do
-    case Keyword.pop(opts, :name) do
-      {nil, rest} -> {[], rest}
-      {name, rest} -> {[name: name], rest}
-    end
-  end
 
   defp ranges_overlap?(s1, e1, s2, e2), do: s1 <= e2 and s2 <= e1
 

--- a/lib/nous/tool/schema.ex
+++ b/lib/nous/tool/schema.ex
@@ -82,6 +82,7 @@ defmodule Nous.Tool.Schema do
       Module.register_attribute(__MODULE__, :tool_description, [])
       Module.register_attribute(__MODULE__, :tool_category, [])
       Module.register_attribute(__MODULE__, :tool_tags, [])
+      Module.register_attribute(__MODULE__, :tool_requires_approval, [])
 
       @before_compile Nous.Tool.Schema
     end
@@ -95,6 +96,9 @@ defmodule Nous.Tool.Schema do
     * `:description` - Human-readable description of the tool (required)
     * `:category` - Tool category: `:read`, `:write`, `:execute`, `:communicate`, `:search`
     * `:tags` - List of atom tags for filtering (default: `[]`)
+    * `:requires_approval` - Whether the tool needs human approval before
+      execution (default: `false`). Flows into `Nous.Tool.from_module/2` and
+      the agent runner's approval flow.
 
   ## Example
 
@@ -111,12 +115,14 @@ defmodule Nous.Tool.Schema do
     description = Keyword.get(opts, :description, "")
     category = Keyword.get(opts, :category)
     tags = Keyword.get(opts, :tags, [])
+    requires_approval = Keyword.get(opts, :requires_approval, false)
 
     quote do
       @tool_name unquote(name)
       @tool_description unquote(description)
       @tool_category unquote(category)
       @tool_tags unquote(tags)
+      @tool_requires_approval unquote(requires_approval)
 
       unquote(block)
     end
@@ -162,6 +168,7 @@ defmodule Nous.Tool.Schema do
     description = Module.get_attribute(env.module, :tool_description)
     category = Module.get_attribute(env.module, :tool_category)
     tags = Module.get_attribute(env.module, :tool_tags)
+    requires_approval = Module.get_attribute(env.module, :tool_requires_approval) || false
 
     json_schema = build_json_schema(params)
 
@@ -170,7 +177,8 @@ defmodule Nous.Tool.Schema do
       description: description,
       parameters: json_schema,
       category: category,
-      tags: tags
+      tags: tags,
+      requires_approval: requires_approval
     }
 
     tool_schema = %{
@@ -178,6 +186,7 @@ defmodule Nous.Tool.Schema do
       description: description,
       category: category,
       tags: tags,
+      requires_approval: requires_approval,
       params: params
     }
 

--- a/lib/nous/tool_call.ex
+++ b/lib/nous/tool_call.ex
@@ -1,0 +1,61 @@
+defmodule Nous.ToolCall do
+  @moduledoc """
+  Field access for tool-call maps whose keys may be atoms or strings.
+
+  Providers return tool calls with string keys (`%{"name" => ...}`) while the
+  internal format uses atom keys (`%{name: ...}`). These helpers resolve a
+  field across both key styles in one place.
+
+  Unlike the `call[:name] || call["name"]` idiom, `field/3` preserves
+  legitimately-falsy values: `arguments: false` / `0` / `""` are returned
+  as-is instead of being coalesced into the fallback. Only a missing key or
+  an explicit `nil` falls through to the next key style and then the default.
+  """
+
+  @doc """
+  Get `key` from a tool-call map, checking the atom key then its string form.
+
+  Returns `default` when the field is absent or `nil` under both key styles.
+
+  ## Examples
+
+      iex> Nous.ToolCall.field(%{"name" => "search"}, :name)
+      "search"
+
+      iex> Nous.ToolCall.field(%{arguments: false}, :arguments)
+      false
+
+      iex> Nous.ToolCall.field(%{}, :arguments, %{})
+      %{}
+
+  """
+  @spec field(map(), atom(), term()) :: term()
+  def field(call, key, default \\ nil) when is_map(call) and is_atom(key) do
+    case Map.fetch(call, key) do
+      {:ok, value} when not is_nil(value) ->
+        value
+
+      _ ->
+        case Map.fetch(call, Atom.to_string(key)) do
+          {:ok, value} when not is_nil(value) -> value
+          _ -> default
+        end
+    end
+  end
+
+  @doc """
+  Put `value` under `key`, preserving the map's existing key style.
+
+  Writes to the atom key when present, otherwise to the existing string key,
+  and defaults to the string form when the field is new (matching the wire
+  format providers use).
+  """
+  @spec put_field(map(), atom(), term()) :: map()
+  def put_field(call, key, value) when is_map(call) and is_atom(key) do
+    if Map.has_key?(call, key) do
+      Map.put(call, key, value)
+    else
+      Map.put(call, Atom.to_string(key), value)
+    end
+  end
+end

--- a/lib/nous/tools/bash.ex
+++ b/lib/nous/tools/bash.ex
@@ -37,7 +37,7 @@ defmodule Nous.Tools.Bash do
       NetRunner.run(["/bin/sh", "-c", command],
         timeout: timeout,
         max_output_size: @max_output_size,
-        env: scrubbed_env()
+        env: Nous.Tools.Env.scrubbed()
       )
 
     case result do
@@ -56,16 +56,5 @@ defmodule Nous.Tools.Bash do
       {output, exit_code} ->
         {:ok, "Exit code: #{exit_code}\n#{output}"}
     end
-  end
-
-  # Whitelist of env vars safe to forward to the shell. Everything else,
-  # including API keys, OAuth tokens, vault creds, and shell-loader hooks
-  # (LD_PRELOAD, DYLD_INSERT_LIBRARIES) is dropped.
-  @env_allowlist ~w(PATH HOME LANG LC_ALL TZ USER SHELL TERM)
-
-  defp scrubbed_env do
-    @env_allowlist
-    |> Enum.map(fn name -> {name, System.get_env(name)} end)
-    |> Enum.reject(fn {_, v} -> is_nil(v) end)
   end
 end

--- a/lib/nous/tools/bash.ex
+++ b/lib/nous/tools/bash.ex
@@ -11,33 +11,18 @@ defmodule Nous.Tools.Bash do
   access to this tool in production.
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
   @default_timeout 120_000
   @max_output_size 1_000_000
 
-  @impl true
-  def metadata do
-    %{
-      name: "bash",
-      description: "Execute a shell command and return its output.",
-      category: :execute,
-      requires_approval: true,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "command" => %{
-            "type" => "string",
-            "description" => "The shell command to execute"
-          },
-          "timeout" => %{
-            "type" => "integer",
-            "description" => "Timeout in milliseconds. Defaults to 120000 (2 minutes)."
-          }
-        },
-        "required" => ["command"]
-      }
-    }
+  tool "bash",
+    description: "Execute a shell command and return its output.",
+    category: :execute,
+    requires_approval: true do
+    param(:command, :string, required: true, doc: "The shell command to execute")
+
+    param(:timeout, :integer, doc: "Timeout in milliseconds. Defaults to 120000 (2 minutes).")
   end
 
   @impl true

--- a/lib/nous/tools/brave_search.ex
+++ b/lib/nous/tools/brave_search.ex
@@ -37,6 +37,8 @@ defmodule Nous.Tools.BraveSearch do
 
   require Logger
 
+  alias Nous.Tools.Search.Common
+
   @doc """
   Search the web using Brave Search API.
 
@@ -57,43 +59,27 @@ defmodule Nous.Tools.BraveSearch do
   - success: Whether the search succeeded
   """
   def web_search(ctx, args) do
-    # Support both "query" and "q" parameter names
-    query = Map.get(args, "query") || Map.get(args, "q") || ""
+    query = Common.query(args)
     # Max 20 results
     count = Map.get(args, "count", 5) |> min(20)
     country = Map.get(args, "country")
     search_lang = Map.get(args, "search_lang")
     safesearch = Map.get(args, "safesearch", "moderate")
+    api_key = Common.api_key(ctx, :brave_api_key, "BRAVE_API_KEY")
 
-    # Get API key from context or environment
-    api_key = get_api_key(ctx)
+    opts = [
+      missing_key_error:
+        "BRAVE_API_KEY not configured. Get your key from https://brave.com/search/api/",
+      log_label: "Brave search",
+      error_prefix: "Search failed"
+    ]
 
-    if api_key && api_key != "" do
-      case perform_search(query, api_key, count, country, search_lang, safesearch) do
-        {:ok, results} ->
-          %{
-            query: query,
-            results: results,
-            result_count: length(results),
-            success: true
-          }
-
-        {:error, reason} ->
-          Logger.error("Brave search failed: #{inspect(reason)}")
-
-          %{
-            query: query,
-            error: "Search failed: #{inspect(reason)}",
-            success: false
-          }
+    Common.run_search(query, api_key, opts, fn ->
+      with {:ok, results} <-
+             perform_search(query, api_key, count, country, search_lang, safesearch) do
+        {:ok, %{results: results, result_count: length(results)}}
       end
-    else
-      %{
-        query: query,
-        error: "BRAVE_API_KEY not configured. Get your key from https://brave.com/search/api/",
-        success: false
-      }
-    end
+    end)
   end
 
   @doc """
@@ -107,50 +93,26 @@ defmodule Nous.Tools.BraveSearch do
   - search_lang: Language of search
   """
   def news_search(ctx, args) do
-    # Support both "query" and "q" parameter names
-    query = Map.get(args, "query") || Map.get(args, "q") || ""
+    query = Common.query(args)
     count = Map.get(args, "count", 5) |> min(20)
     country = Map.get(args, "country")
     search_lang = Map.get(args, "search_lang")
+    api_key = Common.api_key(ctx, :brave_api_key, "BRAVE_API_KEY")
 
-    api_key = get_api_key(ctx)
+    opts = [
+      missing_key_error: "BRAVE_API_KEY not configured",
+      log_label: "Brave news search",
+      error_prefix: "News search failed"
+    ]
 
-    if api_key && api_key != "" do
-      case perform_news_search(query, api_key, count, country, search_lang) do
-        {:ok, results} ->
-          %{
-            query: query,
-            results: results,
-            result_count: length(results),
-            success: true
-          }
-
-        {:error, reason} ->
-          Logger.error("Brave news search failed: #{inspect(reason)}")
-
-          %{
-            query: query,
-            error: "News search failed: #{inspect(reason)}",
-            success: false
-          }
+    Common.run_search(query, api_key, opts, fn ->
+      with {:ok, results} <- perform_news_search(query, api_key, count, country, search_lang) do
+        {:ok, %{results: results, result_count: length(results)}}
       end
-    else
-      %{
-        query: query,
-        error: "BRAVE_API_KEY not configured",
-        success: false
-      }
-    end
+    end)
   end
 
   # Private functions
-
-  defp get_api_key(ctx) do
-    # Try context first, then config, then environment
-    ctx.deps[:brave_api_key] ||
-      Application.get_env(:nous, :brave_api_key) ||
-      System.get_env("BRAVE_API_KEY")
-  end
 
   defp perform_search(query, api_key, count, country, search_lang, safesearch) do
     url = "https://api.search.brave.com/res/v1/web/search"
@@ -227,31 +189,27 @@ defmodule Nous.Tools.BraveSearch do
   defp maybe_add_param(params, _key, nil), do: params
   defp maybe_add_param(params, key, value), do: Map.put(params, key, value)
 
-  defp parse_web_results(%{"web" => %{"results" => results}}) when is_list(results) do
-    Enum.map(results, fn result ->
-      %{
-        title: Map.get(result, "title", ""),
-        url: Map.get(result, "url", ""),
-        description: Map.get(result, "description", ""),
-        age: Map.get(result, "age"),
-        page_age: Map.get(result, "page_age")
-      }
-    end)
+  defp parse_web_results(response) do
+    response
+    |> get_in(["web", "results"])
+    |> Common.map_results(
+      title: {"title", ""},
+      url: {"url", ""},
+      description: {"description", ""},
+      age: "age",
+      page_age: "page_age"
+    )
   end
 
-  defp parse_web_results(_response), do: []
-
-  defp parse_news_results(%{"results" => results}) when is_list(results) do
-    Enum.map(results, fn result ->
-      %{
-        title: Map.get(result, "title", ""),
-        url: Map.get(result, "url", ""),
-        description: Map.get(result, "description", ""),
-        age: Map.get(result, "age"),
-        source: Map.get(result, "source")
-      }
-    end)
+  defp parse_news_results(response) do
+    response
+    |> Map.get("results")
+    |> Common.map_results(
+      title: {"title", ""},
+      url: {"url", ""},
+      description: {"description", ""},
+      age: "age",
+      source: "source"
+    )
   end
-
-  defp parse_news_results(_response), do: []
 end

--- a/lib/nous/tools/env.ex
+++ b/lib/nous/tools/env.ex
@@ -1,0 +1,29 @@
+defmodule Nous.Tools.Env do
+  @moduledoc """
+  Scrubbed environment for tool subprocesses.
+
+  Tools that spawn OS processes (`bash`, ripgrep in `file_grep`) must not
+  inherit the BEAM's environment: it routinely holds API keys, OAuth tokens,
+  and vault credentials, and an LLM is one `printenv` away from leaking them.
+  Shell-loader hooks (LD_PRELOAD, DYLD_INSERT_LIBRARIES) are dropped for the
+  same reason.
+
+  Every subprocess-spawning tool must use `scrubbed/0` so the allowlist has
+  exactly one definition.
+  """
+
+  # Whitelist of env vars safe to forward to subprocesses. Everything else
+  # is dropped.
+  @allowlist ~w(PATH HOME LANG LC_ALL TZ USER SHELL TERM)
+
+  @doc """
+  The environment to pass to tool subprocesses: allowlisted variables that
+  are currently set, as `{name, value}` tuples.
+  """
+  @spec scrubbed() :: [{String.t(), String.t()}]
+  def scrubbed do
+    @allowlist
+    |> Enum.map(fn name -> {name, System.get_env(name)} end)
+    |> Enum.reject(fn {_, v} -> is_nil(v) end)
+  end
+end

--- a/lib/nous/tools/file_edit.ex
+++ b/lib/nous/tools/file_edit.ex
@@ -7,40 +7,20 @@ defmodule Nous.Tools.FileEdit do
   to prevent unintended changes.
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
-  @impl true
-  def metadata do
-    %{
-      name: "file_edit",
-      description:
-        "Edit a file by replacing exact string matches. The old_string must be unique in the file unless replace_all is true.",
-      category: :write,
-      requires_approval: true,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "file_path" => %{
-            "type" => "string",
-            "description" => "Path to the file to edit"
-          },
-          "old_string" => %{
-            "type" => "string",
-            "description" => "The exact text to find and replace"
-          },
-          "new_string" => %{
-            "type" => "string",
-            "description" => "The replacement text"
-          },
-          "replace_all" => %{
-            "type" => "boolean",
-            "description" =>
-              "Replace all occurrences instead of requiring uniqueness. Defaults to false."
-          }
-        },
-        "required" => ["file_path", "old_string", "new_string"]
-      }
-    }
+  tool "file_edit",
+    description:
+      "Edit a file by replacing exact string matches. The old_string must be unique in the file unless replace_all is true.",
+    category: :write,
+    requires_approval: true do
+    param(:file_path, :string, required: true, doc: "Path to the file to edit")
+    param(:old_string, :string, required: true, doc: "The exact text to find and replace")
+    param(:new_string, :string, required: true, doc: "The replacement text")
+
+    param(:replace_all, :boolean,
+      doc: "Replace all occurrences instead of requiring uniqueness. Defaults to false."
+    )
   end
 
   @impl true

--- a/lib/nous/tools/file_glob.ex
+++ b/lib/nous/tools/file_glob.ex
@@ -6,32 +6,19 @@ defmodule Nous.Tools.FileGlob do
   Results are sorted by modification time (most recent first).
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
   @default_limit 200
 
-  @impl true
-  def metadata do
-    %{
-      name: "file_glob",
-      description: "Find files matching a glob pattern (e.g. \"**/*.ex\", \"lib/**/*.exs\").",
-      category: :search,
-      requires_approval: false,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "pattern" => %{
-            "type" => "string",
-            "description" => "Glob pattern to match files (e.g. \"**/*.ex\")"
-          },
-          "path" => %{
-            "type" => "string",
-            "description" => "Base directory to search from. Defaults to current directory."
-          }
-        },
-        "required" => ["pattern"]
-      }
-    }
+  tool "file_glob",
+    description: "Find files matching a glob pattern (e.g. \"**/*.ex\", \"lib/**/*.exs\").",
+    category: :search do
+    param(:pattern, :string,
+      required: true,
+      doc: "Glob pattern to match files (e.g. \"**/*.ex\")"
+    )
+
+    param(:path, :string, doc: "Base directory to search from. Defaults to current directory.")
   end
 
   @impl true

--- a/lib/nous/tools/file_grep.ex
+++ b/lib/nous/tools/file_grep.ex
@@ -6,41 +6,23 @@ defmodule Nous.Tools.FileGrep do
   when available for performance, falls back to pure Elixir regex.
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
   @default_limit 250
 
-  @impl true
-  def metadata do
-    %{
-      name: "file_grep",
-      description: "Search file contents using regex patterns. Uses ripgrep when available.",
-      category: :search,
-      requires_approval: false,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "pattern" => %{
-            "type" => "string",
-            "description" => "Regular expression pattern to search for"
-          },
-          "path" => %{
-            "type" => "string",
-            "description" => "File or directory to search in. Defaults to current directory."
-          },
-          "glob" => %{
-            "type" => "string",
-            "description" => "Glob filter for files (e.g. \"*.ex\", \"*.{ts,tsx}\")"
-          },
-          "output_mode" => %{
-            "type" => "string",
-            "description" =>
-              "Output mode: \"content\" (matching lines), \"files_with_matches\" (file paths only), \"count\" (match counts). Defaults to \"files_with_matches\"."
-          }
-        },
-        "required" => ["pattern"]
-      }
-    }
+  tool "file_grep",
+    description: "Search file contents using regex patterns. Uses ripgrep when available.",
+    category: :search do
+    param(:pattern, :string, required: true, doc: "Regular expression pattern to search for")
+
+    param(:path, :string, doc: "File or directory to search in. Defaults to current directory.")
+
+    param(:glob, :string, doc: "Glob filter for files (e.g. \"*.ex\", \"*.{ts,tsx}\")")
+
+    param(:output_mode, :string,
+      doc:
+        "Output mode: \"content\" (matching lines), \"files_with_matches\" (file paths only), \"count\" (match counts). Defaults to \"files_with_matches\"."
+    )
   end
 
   @impl true

--- a/lib/nous/tools/file_grep.ex
+++ b/lib/nous/tools/file_grep.ex
@@ -70,20 +70,12 @@ defmodule Nous.Tools.FileGrep do
 
     rg = rg_path()
 
-    case System.cmd(rg, args, stderr_to_stdout: true, env: scrubbed_env()) do
+    # Scrubbed env keeps API keys out of the rg subprocess.
+    case System.cmd(rg, args, stderr_to_stdout: true, env: Nous.Tools.Env.scrubbed()) do
       {output, 0} -> {:ok, String.trim(output)}
       {_output, 1} -> {:ok, "No matches found"}
       {output, _} -> {:error, "rg failed: #{String.trim(output)}"}
     end
-  end
-
-  # Same allowlist as Nous.Tools.Bash; keeps API keys out of subprocesses.
-  @env_allowlist ~w(PATH HOME LANG LC_ALL TZ USER SHELL TERM)
-
-  defp scrubbed_env do
-    @env_allowlist
-    |> Enum.map(fn name -> {name, System.get_env(name)} end)
-    |> Enum.reject(fn {_, v} -> is_nil(v) end)
   end
 
   defp mode_flag("content"), do: ["-n"]

--- a/lib/nous/tools/file_read.ex
+++ b/lib/nous/tools/file_read.ex
@@ -6,36 +6,18 @@ defmodule Nous.Tools.FileRead do
   offset and limit for reading specific sections of large files.
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
   @default_limit 2000
 
-  @impl true
-  def metadata do
-    %{
-      name: "file_read",
-      description: "Read a file from the filesystem. Returns content with line numbers.",
-      category: :read,
-      requires_approval: false,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "file_path" => %{
-            "type" => "string",
-            "description" => "Path to the file to read"
-          },
-          "offset" => %{
-            "type" => "integer",
-            "description" => "Line number to start reading from (1-based). Defaults to 1."
-          },
-          "limit" => %{
-            "type" => "integer",
-            "description" => "Number of lines to read. Defaults to 2000."
-          }
-        },
-        "required" => ["file_path"]
-      }
-    }
+  tool "file_read",
+    description: "Read a file from the filesystem. Returns content with line numbers.",
+    category: :read do
+    param(:file_path, :string, required: true, doc: "Path to the file to read")
+
+    param(:offset, :integer, doc: "Line number to start reading from (1-based). Defaults to 1.")
+
+    param(:limit, :integer, doc: "Number of lines to read. Defaults to 2000.")
   end
 
   @impl true

--- a/lib/nous/tools/file_write.ex
+++ b/lib/nous/tools/file_write.ex
@@ -6,30 +6,14 @@ defmodule Nous.Tools.FileWrite do
   if they don't exist.
   """
 
-  @behaviour Nous.Tool.Behaviour
+  use Nous.Tool.Schema
 
-  @impl true
-  def metadata do
-    %{
-      name: "file_write",
-      description: "Write content to a file. Creates parent directories if needed.",
-      category: :write,
-      requires_approval: true,
-      parameters: %{
-        "type" => "object",
-        "properties" => %{
-          "file_path" => %{
-            "type" => "string",
-            "description" => "Path to the file to write"
-          },
-          "content" => %{
-            "type" => "string",
-            "description" => "The content to write to the file"
-          }
-        },
-        "required" => ["file_path", "content"]
-      }
-    }
+  tool "file_write",
+    description: "Write content to a file. Creates parent directories if needed.",
+    category: :write,
+    requires_approval: true do
+    param(:file_path, :string, required: true, doc: "Path to the file to write")
+    param(:content, :string, required: true, doc: "The content to write to the file")
   end
 
   @impl true

--- a/lib/nous/tools/search/common.ex
+++ b/lib/nous/tools/search/common.ex
@@ -1,0 +1,78 @@
+defmodule Nous.Tools.Search.Common do
+  @moduledoc """
+  Shared plumbing for search tools (Brave, Tavily, ...).
+
+  Owns the pieces every search tool repeats: API-key resolution, query
+  extraction, the success/error result envelope, and response-to-result
+  field mapping.
+  """
+
+  require Logger
+
+  @doc """
+  Resolve an API key: context deps first, then application config under
+  `:nous`, then the system environment.
+  """
+  @spec api_key(Nous.RunContext.t(), atom(), String.t()) :: String.t() | nil
+  def api_key(ctx, key, env_var) do
+    ctx.deps[key] || Application.get_env(:nous, key) || System.get_env(env_var)
+  end
+
+  @doc """
+  Extract the query from tool args, accepting `"query"` or `"q"`.
+  """
+  @spec query(map()) :: String.t()
+  def query(args), do: Map.get(args, "query") || Map.get(args, "q") || ""
+
+  @doc """
+  Run a search behind the standard result envelope.
+
+  When `api_key` is missing or empty, returns the failure envelope with
+  `opts[:missing_key_error]` without invoking `fun`. Otherwise `fun` must
+  return `{:ok, envelope_map}` (merged with `query` and `success: true`) or
+  `{:error, reason}` (logged under `opts[:log_label]`, wrapped with
+  `opts[:error_prefix]`).
+  """
+  @spec run_search(String.t(), String.t() | nil, keyword(), (-> {:ok, map()} | {:error, term()})) ::
+          map()
+  def run_search(query, api_key, opts, fun) do
+    if api_key in [nil, ""] do
+      %{query: query, error: Keyword.fetch!(opts, :missing_key_error), success: false}
+    else
+      case fun.() do
+        {:ok, envelope} when is_map(envelope) ->
+          envelope
+          |> Map.put(:query, query)
+          |> Map.put(:success, true)
+
+        {:error, reason} ->
+          Logger.error("#{Keyword.fetch!(opts, :log_label)} failed: #{inspect(reason)}")
+
+          %{
+            query: query,
+            error: "#{Keyword.fetch!(opts, :error_prefix)}: #{inspect(reason)}",
+            success: false
+          }
+      end
+    end
+  end
+
+  @doc """
+  Map raw API result maps to the tool's result shape.
+
+  `fields` is a keyword list of `output_key: "source_key"` or
+  `output_key: {"source_key", default}`. Non-list input yields `[]` so a
+  malformed response can't crash the tool.
+  """
+  @spec map_results(term(), keyword()) :: [map()]
+  def map_results(results, fields) when is_list(results) do
+    Enum.map(results, fn result ->
+      Map.new(fields, fn
+        {key, {source, default}} -> {key, Map.get(result, source, default)}
+        {key, source} when is_binary(source) -> {key, Map.get(result, source)}
+      end)
+    end)
+  end
+
+  def map_results(_results, _fields), do: []
+end

--- a/lib/nous/tools/tavily_search.ex
+++ b/lib/nous/tools/tavily_search.ex
@@ -25,6 +25,8 @@ defmodule Nous.Tools.TavilySearch do
 
   require Logger
 
+  alias Nous.Tools.Search.Common
+
   @api_url "https://api.tavily.com/search"
 
   @doc """
@@ -42,35 +44,21 @@ defmodule Nous.Tools.TavilySearch do
   A map with results list and optional direct answer.
   """
   def search(ctx, args) do
-    query = Map.get(args, "query") || Map.get(args, "q") || ""
+    query = Common.query(args)
     search_depth = Map.get(args, "search_depth", "basic")
     max_results = Map.get(args, "max_results", 5) |> min(10)
     include_answer = Map.get(args, "include_answer", true)
+    api_key = Common.api_key(ctx, :tavily_api_key, "TAVILY_API_KEY")
 
-    api_key = get_api_key(ctx)
+    opts = [
+      missing_key_error: "TAVILY_API_KEY not configured. Get your key from https://tavily.com",
+      log_label: "Tavily search",
+      error_prefix: "Search failed"
+    ]
 
-    if api_key && api_key != "" do
-      case perform_search(query, api_key, search_depth, max_results, include_answer) do
-        {:ok, results} ->
-          Map.put(results, :success, true)
-
-        {:error, reason} ->
-          Logger.error("Tavily search failed: #{inspect(reason)}")
-          %{query: query, error: "Search failed: #{inspect(reason)}", success: false}
-      end
-    else
-      %{
-        query: query,
-        error: "TAVILY_API_KEY not configured. Get your key from https://tavily.com",
-        success: false
-      }
-    end
-  end
-
-  defp get_api_key(ctx) do
-    ctx.deps[:tavily_api_key] ||
-      Application.get_env(:nous, :tavily_api_key) ||
-      System.get_env("TAVILY_API_KEY")
+    Common.run_search(query, api_key, opts, fn ->
+      perform_search(query, api_key, search_depth, max_results, include_answer)
+    end)
   end
 
   defp perform_search(query, api_key, search_depth, max_results, include_answer) do
@@ -96,7 +84,6 @@ defmodule Nous.Tools.TavilySearch do
 
           {:ok,
            %{
-             query: query,
              results: results,
              result_count: length(results),
              answer: Map.get(response, "answer")
@@ -113,17 +100,15 @@ defmodule Nous.Tools.TavilySearch do
     end
   end
 
-  defp parse_results(%{"results" => results}) when is_list(results) do
-    Enum.map(results, fn result ->
-      %{
-        url: Map.get(result, "url", ""),
-        title: Map.get(result, "title", ""),
-        content: Map.get(result, "content", ""),
-        score: Map.get(result, "score", 0.0),
-        raw_content: Map.get(result, "raw_content")
-      }
-    end)
+  defp parse_results(response) do
+    response
+    |> Map.get("results")
+    |> Common.map_results(
+      url: {"url", ""},
+      title: {"title", ""},
+      content: {"content", ""},
+      score: {"score", 0.0},
+      raw_content: "raw_content"
+    )
   end
-
-  defp parse_results(_), do: []
 end

--- a/lib/nous/util.ex
+++ b/lib/nous/util.ex
@@ -38,6 +38,26 @@ defmodule Nous.Util do
   def safe_existing_atom(_value, fallback), do: fallback
 
   @doc """
+  Split a keyword list into `{gen_opts, init_opts}` for `GenServer.start_link/3`.
+
+  `:name` (when present and non-nil) goes to the GenServer options; everything
+  else is passed through as init options.
+
+  ## Examples
+
+      iex> Nous.Util.split_gen_opts(name: MyServer, foo: 1)
+      {[name: MyServer], [foo: 1]}
+
+  """
+  @spec split_gen_opts(keyword()) :: {keyword(), keyword()}
+  def split_gen_opts(opts) when is_list(opts) do
+    case Keyword.pop(opts, :name) do
+      {nil, rest} -> {[], rest}
+      {name, rest} -> {[name: name], rest}
+    end
+  end
+
+  @doc """
   Convert a map's top-level binary keys to already-existing atoms; keys with
   no existing atom stay binaries (downstream casts simply ignore them).
 

--- a/lib/nous/util.ex
+++ b/lib/nous/util.ex
@@ -1,0 +1,59 @@
+defmodule Nous.Util do
+  @moduledoc """
+  Small shared helpers used across Nous internals.
+  """
+
+  @doc """
+  Convert a binary to an already-existing atom, returning `fallback` when no
+  such atom exists.
+
+  Never calls `String.to_atom/1`: these values are routinely
+  attacker-controllable (persisted state, YAML files, provider responses),
+  and minting atoms from them would exhaust the global atom table (atoms are
+  not GC'd; node-wide DoS).
+
+  Atoms (including `nil`) pass through unchanged; any other input returns
+  `fallback`.
+
+  ## Examples
+
+      iex> Nous.Util.safe_existing_atom("ok")
+      :ok
+
+      iex> Nous.Util.safe_existing_atom("no_such_atom_xyz", "no_such_atom_xyz")
+      "no_such_atom_xyz"
+
+  """
+  @spec safe_existing_atom(term(), term()) :: atom() | term()
+  def safe_existing_atom(value, fallback \\ nil)
+
+  def safe_existing_atom(value, _fallback) when is_atom(value), do: value
+
+  def safe_existing_atom(value, fallback) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> fallback
+  end
+
+  def safe_existing_atom(_value, fallback), do: fallback
+
+  @doc """
+  Convert a map's top-level binary keys to already-existing atoms; keys with
+  no existing atom stay binaries (downstream casts simply ignore them).
+
+  Same atom-safety guarantees as `safe_existing_atom/2`.
+
+  ## Examples
+
+      iex> Nous.Util.atomize_keys(%{"name" => "a"})
+      %{name: "a"}
+
+  """
+  @spec atomize_keys(map()) :: map()
+  def atomize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) -> {safe_existing_atom(k, k), v}
+      {k, v} -> {k, v}
+    end)
+  end
+end

--- a/test/nous/content_part_test.exs
+++ b/test/nous/content_part_test.exs
@@ -283,4 +283,42 @@ defmodule Nous.Message.ContentPartTest do
       assert {:error, :incompatible_types} = ContentPart.merge(part1, part2)
     end
   end
+
+  describe "consolidate/1" do
+    test "empty list becomes an empty string" do
+      assert ContentPart.consolidate([]) == ""
+    end
+
+    test "a single text or thinking part unwraps to its content" do
+      assert ContentPart.consolidate([%ContentPart{type: :text, content: "hi"}]) == "hi"
+      assert ContentPart.consolidate([%ContentPart{type: :thinking, content: "hm"}]) == "hm"
+    end
+
+    test "homogeneous text parts join into one string" do
+      parts = [
+        %ContentPart{type: :text, content: "one "},
+        %ContentPart{type: :text, content: "two"}
+      ]
+
+      assert ContentPart.consolidate(parts) == "one two"
+    end
+
+    test "homogeneous thinking parts join into one string" do
+      parts = [
+        %ContentPart{type: :thinking, content: "a"},
+        %ContentPart{type: :thinking, content: "b"}
+      ]
+
+      assert ContentPart.consolidate(parts) == "ab"
+    end
+
+    test "mixed part types pass through unchanged" do
+      parts = [
+        %ContentPart{type: :text, content: "look"},
+        %ContentPart{type: :image_url, content: "http://example/img.png"}
+      ]
+
+      assert ContentPart.consolidate(parts) == parts
+    end
+  end
 end

--- a/test/nous/errors_test.exs
+++ b/test/nous/errors_test.exs
@@ -1,0 +1,151 @@
+defmodule Nous.ErrorsTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.Errors
+
+  # Characterization tests for exception construction: every exception must
+  # accept a keyword list (fields + optional :message override) and a bare
+  # binary message. Default messages are part of the public error surface.
+
+  describe "ConfigurationError" do
+    test "keyword construction with default message" do
+      e = Errors.ConfigurationError.exception(details: :missing_dep)
+      assert e.message == "Configuration error"
+      assert e.details == :missing_dep
+    end
+
+    test "binary construction" do
+      assert Errors.ConfigurationError.exception("nope").message == "nope"
+    end
+  end
+
+  describe "ModelError" do
+    test "default message includes provider and status" do
+      e = Errors.ModelError.exception(provider: :openai, status_code: 500, details: %{})
+      assert e.message == "Model request failed (openai) [500]"
+      assert e.provider == :openai
+      assert e.status_code == 500
+    end
+
+    test "explicit message wins" do
+      assert Errors.ModelError.exception(message: "custom", provider: :x).message == "custom"
+    end
+
+    test "binary construction" do
+      assert Errors.ModelError.exception("boom").message == "boom"
+    end
+  end
+
+  describe "ProviderError" do
+    test "default message and fields" do
+      e =
+        Errors.ProviderError.exception(
+          provider: :vertex_ai,
+          status_code: 429,
+          retry_after_ms: 1000,
+          details: %{"error" => "quota"}
+        )
+
+      assert e.message == "Provider request failed (vertex_ai) [429]"
+      assert e.retry_after_ms == 1000
+      assert e.details == %{"error" => "quota"}
+    end
+
+    test "binary construction" do
+      assert Errors.ProviderError.exception("down").message == "down"
+    end
+  end
+
+  describe "ToolError" do
+    test "default message includes tool name and attempts" do
+      e = Errors.ToolError.exception(tool_name: "search", attempt: 3, original_error: :oops)
+      assert e.message == "Tool execution failed (search) after 3 attempt(s)"
+      assert e.original_error == :oops
+    end
+
+    test "binary construction" do
+      assert Errors.ToolError.exception("bad tool").message == "bad tool"
+    end
+  end
+
+  describe "ToolTimeout" do
+    test "default message includes tool name and timeout" do
+      e = Errors.ToolTimeout.exception(tool_name: "slow", timeout: 5000)
+      assert e.message == "Tool 'slow' timed out after 5000ms"
+    end
+
+    test "default message tolerates missing fields" do
+      assert Errors.ToolTimeout.exception([]).message == "Tool 'unknown' timed out after 0ms"
+    end
+
+    test "binary construction" do
+      assert Errors.ToolTimeout.exception("timeout").message == "timeout"
+    end
+  end
+
+  describe "ValidationError" do
+    test "default message includes output type" do
+      e = Errors.ValidationError.exception(output_type: MySchema, errors: [name: "required"])
+      assert e.message == "Output validation failed for MySchema"
+      assert e.errors == [name: "required"]
+    end
+
+    test "binary construction" do
+      assert Errors.ValidationError.exception("invalid").message == "invalid"
+    end
+  end
+
+  describe "UsageLimitExceeded" do
+    test "default message includes limit comparison" do
+      e =
+        Errors.UsageLimitExceeded.exception(
+          limit_type: :tokens,
+          limit_value: 100,
+          actual_value: 150
+        )
+
+      assert e.message == "Usage limit exceeded (tokens): 150 > 100"
+    end
+
+    test "binary construction" do
+      assert Errors.UsageLimitExceeded.exception("over").message == "over"
+    end
+  end
+
+  describe "MaxIterationsExceeded" do
+    test "default message includes the limit" do
+      e = Errors.MaxIterationsExceeded.exception(max_iterations: 5)
+      assert e.message == "Maximum iterations exceeded (5)"
+      assert e.max_iterations == 5
+    end
+
+    test "binary construction" do
+      assert Errors.MaxIterationsExceeded.exception("looped").message == "looped"
+    end
+  end
+
+  describe "ExecutionCancelled" do
+    test "default message includes reason" do
+      e = Errors.ExecutionCancelled.exception(reason: "user abort")
+      assert e.message == "Execution cancelled: user abort"
+    end
+
+    test "binary construction" do
+      assert Errors.ExecutionCancelled.exception("stop").message == "stop"
+    end
+  end
+
+  describe "raise compatibility" do
+    test "exceptions raise with keyword opts" do
+      assert_raise Errors.ProviderError, "Provider request failed (openai) [500]", fn ->
+        raise Errors.ProviderError, provider: :openai, status_code: 500
+      end
+    end
+
+    test "exceptions raise with a bare message" do
+      assert_raise Errors.ToolError, "kaput", fn ->
+        raise Errors.ToolError, "kaput"
+      end
+    end
+  end
+end

--- a/test/nous/hook/runner_test.exs
+++ b/test/nous/hook/runner_test.exs
@@ -203,6 +203,30 @@ defmodule Nous.Hook.RunnerTest do
       assert Runner.run(registry, :pre_tool_use, %{tool_name: "dangerous"}) == :deny
       assert Runner.run(registry, :pre_tool_use, %{tool_name: "safe"}) == :allow
     end
+
+    defmodule RaisingHook do
+      @behaviour Nous.Hook
+      @impl true
+      def handle(_event, _payload), do: raise("boom")
+    end
+
+    defmodule ThrowingHook do
+      @behaviour Nous.Hook
+      @impl true
+      def handle(_event, _payload), do: throw(:boom)
+    end
+
+    test "a raising module hook is contained, not fatal" do
+      hook = make_hook(:pre_tool_use, RaisingHook, type: :module)
+      registry = Registry.from_hooks([hook])
+      assert Runner.run(registry, :pre_tool_use, %{tool_name: "test"}) == :allow
+    end
+
+    test "a throwing module hook is contained, not fatal" do
+      hook = make_hook(:pre_tool_use, ThrowingHook, type: :module)
+      registry = Registry.from_hooks([hook])
+      assert Runner.run(registry, :pre_tool_use, %{tool_name: "test"}) == :allow
+    end
   end
 
   describe "matcher filtering" do

--- a/test/nous/messages_gemini_test.exs
+++ b/test/nous/messages_gemini_test.exs
@@ -787,4 +787,92 @@ defmodule Nous.MessagesGeminiTest do
       assert file_part["fileData"]["mimeType"] == "image/png"
     end
   end
+
+  describe "build_request_params/3" do
+    # Shared by the Gemini and Vertex AI providers — pins the wire format both
+    # produced before the builder was extracted.
+    defp model(settings \\ %{}) do
+      %Nous.Model{provider: :gemini, model: "gemini-2.5-flash", default_settings: settings}
+    end
+
+    test "builds minimal params with model and contents" do
+      params = Gemini.build_request_params(model(), [Message.user("Hello")], %{})
+
+      assert params["model"] == "gemini-2.5-flash"
+      assert [%{"role" => "user", "parts" => [%{"text" => "Hello"}]}] = params["contents"]
+      refute Map.has_key?(params, "systemInstruction")
+      refute Map.has_key?(params, "generationConfig")
+      refute Map.has_key?(params, "tools")
+    end
+
+    test "extracts system messages into systemInstruction" do
+      messages = [Message.system("Be helpful"), Message.user("Hi")]
+      params = Gemini.build_request_params(model(), messages, %{})
+
+      assert params["systemInstruction"] == %{"parts" => [%{"text" => "Be helpful"}]}
+      assert [%{"role" => "user"}] = params["contents"]
+    end
+
+    test "maps generic settings into generationConfig with camelCase keys" do
+      settings = %{
+        temperature: 0.5,
+        max_tokens: 1024,
+        top_p: 0.9,
+        top_k: 40,
+        stop_sequences: ["END"]
+      }
+
+      params = Gemini.build_request_params(model(), [Message.user("Hi")], settings)
+
+      assert params["generationConfig"] == %{
+               "temperature" => 0.5,
+               "maxOutputTokens" => 1024,
+               "topP" => 0.9,
+               "topK" => 40,
+               "stopSequences" => ["END"]
+             }
+    end
+
+    test "explicit generationConfig from settings wins over mapped keys" do
+      settings = %{temperature: 0.5, generationConfig: %{"temperature" => 0.9}}
+      params = Gemini.build_request_params(model(), [Message.user("Hi")], settings)
+
+      assert params["generationConfig"]["temperature"] == 0.9
+    end
+
+    test "json_schema settings produce responseMimeType and responseSchema" do
+      schema = %{"type" => "object"}
+      params = Gemini.build_request_params(model(), [Message.user("Hi")], %{json_schema: schema})
+
+      assert params["generationConfig"]["responseMimeType"] == "application/json"
+      assert params["generationConfig"]["responseSchema"] == schema
+    end
+
+    test "includes tools, toolConfig, and cachedContent when set" do
+      declaration = %{"name" => "get_weather", "parameters" => %{"type" => "object"}}
+
+      settings = %{
+        tools: [declaration],
+        tool_choice: :none,
+        cached_content: "cachedContents/abc"
+      }
+
+      params = Gemini.build_request_params(model(), [Message.user("Hi")], settings)
+
+      assert [%{"functionDeclarations" => [^declaration]}] = params["tools"]
+      assert params["toolConfig"] == %{"functionCallingConfig" => %{"mode" => "NONE"}}
+      assert params["cachedContent"] == "cachedContents/abc"
+    end
+
+    test "explicit tool_config takes priority over tool_choice" do
+      settings = %{
+        tool_config: %{"functionCallingConfig" => %{"mode" => "ANY"}},
+        tool_choice: :none
+      }
+
+      params = Gemini.build_request_params(model(), [Message.user("Hi")], settings)
+
+      assert params["toolConfig"] == %{"functionCallingConfig" => %{"mode" => "ANY"}}
+    end
+  end
 end

--- a/test/nous/messages_generic_helpers_test.exs
+++ b/test/nous/messages_generic_helpers_test.exs
@@ -635,4 +635,24 @@ defmodule Nous.MessagesGenericHelpersTest do
       assert length(user_msgs) == 2
     end
   end
+
+  describe "Message.split_system/1" do
+    test "extracts a single system prompt" do
+      messages = [Message.system("Be helpful"), Message.user("Hi")]
+
+      assert {"Be helpful", [%Message{role: :user}]} = Message.split_system(messages)
+    end
+
+    test "joins multiple system messages with blank lines" do
+      messages = [Message.system("One"), Message.user("Hi"), Message.system("Two")]
+
+      assert {"One\n\nTwo", [%Message{role: :user}]} = Message.split_system(messages)
+    end
+
+    test "returns nil system prompt when no system messages exist" do
+      messages = [Message.user("Hi"), Message.assistant("Hello")]
+
+      assert {nil, ^messages} = Message.split_system(messages)
+    end
+  end
 end

--- a/test/nous/model_dispatcher_test.exs
+++ b/test/nous/model_dispatcher_test.exs
@@ -1,0 +1,54 @@
+defmodule Nous.ModelDispatcherTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.ModelDispatcher
+  alias Nous.Providers
+
+  describe "provider_module/1" do
+    test "routes each known provider to its module" do
+      assert ModelDispatcher.provider_module(:anthropic) == Providers.Anthropic
+      assert ModelDispatcher.provider_module(:gemini) == Providers.Gemini
+      assert ModelDispatcher.provider_module(:vertex_ai) == Providers.VertexAI
+      assert ModelDispatcher.provider_module(:mistral) == Providers.Mistral
+      assert ModelDispatcher.provider_module(:lmstudio) == Providers.LMStudio
+      assert ModelDispatcher.provider_module(:llamacpp) == Providers.LlamaCpp
+      assert ModelDispatcher.provider_module(:vllm) == Providers.VLLM
+      assert ModelDispatcher.provider_module(:sglang) == Providers.SGLang
+      assert ModelDispatcher.provider_module(:openai) == Providers.OpenAI
+      assert ModelDispatcher.provider_module(:custom) == Providers.Custom
+    end
+
+    test "unknown providers fall back to OpenAICompatible" do
+      assert ModelDispatcher.provider_module(:groq) == Providers.OpenAICompatible
+      assert ModelDispatcher.provider_module(:something_new) == Providers.OpenAICompatible
+    end
+
+    test "every routed module exports the dispatched functions" do
+      for provider <- [
+            :anthropic,
+            :gemini,
+            :vertex_ai,
+            :mistral,
+            :lmstudio,
+            :llamacpp,
+            :vllm,
+            :sglang,
+            :openai,
+            :custom,
+            :unknown_fallback
+          ] do
+        module = ModelDispatcher.provider_module(provider)
+        Code.ensure_loaded!(module)
+
+        assert function_exported?(module, :request, 3),
+               "#{inspect(module)} should export request/3"
+
+        assert function_exported?(module, :request_stream, 3),
+               "#{inspect(module)} should export request_stream/3"
+
+        assert function_exported?(module, :count_tokens, 1),
+               "#{inspect(module)} should export count_tokens/1"
+      end
+    end
+  end
+end

--- a/test/nous/skill_test.exs
+++ b/test/nous/skill_test.exs
@@ -87,5 +87,51 @@ defmodule Nous.SkillTest do
     test "sets default group from use opts" do
       assert MacroSkill.group() == :coding
     end
+
+    defmodule KeywordSkill do
+      use Nous.Skill, keywords: ["review", "check this code"]
+
+      @impl true
+      def name, do: "keyword_test"
+      @impl true
+      def description, do: "Keyword test"
+      @impl true
+      def instructions(_, _), do: "test"
+    end
+
+    test "generates match?/1 from :keywords, case-insensitively" do
+      assert KeywordSkill.match?("please REVIEW my diff")
+      assert KeywordSkill.match?("Check This Code for me")
+      refute KeywordSkill.match?("write a haiku")
+    end
+
+    test "keyword skills activate via on_match in from_module/1" do
+      skill = Skill.from_module(KeywordSkill)
+      assert {:on_match, matcher} = skill.activation
+      assert matcher.("review this")
+    end
+
+    test "no :keywords means no generated match?/1" do
+      refute function_exported?(MacroSkill, :match?, 1)
+    end
+
+    defmodule OverriddenKeywordSkill do
+      use Nous.Skill, keywords: ["ignored"]
+
+      @impl true
+      def name, do: "overridden"
+      @impl true
+      def description, do: "Overridden"
+      @impl true
+      def instructions(_, _), do: "test"
+
+      @impl true
+      def match?(input), do: input == "exact"
+    end
+
+    test "a hand-written match?/1 overrides the generated one" do
+      assert OverriddenKeywordSkill.match?("exact")
+      refute OverriddenKeywordSkill.match?("ignored")
+    end
   end
 end

--- a/test/nous/stream_normalizer/llamacpp_test.exs
+++ b/test/nous/stream_normalizer/llamacpp_test.exs
@@ -1,0 +1,61 @@
+defmodule Nous.StreamNormalizer.LlamaCppTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.StreamNormalizer.LlamaCpp
+
+  describe "normalize_chunk/1 — streaming deltas" do
+    test "content delta becomes text_delta" do
+      chunk = %{choices: [%{delta: %{content: "hello"}, finish_reason: nil}]}
+      assert LlamaCpp.normalize_chunk(chunk) == [{:text_delta, "hello"}]
+    end
+
+    test "finish_reason becomes finish" do
+      chunk = %{choices: [%{delta: %{}, finish_reason: "stop"}]}
+      assert LlamaCpp.normalize_chunk(chunk) == [{:finish, "stop"}]
+    end
+
+    test "empty choices is unknown" do
+      assert LlamaCpp.normalize_chunk(%{choices: []}) == [{:unknown, %{choices: []}}]
+    end
+
+    test "non-map chunk is unknown" do
+      assert LlamaCpp.normalize_chunk(:garbage) == [{:unknown, :garbage}]
+    end
+  end
+
+  describe "normalize_chunk/1 — degenerate complete responses" do
+    # llama.cpp (like LM Studio/vLLM/Ollama) can return one complete
+    # response object on a stream: message instead of delta. Content and
+    # tool calls must survive, not just the finish_reason.
+    test "complete response with content emits text and finish" do
+      chunk = %{choices: [%{message: %{content: "full answer"}, finish_reason: "stop"}]}
+
+      assert LlamaCpp.normalize_chunk(chunk) == [
+               {:text_delta, "full answer"},
+               {:finish, "stop"}
+             ]
+    end
+
+    test "complete response with tool calls keeps them" do
+      calls = [%{"id" => "c1", "function" => %{"name" => "search", "arguments" => "{}"}}]
+
+      chunk = %{
+        choices: [%{message: %{content: nil, tool_calls: calls}, finish_reason: "tool_calls"}]
+      }
+
+      assert LlamaCpp.normalize_chunk(chunk) == [
+               {:tool_call_delta, calls},
+               {:finish, "tool_calls"}
+             ]
+    end
+  end
+
+  describe "complete_response?/1" do
+    test "true when a message is present, false for deltas" do
+      assert LlamaCpp.complete_response?(%{choices: [%{message: %{content: "x"}}]})
+      refute LlamaCpp.complete_response?(%{choices: [%{delta: %{content: "x"}}]})
+      refute LlamaCpp.complete_response?(%{choices: []})
+      refute LlamaCpp.complete_response?(:garbage)
+    end
+  end
+end

--- a/test/nous/tool/schema_test.exs
+++ b/test/nous/tool/schema_test.exs
@@ -37,6 +37,21 @@ defmodule Nous.Tool.SchemaTest do
     end
   end
 
+  # Tool that requires human approval before execution
+  defmodule ApprovalTool do
+    use Nous.Tool.Schema
+
+    tool "dangerous",
+      description: "A tool that needs approval",
+      category: :execute,
+      requires_approval: true do
+      param(:command, :string, required: true, doc: "Command to run")
+    end
+
+    @impl Nous.Tool.Behaviour
+    def execute(_ctx, _args), do: {:ok, "done"}
+  end
+
   # Tool with all param types
   defmodule AllTypesTool do
     use Nous.Tool.Schema
@@ -91,6 +106,19 @@ defmodule Nous.Tool.SchemaTest do
       assert meta.description == "A minimal tool"
       assert meta.category == nil
       assert meta.tags == []
+    end
+
+    test "requires_approval is included in metadata" do
+      assert ApprovalTool.metadata().requires_approval == true
+    end
+
+    test "requires_approval defaults to false" do
+      assert MinimalTool.metadata().requires_approval == false
+    end
+
+    test "requires_approval flows into Tool.from_module/2" do
+      assert Tool.from_module(ApprovalTool).requires_approval == true
+      assert Tool.from_module(MinimalTool).requires_approval == false
     end
 
     test "required params appear in required list" do

--- a/test/nous/tool_call_test.exs
+++ b/test/nous/tool_call_test.exs
@@ -1,0 +1,61 @@
+defmodule Nous.ToolCallTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.ToolCall
+
+  describe "field/3" do
+    test "reads atom keys" do
+      assert ToolCall.field(%{name: "search"}, :name) == "search"
+    end
+
+    test "reads string keys" do
+      assert ToolCall.field(%{"name" => "search"}, :name) == "search"
+    end
+
+    test "atom key wins when both present" do
+      assert ToolCall.field(%{"name" => "string", name: "atom"}, :name) == "atom"
+    end
+
+    test "preserves falsy values instead of coalescing them away" do
+      # The `call[:x] || call["x"]` idiom this replaces silently dropped these.
+      assert ToolCall.field(%{arguments: false}, :arguments) == false
+      assert ToolCall.field(%{arguments: 0}, :arguments) == 0
+      assert ToolCall.field(%{arguments: ""}, :arguments) == ""
+      assert ToolCall.field(%{"arguments" => false}, :arguments) == false
+    end
+
+    test "returns default when key is missing" do
+      assert ToolCall.field(%{}, :name) == nil
+      assert ToolCall.field(%{}, :name, "unknown") == "unknown"
+      assert ToolCall.field(%{}, :arguments, %{}) == %{}
+    end
+
+    test "nil values fall through to the default" do
+      assert ToolCall.field(%{name: nil}, :name, "unknown") == "unknown"
+      assert ToolCall.field(%{"name" => nil}, :name, "unknown") == "unknown"
+    end
+
+    test "nil atom value falls through to string key" do
+      assert ToolCall.field(%{"name" => "search", name: nil}, :name) == "search"
+    end
+  end
+
+  describe "put_field/3" do
+    test "updates an existing atom key" do
+      assert ToolCall.put_field(%{name: "a"}, :name, "b") == %{name: "b"}
+    end
+
+    test "updates an existing string key without adding an atom key" do
+      assert ToolCall.put_field(%{"name" => "a"}, :name, "b") == %{"name" => "b"}
+    end
+
+    test "prefers the atom key when both present" do
+      assert ToolCall.put_field(%{"name" => "a", name: "a"}, :name, "b") ==
+               %{"name" => "a", name: "b"}
+    end
+
+    test "adds a string key when neither present" do
+      assert ToolCall.put_field(%{}, :name, "b") == %{"name" => "b"}
+    end
+  end
+end

--- a/test/nous/tools/env_test.exs
+++ b/test/nous/tools/env_test.exs
@@ -1,0 +1,37 @@
+defmodule Nous.Tools.EnvTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.Tools.Env
+
+  describe "scrubbed/0" do
+    test "forwards only allowlisted variables" do
+      System.put_env("NOUS_FAKE_API_KEY", "secret")
+      on_exit(fn -> System.delete_env("NOUS_FAKE_API_KEY") end)
+
+      env = Env.scrubbed()
+      names = Enum.map(env, fn {name, _} -> name end)
+
+      refute "NOUS_FAKE_API_KEY" in names
+      assert Enum.all?(names, &(&1 in ~w(PATH HOME LANG LC_ALL TZ USER SHELL TERM)))
+    end
+
+    test "includes set allowlisted variables with their values" do
+      System.put_env("TZ", "UTC")
+      on_exit(fn -> System.delete_env("TZ") end)
+
+      assert {"TZ", "UTC"} in Env.scrubbed()
+    end
+
+    test "drops unset allowlisted variables instead of emitting nil" do
+      original = System.get_env("LC_ALL")
+      System.delete_env("LC_ALL")
+
+      on_exit(fn ->
+        if original, do: System.put_env("LC_ALL", original)
+      end)
+
+      refute Enum.any?(Env.scrubbed(), fn {name, _} -> name == "LC_ALL" end)
+      refute Enum.any?(Env.scrubbed(), fn {_, value} -> is_nil(value) end)
+    end
+  end
+end

--- a/test/nous/tools/search_common_test.exs
+++ b/test/nous/tools/search_common_test.exs
@@ -1,0 +1,111 @@
+defmodule Nous.Tools.Search.CommonTest do
+  use ExUnit.Case, async: false
+
+  alias Nous.Tools.Search.Common
+
+  defp ctx(deps \\ %{}), do: Nous.RunContext.new(deps)
+
+  describe "api_key/3" do
+    test "context deps win" do
+      assert Common.api_key(ctx(%{fake_search_key: "from-deps"}), :fake_search_key, "NOUS_X") ==
+               "from-deps"
+    end
+
+    test "application env is the second choice" do
+      Application.put_env(:nous, :fake_search_key, "from-config")
+      on_exit(fn -> Application.delete_env(:nous, :fake_search_key) end)
+
+      assert Common.api_key(ctx(), :fake_search_key, "NOUS_X") == "from-config"
+    end
+
+    test "system env is the fallback" do
+      System.put_env("NOUS_FAKE_SEARCH_KEY", "from-env")
+      on_exit(fn -> System.delete_env("NOUS_FAKE_SEARCH_KEY") end)
+
+      assert Common.api_key(ctx(), :fake_search_key, "NOUS_FAKE_SEARCH_KEY") == "from-env"
+    end
+  end
+
+  describe "query/1" do
+    test "accepts \"query\", falls back to \"q\", defaults to empty" do
+      assert Common.query(%{"query" => "elixir"}) == "elixir"
+      assert Common.query(%{"q" => "beam"}) == "beam"
+      assert Common.query(%{}) == ""
+    end
+  end
+
+  describe "run_search/4" do
+    @opts [
+      missing_key_error: "KEY not configured",
+      log_label: "Fake search",
+      error_prefix: "Search failed"
+    ]
+
+    test "missing or empty key returns the error envelope without running" do
+      for key <- [nil, ""] do
+        assert Common.run_search("q", key, @opts, fn -> flunk("should not run") end) ==
+                 %{query: "q", error: "KEY not configured", success: false}
+      end
+    end
+
+    test "success merges query and success into the envelope" do
+      result =
+        Common.run_search("q", "key", @opts, fn ->
+          {:ok, %{results: [1], result_count: 1}}
+        end)
+
+      assert result == %{query: "q", results: [1], result_count: 1, success: true}
+    end
+
+    test "errors become the failure envelope" do
+      result = Common.run_search("q", "key", @opts, fn -> {:error, :timeout} end)
+
+      assert result == %{query: "q", error: "Search failed: :timeout", success: false}
+    end
+  end
+
+  describe "tool integration (no network)" do
+    test "BraveSearch returns the missing-key envelope" do
+      # An empty-string dep short-circuits key resolution deterministically,
+      # regardless of the machine's BRAVE_API_KEY.
+      ctx = ctx(%{brave_api_key: ""})
+
+      assert %{success: false, query: "elixir", error: error} =
+               Nous.Tools.BraveSearch.web_search(ctx, %{"query" => "elixir"})
+
+      assert error =~ "BRAVE_API_KEY not configured"
+
+      assert %{success: false, error: "BRAVE_API_KEY not configured"} =
+               Nous.Tools.BraveSearch.news_search(ctx, %{"q" => "elixir"})
+    end
+
+    test "TavilySearch returns the missing-key envelope" do
+      ctx = ctx(%{tavily_api_key: ""})
+
+      assert %{success: false, query: "beam", error: error} =
+               Nous.Tools.TavilySearch.search(ctx, %{"query" => "beam"})
+
+      assert error =~ "TAVILY_API_KEY not configured"
+    end
+  end
+
+  describe "map_results/2" do
+    test "maps fields with and without defaults" do
+      results = [%{"title" => "T", "url" => "U"}]
+
+      mapped =
+        Common.map_results(results,
+          title: {"title", ""},
+          url: {"url", ""},
+          age: "age"
+        )
+
+      assert mapped == [%{title: "T", url: "U", age: nil}]
+    end
+
+    test "non-list input maps to an empty list" do
+      assert Common.map_results(%{"unexpected" => true}, title: {"title", ""}) == []
+      assert Common.map_results(nil, title: {"title", ""}) == []
+    end
+  end
+end

--- a/test/nous/util_test.exs
+++ b/test/nous/util_test.exs
@@ -35,6 +35,21 @@ defmodule Nous.UtilTest do
     end
   end
 
+  describe "split_gen_opts/1" do
+    test "splits :name into GenServer opts" do
+      assert Util.split_gen_opts(name: MyServer, foo: 1) ==
+               {[name: MyServer], [foo: 1]}
+    end
+
+    test "returns empty gen opts when :name is absent" do
+      assert Util.split_gen_opts(foo: 1) == {[], [foo: 1]}
+    end
+
+    test "treats an explicit nil name as absent" do
+      assert Util.split_gen_opts(name: nil, foo: 1) == {[], [foo: 1]}
+    end
+  end
+
   describe "atomize_keys/1" do
     test "converts keys that are existing atoms" do
       assert Util.atomize_keys(%{"name" => "a", "id" => 1}) == %{name: "a", id: 1}

--- a/test/nous/util_test.exs
+++ b/test/nous/util_test.exs
@@ -1,0 +1,53 @@
+defmodule Nous.UtilTest do
+  use ExUnit.Case, async: true
+
+  alias Nous.Util
+
+  doctest Nous.Util
+
+  describe "safe_existing_atom/2" do
+    test "converts a binary to an existing atom" do
+      assert Util.safe_existing_atom("ok") == :ok
+    end
+
+    test "returns the fallback for unknown atoms" do
+      assert Util.safe_existing_atom("definitely_not_an_atom_xyz9") == nil
+
+      assert Util.safe_existing_atom("definitely_not_an_atom_xyz9", "kept") ==
+               "kept"
+    end
+
+    test "never mints new atoms" do
+      binary = "unminted_atom_#{:erlang.unique_integer([:positive])}"
+      assert Util.safe_existing_atom(binary, binary) == binary
+
+      assert_raise ArgumentError, fn -> String.to_existing_atom(binary) end
+    end
+
+    test "atoms pass through unchanged" do
+      assert Util.safe_existing_atom(:already) == :already
+      assert Util.safe_existing_atom(nil) == nil
+    end
+
+    test "non-binary, non-atom input returns the fallback" do
+      assert Util.safe_existing_atom(123) == nil
+      assert Util.safe_existing_atom(%{}, :fallback) == :fallback
+    end
+  end
+
+  describe "atomize_keys/1" do
+    test "converts keys that are existing atoms" do
+      assert Util.atomize_keys(%{"name" => "a", "id" => 1}) == %{name: "a", id: 1}
+    end
+
+    test "leaves unknown keys as binaries" do
+      binary = "unknown_key_#{:erlang.unique_integer([:positive])}"
+      assert Util.atomize_keys(%{binary => 1}) == %{binary => 1}
+    end
+
+    test "leaves values untouched and handles mixed keys" do
+      assert Util.atomize_keys(%{"name" => %{"nested" => true}, already: :atom}) ==
+               %{name: %{"nested" => true}, already: :atom}
+    end
+  end
+end


### PR DESCRIPTION
## What

  A 14-commit deduplication pass over the library (79 files, +1805/−1441), driven by
  `/phx:techdebt` findings. Each commit collapses one class of copy-paste into a
  single source of truth. Two real bug fixes fell out of the sweep.

  ### Dedup / extraction

  - **Providers:** shared Gemini request builder for Gemini + VertexAI; ModelDispatcher
    dispatch tables collapsed into one provider map; llamacpp responses routed through
    the OpenAI normalizer instead of a parallel code path
  - **Tools:** built-in tools adopt the `Tool.Schema` DSL; shared search-tool plumbing
    extracted into `Search.Common`; subprocess env allowlist single-sourced in
    `Nous.Tools.Env`
  - **Core utilities:** safe existing-atom idiom and `split_gen_opts/1` moved to
    `Nous.Util`; message-adapter helpers (`split_system`, consolidate) shared;
    repeated intra-module blocks collapsed (registry, memory, hooks)
  - **Errors:** exception construction generated via `Nous.Errors.Base`; skill
    `match?/1` generated from a `:keywords` option
  - **Error handling:** schema-reflection rescues narrowed so real errors
    (`KeyError`, typos) propagate; deliberate boundaries documented

  ### Fixes

  - **Dual-key tool-call field access** centralized — previously falsy-but-present
    values could be dropped when reading string/atom-keyed fields (871abb0)
  - **llamacpp complete responses** now go through the OpenAI normalizer, fixing
    shape drift between streaming and non-streaming paths (b2a27c4)

  ## Verification

  - `mix test`: 1992 passed (7 doctests), 102 excluded — no regressions; +75 new tests
    including `search_common_test.exs` and `util_test.exs`
  - `mix credo --strict`: 0 issues; `mix compile --warnings-as-errors` clean
  - llamacpp normalizer fix validated live via the gated smoke test
    (`mix test --only llama` against a local Qwen3.5 GGUF on Metal): 7 passed
