### PR TITLE
refactor: adopt alias __MODULE__ for struct references

### DIFF
--- a/lib/nous/agent.ex
+++ b/lib/nous/agent.ex
@@ -27,9 +27,10 @@ defmodule Nous.Agent do
 
   """
 
+  alias __MODULE__
   alias Nous.{Fallback, Hook, Model, Tool, Types}
 
-  @type t :: %__MODULE__{
+  @type t :: %Agent{
           model: Model.t(),
           fallback: [Model.t()],
           output_type: Types.output_type(),
@@ -128,7 +129,7 @@ defmodule Nous.Agent do
   def new(model_string, opts \\ []) do
     model = Model.parse(model_string, opts)
 
-    %__MODULE__{
+    %Agent{
       model: model,
       fallback: Fallback.parse_fallback_models(Keyword.get(opts, :fallback, [])),
       output_type: Keyword.get(opts, :output_type, :string),
@@ -242,12 +243,12 @@ defmodule Nous.Agent do
   def run(agent, input, opts \\ [])
 
   # String prompt
-  def run(%__MODULE__{} = agent, prompt, opts) when is_binary(prompt) do
+  def run(%Agent{} = agent, prompt, opts) when is_binary(prompt) do
     Nous.AgentRunner.run(agent, prompt, opts)
   end
 
   # Keyword input with messages or context
-  def run(%__MODULE__{} = agent, input, opts) when is_list(input) do
+  def run(%Agent{} = agent, input, opts) when is_list(input) do
     merged_opts = Keyword.merge(input, opts)
 
     cond do
@@ -309,7 +310,7 @@ defmodule Nous.Agent do
 
   """
   @spec run_stream(t(), String.t(), keyword()) :: {:ok, Enumerable.t()} | {:error, term()}
-  def run_stream(%__MODULE__{} = agent, prompt, opts \\ []) do
+  def run_stream(%Agent{} = agent, prompt, opts \\ []) do
     Nous.AgentRunner.run_stream(agent, prompt, opts)
   end
 
@@ -334,7 +335,7 @@ defmodule Nous.Agent do
   """
   @deprecated "Prefer Agent.new/2 with the :tools option, or build %Nous.Tool{} directly"
   @spec tool(t(), function(), keyword()) :: t()
-  def tool(%__MODULE__{} = agent, tool_fun, opts \\ []) do
+  def tool(%Agent{} = agent, tool_fun, opts \\ []) do
     tool = Tool.from_function(tool_fun, opts)
     %{agent | tools: [tool | agent.tools]}
   end

--- a/lib/nous/agent/context.ex
+++ b/lib/nous/agent/context.ex
@@ -52,11 +52,12 @@ defmodule Nous.Agent.Context do
 
   require Logger
 
+  alias __MODULE__
   alias Nous.{Message, Usage}
 
   @type callback_fn :: (atom(), any() -> any())
 
-  @type t :: %__MODULE__{
+  @type t :: %Context{
           # Conversation
           messages: [Message.t()],
           tool_calls: [map()],
@@ -155,7 +156,7 @@ defmodule Nous.Agent.Context do
   """
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
-    %__MODULE__{
+    %Context{
       messages: Keyword.get(opts, :messages, []),
       system_prompt: Keyword.get(opts, :system_prompt),
       deps: Keyword.get(opts, :deps, %{}),
@@ -192,7 +193,7 @@ defmodule Nous.Agent.Context do
   # NOTE: `messages` is appended-to (`++ [message]`), which is O(n) per call —
   # acceptable for single appends, but use `add_messages/2` for bulk inserts;
   # it concatenates once instead of re-walking the list per message.
-  def add_message(%__MODULE__{} = ctx, %Message{} = message) do
+  def add_message(%Context{} = ctx, %Message{} = message) do
     updated_messages = ctx.messages ++ [message]
 
     %{ctx | messages: updated_messages}
@@ -212,7 +213,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec add_messages(t(), [Message.t()]) :: t()
-  def add_messages(%__MODULE__{} = ctx, messages) when is_list(messages) do
+  def add_messages(%Context{} = ctx, messages) when is_list(messages) do
     # Concatenate the whole batch ONCE (O(n+m)) instead of `++ [msg]` per
     # message (O(n*m)). `needs_response` is then folded over just the new
     # messages — identical result to the old per-item reduce, since
@@ -234,7 +235,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec add_tool_call(t(), map()) :: t()
-  def add_tool_call(%__MODULE__{} = ctx, call) when is_map(call) do
+  def add_tool_call(%Context{} = ctx, call) when is_map(call) do
     %{ctx | tool_calls: ctx.tool_calls ++ [call]}
   end
 
@@ -251,12 +252,12 @@ defmodule Nous.Agent.Context do
 
   """
   @spec add_usage(t(), Usage.t() | map()) :: t()
-  def add_usage(%__MODULE__{} = ctx, %Usage{} = usage) do
+  def add_usage(%Context{} = ctx, %Usage{} = usage) do
     new_usage = Usage.add(ctx.usage, usage)
     %{ctx | usage: new_usage}
   end
 
-  def add_usage(%__MODULE__{} = ctx, usage) when is_map(usage) do
+  def add_usage(%Context{} = ctx, usage) when is_map(usage) do
     # Convert map to Usage struct, handling partial updates
     usage_struct = %Usage{
       requests: Map.get(usage, :requests, 0),
@@ -286,7 +287,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec merge_deps(t(), map()) :: t()
-  def merge_deps(%__MODULE__{} = ctx, new_deps) when is_map(new_deps) do
+  def merge_deps(%Context{} = ctx, new_deps) when is_map(new_deps) do
     merged = Map.merge(ctx.deps || %{}, new_deps)
     %{ctx | deps: merged}
   end
@@ -303,7 +304,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec increment_iteration(t()) :: t()
-  def increment_iteration(%__MODULE__{} = ctx) do
+  def increment_iteration(%Context{} = ctx) do
     %{ctx | iteration: ctx.iteration + 1}
   end
 
@@ -319,7 +320,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec set_needs_response(t(), boolean()) :: t()
-  def set_needs_response(%__MODULE__{} = ctx, value) when is_boolean(value) do
+  def set_needs_response(%Context{} = ctx, value) when is_boolean(value) do
     %{ctx | needs_response: value}
   end
 
@@ -338,7 +339,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec max_iterations_reached?(t()) :: boolean()
-  def max_iterations_reached?(%__MODULE__{iteration: i, max_iterations: max}) do
+  def max_iterations_reached?(%Context{iteration: i, max_iterations: max}) do
     i >= max
   end
 
@@ -357,8 +358,8 @@ defmodule Nous.Agent.Context do
 
   """
   @spec last_message(t()) :: Message.t() | nil
-  def last_message(%__MODULE__{messages: []}), do: nil
-  def last_message(%__MODULE__{messages: messages}), do: List.last(messages)
+  def last_message(%Context{messages: []}), do: nil
+  def last_message(%Context{messages: messages}), do: List.last(messages)
 
   @doc """
   Get all assistant messages from the context.
@@ -373,7 +374,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec assistant_messages(t()) :: [Message.t()]
-  def assistant_messages(%__MODULE__{messages: messages}) do
+  def assistant_messages(%Context{messages: messages}) do
     Enum.filter(messages, &(&1.role == :assistant))
   end
 
@@ -391,7 +392,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec to_run_context(t()) :: Nous.RunContext.t()
-  def to_run_context(%__MODULE__{} = ctx) do
+  def to_run_context(%Context{} = ctx) do
     Nous.RunContext.new(ctx.deps, usage: ctx.usage)
   end
 
@@ -437,7 +438,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec patch_dangling_tool_calls(t()) :: t()
-  def patch_dangling_tool_calls(%__MODULE__{messages: messages} = ctx) do
+  def patch_dangling_tool_calls(%Context{messages: messages} = ctx) do
     # Build id -> name map from assistant tool_calls (name needed so providers
     # like Gemini can populate functionResponse.name correctly).
     tool_call_names =
@@ -497,7 +498,7 @@ defmodule Nous.Agent.Context do
 
   """
   @spec serialize(t()) :: map()
-  def serialize(%__MODULE__{} = ctx) do
+  def serialize(%Context{} = ctx) do
     %{
       version: 1,
       messages: Enum.map(ctx.messages, &serialize_message/1),
@@ -574,7 +575,7 @@ defmodule Nous.Agent.Context do
           end
       end
 
-    ctx = %__MODULE__{
+    ctx = %Context{
       messages: messages,
       tool_calls: data[:tool_calls] || [],
       system_prompt: data[:system_prompt],

--- a/lib/nous/decisions/edge.ex
+++ b/lib/nous/decisions/edge.ex
@@ -32,10 +32,12 @@ defmodule Nous.Decisions.Edge do
   | `created_at` | `DateTime.t()` | When the edge was created |
   """
 
+  alias __MODULE__
+
   @type edge_type ::
           :leads_to | :chosen | :rejected | :requires | :blocks | :enables | :supersedes
 
-  @type t :: %__MODULE__{
+  @type t :: %Edge{
           id: String.t(),
           from_id: String.t(),
           to_id: String.t(),
@@ -72,7 +74,7 @@ defmodule Nous.Decisions.Edge do
     now = DateTime.utc_now()
     id = Map.get(attrs, :id) || generate_id()
 
-    %__MODULE__{
+    %Edge{
       id: id,
       from_id: Map.fetch!(attrs, :from_id),
       to_id: Map.fetch!(attrs, :to_id),

--- a/lib/nous/decisions/node.ex
+++ b/lib/nous/decisions/node.ex
@@ -34,10 +34,12 @@ defmodule Nous.Decisions.Node do
   | `updated_at` | `DateTime.t()` | When the node was last modified |
   """
 
+  alias __MODULE__
+
   @type node_type :: :goal | :decision | :option | :action | :outcome | :observation | :revisit
   @type status :: :active | :completed | :superseded | :rejected
 
-  @type t :: %__MODULE__{
+  @type t :: %Node{
           id: String.t(),
           type: node_type(),
           label: String.t(),
@@ -85,7 +87,7 @@ defmodule Nous.Decisions.Node do
     now = DateTime.utc_now()
     id = Map.get(attrs, :id) || generate_id()
 
-    %__MODULE__{
+    %Node{
       id: id,
       type: Map.fetch!(attrs, :type),
       label: Map.fetch!(attrs, :label),

--- a/lib/nous/eval/config.ex
+++ b/lib/nous/eval/config.ex
@@ -33,7 +33,9 @@ defmodule Nous.Eval.Config do
 
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Config{
           default_model: String.t() | nil,
           default_timeout: non_neg_integer(),
           default_instructions: String.t() | nil,
@@ -78,7 +80,7 @@ defmodule Nous.Eval.Config do
   def get(opts \\ []) do
     app_config = Application.get_env(:nous, Nous.Eval, [])
 
-    %__MODULE__{
+    %Config{
       default_model:
         opts[:default_model] ||
           env_string("NOUS_EVAL_DEFAULT_MODEL") ||
@@ -177,12 +179,12 @@ defmodule Nous.Eval.Config do
     end
   end
 
-  defp merge_cost_config(nil), do: %__MODULE__{}.cost_config
+  defp merge_cost_config(nil), do: %Config{}.cost_config
 
   defp merge_cost_config(custom) do
     # Deep-merge per-provider rate maps so a partial custom entry (e.g. only
     # :input for one provider) doesn't wipe the built-in :output rate.
-    Map.merge(%__MODULE__{}.cost_config, custom, fn
+    Map.merge(%Config{}.cost_config, custom, fn
       _provider, default_rates, custom_rates
       when is_map(default_rates) and is_map(custom_rates) ->
         Map.merge(default_rates, custom_rates)

--- a/lib/nous/eval/metrics.ex
+++ b/lib/nous/eval/metrics.ex
@@ -12,7 +12,9 @@ defmodule Nous.Eval.Metrics do
 
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Metrics{
           # Token metrics
           input_tokens: non_neg_integer(),
           output_tokens: non_neg_integer(),
@@ -57,14 +59,14 @@ defmodule Nous.Eval.Metrics do
   Create empty metrics.
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %Metrics{}
 
   @doc """
   Create metrics from a Nous.Usage struct.
   """
   @spec from_usage(Nous.Usage.t()) :: t()
   def from_usage(%Nous.Usage{} = usage) do
-    %__MODULE__{
+    %Metrics{
       input_tokens: usage.input_tokens,
       output_tokens: usage.output_tokens,
       total_tokens: usage.total_tokens,
@@ -90,7 +92,7 @@ defmodule Nous.Eval.Metrics do
         _ -> 1
       end
 
-    %__MODULE__{
+    %Metrics{
       input_tokens: usage.input_tokens,
       output_tokens: usage.output_tokens,
       total_tokens: usage.total_tokens,
@@ -106,8 +108,8 @@ defmodule Nous.Eval.Metrics do
   Merge two metrics structs.
   """
   @spec merge(t(), t()) :: t()
-  def merge(%__MODULE__{} = m1, %__MODULE__{} = m2) do
-    %__MODULE__{
+  def merge(%Metrics{} = m1, %Metrics{} = m2) do
+    %Metrics{
       input_tokens: m1.input_tokens + m2.input_tokens,
       output_tokens: m1.output_tokens + m2.output_tokens,
       total_tokens: m1.total_tokens + m2.total_tokens,
@@ -129,7 +131,7 @@ defmodule Nous.Eval.Metrics do
   Add cost estimation to metrics.
   """
   @spec with_cost(t(), String.t()) :: t()
-  def with_cost(%__MODULE__{} = metrics, provider) do
+  def with_cost(%Metrics{} = metrics, provider) do
     cost = Nous.Eval.Config.estimate_cost(provider, metrics.input_tokens, metrics.output_tokens)
     %{metrics | estimated_cost: cost}
   end
@@ -165,9 +167,10 @@ defmodule Nous.Eval.Metrics.Summary do
   Aggregated metrics summary across multiple evaluation runs.
   """
 
+  alias __MODULE__
   alias Nous.Eval.Metrics
 
-  @type t :: %__MODULE__{
+  @type t :: %Summary{
           count: non_neg_integer(),
 
           # Aggregated scores
@@ -233,7 +236,7 @@ defmodule Nous.Eval.Metrics.Summary do
     count = length(metrics_list)
 
     if count == 0 do
-      %__MODULE__{}
+      %Summary{}
     else
       tokens = Enum.map(metrics_list, & &1.total_tokens)
       latencies = Enum.map(metrics_list, & &1.total_duration_ms)
@@ -254,7 +257,7 @@ defmodule Nous.Eval.Metrics.Summary do
       # Score calculations
       pass_count = Enum.count(scores, &(&1 >= 0.5))
 
-      %__MODULE__{
+      %Summary{
         count: count,
         mean_score: mean(scores),
         min_score: Enum.min(scores, fn -> 0.0 end),
@@ -284,7 +287,7 @@ defmodule Nous.Eval.Metrics.Summary do
   Compare two summaries.
   """
   @spec compare(t(), t()) :: map()
-  def compare(%__MODULE__{} = a, %__MODULE__{} = b) do
+  def compare(%Summary{} = a, %Summary{} = b) do
     %{
       score_diff: b.mean_score - a.mean_score,
       tokens_diff: b.mean_tokens - a.mean_tokens,

--- a/lib/nous/eval/optimizer/parameter.ex
+++ b/lib/nous/eval/optimizer/parameter.ex
@@ -40,9 +40,11 @@ defmodule Nous.Eval.Optimizer.Parameter do
 
   """
 
+  alias __MODULE__
+
   @type param_type :: :float | :integer | :choice | :bool
 
-  @type t :: %__MODULE__{
+  @type t :: %Parameter{
           name: atom(),
           type: param_type(),
           min: number() | nil,
@@ -85,7 +87,7 @@ defmodule Nous.Eval.Optimizer.Parameter do
   """
   @spec float(atom(), number(), number(), keyword()) :: t()
   def float(name, min, max, opts \\ []) do
-    %__MODULE__{
+    %Parameter{
       name: name,
       type: :float,
       min: min,
@@ -114,7 +116,7 @@ defmodule Nous.Eval.Optimizer.Parameter do
   """
   @spec integer(atom(), integer(), integer(), keyword()) :: t()
   def integer(name, min, max, opts \\ []) do
-    %__MODULE__{
+    %Parameter{
       name: name,
       type: :integer,
       min: min,
@@ -141,7 +143,7 @@ defmodule Nous.Eval.Optimizer.Parameter do
   """
   @spec choice(atom(), [term()], keyword()) :: t()
   def choice(name, choices, opts \\ []) when is_list(choices) do
-    %__MODULE__{
+    %Parameter{
       name: name,
       type: :choice,
       choices: choices,
@@ -166,7 +168,7 @@ defmodule Nous.Eval.Optimizer.Parameter do
   """
   @spec bool(atom(), keyword()) :: t()
   def bool(name, opts \\ []) do
-    %__MODULE__{
+    %Parameter{
       name: name,
       type: :bool,
       choices: [true, false],
@@ -263,17 +265,17 @@ defmodule Nous.Eval.Optimizer.Parameter do
   Get all possible values for a parameter (for grid search).
   """
   @spec values(t()) :: [term()]
-  def values(%__MODULE__{type: :float, min: min, max: max, step: nil}) do
+  def values(%Parameter{type: :float, min: min, max: max, step: nil}) do
     # Default to 10 steps
     step = (max - min) / 10
     generate_range(min, max, step)
   end
 
-  def values(%__MODULE__{type: :float, min: min, max: max, step: step, log_scale: false}) do
+  def values(%Parameter{type: :float, min: min, max: max, step: step, log_scale: false}) do
     generate_range(min, max, step)
   end
 
-  def values(%__MODULE__{type: :float, min: min, max: max, step: step, log_scale: true}) do
+  def values(%Parameter{type: :float, min: min, max: max, step: step, log_scale: true}) do
     # Log scale: generate in log space then convert back
     log_min = :math.log10(min)
     log_max = :math.log10(max)
@@ -284,37 +286,37 @@ defmodule Nous.Eval.Optimizer.Parameter do
     |> Enum.map(&Float.round(&1, 6))
   end
 
-  def values(%__MODULE__{type: :integer, min: min, max: max, step: step}) do
+  def values(%Parameter{type: :integer, min: min, max: max, step: step}) do
     Enum.to_list(min..max//step)
   end
 
-  def values(%__MODULE__{type: :choice, choices: choices}), do: choices
-  def values(%__MODULE__{type: :bool}), do: [true, false]
+  def values(%Parameter{type: :choice, choices: choices}), do: choices
+  def values(%Parameter{type: :bool}), do: [true, false]
 
   @doc """
   Sample a random value from the parameter space.
   """
   @spec sample(t()) :: term()
-  def sample(%__MODULE__{type: :float, min: min, max: max, log_scale: false}) do
+  def sample(%Parameter{type: :float, min: min, max: max, log_scale: false}) do
     min + :rand.uniform() * (max - min)
   end
 
-  def sample(%__MODULE__{type: :float, min: min, max: max, log_scale: true}) do
+  def sample(%Parameter{type: :float, min: min, max: max, log_scale: true}) do
     log_min = :math.log10(min)
     log_max = :math.log10(max)
     log_val = log_min + :rand.uniform() * (log_max - log_min)
     :math.pow(10, log_val)
   end
 
-  def sample(%__MODULE__{type: :integer, min: min, max: max}) do
+  def sample(%Parameter{type: :integer, min: min, max: max}) do
     min + :rand.uniform(max - min + 1) - 1
   end
 
-  def sample(%__MODULE__{type: :choice, choices: choices}) do
+  def sample(%Parameter{type: :choice, choices: choices}) do
     Enum.random(choices)
   end
 
-  def sample(%__MODULE__{type: :bool}) do
+  def sample(%Parameter{type: :bool}) do
     :rand.uniform() > 0.5
   end
 
@@ -322,9 +324,9 @@ defmodule Nous.Eval.Optimizer.Parameter do
   Check if a parameter is active given current config.
   """
   @spec active?(t(), map()) :: boolean()
-  def active?(%__MODULE__{condition: nil}, _config), do: true
+  def active?(%Parameter{condition: nil}, _config), do: true
 
-  def active?(%__MODULE__{condition: {param_name, check_fn}}, config) do
+  def active?(%Parameter{condition: {param_name, check_fn}}, config) do
     case Map.get(config, param_name) do
       nil -> false
       value -> check_fn.(value)

--- a/lib/nous/eval/optimizer/search_space.ex
+++ b/lib/nous/eval/optimizer/search_space.ex
@@ -26,9 +26,10 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
 
   """
 
+  alias __MODULE__
   alias Nous.Eval.Optimizer.Parameter
 
-  @type t :: %__MODULE__{
+  @type t :: %SearchSpace{
           parameters: [Parameter.t()],
           size: non_neg_integer() | :infinite
         }
@@ -43,7 +44,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   def from_parameters(parameters) when is_list(parameters) do
     size = calculate_size(parameters)
 
-    %__MODULE__{
+    %SearchSpace{
       parameters: parameters,
       size: size
     }
@@ -55,7 +56,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Returns `:infinite` if any parameter has continuous range without step.
   """
   @spec size(t()) :: non_neg_integer() | :infinite
-  def size(%__MODULE__{size: size}), do: size
+  def size(%SearchSpace{size: size}), do: size
 
   @doc """
   Generate all configurations for grid search.
@@ -63,12 +64,12 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Only works for finite search spaces. Returns a list of configuration maps.
   """
   @spec grid(t()) :: [map()]
-  def grid(%__MODULE__{size: :infinite}) do
+  def grid(%SearchSpace{size: :infinite}) do
     raise ArgumentError,
           "Cannot generate grid for infinite search space. Add step sizes to parameters."
   end
 
-  def grid(%__MODULE__{parameters: parameters}) do
+  def grid(%SearchSpace{parameters: parameters}) do
     parameters
     |> Enum.map(fn param -> {param.name, Parameter.values(param)} end)
     |> cartesian_product()
@@ -79,7 +80,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Sample a random configuration from the search space.
   """
   @spec sample(t()) :: map()
-  def sample(%__MODULE__{parameters: parameters}) do
+  def sample(%SearchSpace{parameters: parameters}) do
     parameters
     |> Enum.map(fn param -> {param.name, Parameter.sample(param)} end)
     |> Map.new()
@@ -97,7 +98,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Sample configurations using Latin Hypercube Sampling for better coverage.
   """
   @spec latin_hypercube_sample(t(), non_neg_integer()) :: [map()]
-  def latin_hypercube_sample(%__MODULE__{parameters: parameters}, n) do
+  def latin_hypercube_sample(%SearchSpace{parameters: parameters}, n) do
     # For each parameter, divide range into n equal intervals
     # and sample one point from each interval
     param_samples =
@@ -118,7 +119,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Get parameter by name.
   """
   @spec get_parameter(t(), atom()) :: Parameter.t() | nil
-  def get_parameter(%__MODULE__{parameters: parameters}, name) do
+  def get_parameter(%SearchSpace{parameters: parameters}, name) do
     Enum.find(parameters, fn p -> p.name == name end)
   end
 
@@ -126,7 +127,7 @@ defmodule Nous.Eval.Optimizer.SearchSpace do
   Check if a configuration is valid (all required parameters present).
   """
   @spec valid_config?(t(), map()) :: boolean()
-  def valid_config?(%__MODULE__{parameters: parameters}, config) do
+  def valid_config?(%SearchSpace{parameters: parameters}, config) do
     Enum.all?(parameters, fn param ->
       # Check if parameter is active given current config
       if Parameter.active?(param, config) do

--- a/lib/nous/eval/result.ex
+++ b/lib/nous/eval/result.ex
@@ -20,9 +20,10 @@ defmodule Nous.Eval.Result do
 
   """
 
+  alias __MODULE__
   alias Nous.Eval.Metrics
 
-  @type t :: %__MODULE__{
+  @type t :: %Result{
           test_case_id: String.t(),
           test_case_name: String.t(),
           passed: boolean(),
@@ -57,7 +58,7 @@ defmodule Nous.Eval.Result do
   """
   @spec success(keyword()) :: t()
   def success(opts) do
-    %__MODULE__{
+    %Result{
       test_case_id: Keyword.fetch!(opts, :test_case_id),
       test_case_name: Keyword.get(opts, :test_case_name, opts[:test_case_id]),
       passed: true,
@@ -77,7 +78,7 @@ defmodule Nous.Eval.Result do
   """
   @spec failure(keyword()) :: t()
   def failure(opts) do
-    %__MODULE__{
+    %Result{
       test_case_id: Keyword.fetch!(opts, :test_case_id),
       test_case_name: Keyword.get(opts, :test_case_name, opts[:test_case_id]),
       passed: false,
@@ -97,7 +98,7 @@ defmodule Nous.Eval.Result do
   """
   @spec error(keyword()) :: t()
   def error(opts) do
-    %__MODULE__{
+    %Result{
       test_case_id: Keyword.fetch!(opts, :test_case_id),
       test_case_name: Keyword.get(opts, :test_case_name, opts[:test_case_id]),
       passed: false,
@@ -112,8 +113,8 @@ defmodule Nous.Eval.Result do
   Check if the result has an error (test didn't complete).
   """
   @spec has_error?(t()) :: boolean()
-  def has_error?(%__MODULE__{error: nil}), do: false
-  def has_error?(%__MODULE__{}), do: true
+  def has_error?(%Result{error: nil}), do: false
+  def has_error?(%Result{}), do: true
 end
 
 defmodule Nous.Eval.SuiteResult do
@@ -121,9 +122,10 @@ defmodule Nous.Eval.SuiteResult do
   Result of running an entire test suite.
   """
 
+  alias __MODULE__
   alias Nous.Eval.{Result, Metrics}
 
-  @type t :: %__MODULE__{
+  @type t :: %SuiteResult{
           suite_name: String.t(),
           started_at: DateTime.t(),
           completed_at: DateTime.t(),
@@ -185,7 +187,7 @@ defmodule Nous.Eval.SuiteResult do
         nil
       end
 
-    %__MODULE__{
+    %SuiteResult{
       suite_name: suite_name,
       started_at: started_at,
       completed_at: completed_at,
@@ -205,7 +207,7 @@ defmodule Nous.Eval.SuiteResult do
   Get failed test cases.
   """
   @spec failed(t()) :: [Result.t()]
-  def failed(%__MODULE__{results: results}) do
+  def failed(%SuiteResult{results: results}) do
     Enum.reject(results, & &1.passed)
   end
 
@@ -213,7 +215,7 @@ defmodule Nous.Eval.SuiteResult do
   Get passed test cases.
   """
   @spec passed(t()) :: [Result.t()]
-  def passed(%__MODULE__{results: results}) do
+  def passed(%SuiteResult{results: results}) do
     Enum.filter(results, & &1.passed)
   end
 
@@ -221,7 +223,7 @@ defmodule Nous.Eval.SuiteResult do
   Get error test cases (tests that failed to run).
   """
   @spec errors(t()) :: [Result.t()]
-  def errors(%__MODULE__{results: results}) do
+  def errors(%SuiteResult{results: results}) do
     Enum.filter(results, &Result.has_error?/1)
   end
 end

--- a/lib/nous/eval/suite.ex
+++ b/lib/nous/eval/suite.ex
@@ -31,9 +31,10 @@ defmodule Nous.Eval.Suite do
 
   """
 
+  alias __MODULE__
   alias Nous.Eval.TestCase
 
-  @type t :: %__MODULE__{
+  @type t :: %Suite{
           name: String.t(),
           description: String.t() | nil,
           test_cases: [TestCase.t()],
@@ -95,7 +96,7 @@ defmodule Nous.Eval.Suite do
   def new(opts) when is_list(opts) do
     name = Keyword.fetch!(opts, :name)
 
-    %__MODULE__{
+    %Suite{
       name: to_string(name),
       description: Keyword.get(opts, :description),
       test_cases: Keyword.get(opts, :test_cases, []),
@@ -114,7 +115,7 @@ defmodule Nous.Eval.Suite do
   Add a test case to the suite.
   """
   @spec add_case(t(), TestCase.t()) :: t()
-  def add_case(%__MODULE__{} = suite, %TestCase{} = test_case) do
+  def add_case(%Suite{} = suite, %TestCase{} = test_case) do
     %{suite | test_cases: suite.test_cases ++ [test_case]}
   end
 
@@ -122,7 +123,7 @@ defmodule Nous.Eval.Suite do
   Add multiple test cases to the suite.
   """
   @spec add_cases(t(), [TestCase.t()]) :: t()
-  def add_cases(%__MODULE__{} = suite, test_cases) when is_list(test_cases) do
+  def add_cases(%Suite{} = suite, test_cases) when is_list(test_cases) do
     %{suite | test_cases: suite.test_cases ++ test_cases}
   end
 
@@ -130,7 +131,7 @@ defmodule Nous.Eval.Suite do
   Filter test cases by tags (include only cases with ANY of the specified tags).
   """
   @spec filter_by_tags(t(), [atom()]) :: t()
-  def filter_by_tags(%__MODULE__{} = suite, tags) when is_list(tags) do
+  def filter_by_tags(%Suite{} = suite, tags) when is_list(tags) do
     filtered =
       Enum.filter(suite.test_cases, fn tc ->
         Enum.any?(tc.tags, &(&1 in tags))
@@ -143,7 +144,7 @@ defmodule Nous.Eval.Suite do
   Exclude test cases with any of the specified tags.
   """
   @spec exclude_tags(t(), [atom()]) :: t()
-  def exclude_tags(%__MODULE__{} = suite, tags) when is_list(tags) do
+  def exclude_tags(%Suite{} = suite, tags) when is_list(tags) do
     filtered =
       Enum.reject(suite.test_cases, fn tc ->
         Enum.any?(tc.tags, &(&1 in tags))
@@ -156,7 +157,7 @@ defmodule Nous.Eval.Suite do
   Get test case by ID.
   """
   @spec get_case(t(), String.t()) :: TestCase.t() | nil
-  def get_case(%__MODULE__{test_cases: cases}, id) do
+  def get_case(%Suite{test_cases: cases}, id) do
     Enum.find(cases, fn tc -> tc.id == id end)
   end
 
@@ -164,7 +165,7 @@ defmodule Nous.Eval.Suite do
   Get number of test cases.
   """
   @spec count(t()) :: non_neg_integer()
-  def count(%__MODULE__{test_cases: cases}), do: length(cases)
+  def count(%Suite{test_cases: cases}), do: length(cases)
 
   @doc """
   Load a suite from a YAML file.
@@ -219,7 +220,7 @@ defmodule Nous.Eval.Suite do
   Validate a suite and all its test cases.
   """
   @spec validate(t()) :: :ok | {:error, term()}
-  def validate(%__MODULE__{} = suite) do
+  def validate(%Suite{} = suite) do
     cond do
       is_nil(suite.name) or suite.name == "" ->
         {:error, "Suite name is required"}
@@ -245,7 +246,7 @@ defmodule Nous.Eval.Suite do
   Get all unique tags used in the suite.
   """
   @spec all_tags(t()) :: [atom()]
-  def all_tags(%__MODULE__{test_cases: cases}) do
+  def all_tags(%Suite{test_cases: cases}) do
     cases
     |> Enum.flat_map(& &1.tags)
     |> Enum.uniq()

--- a/lib/nous/eval/test_case.ex
+++ b/lib/nous/eval/test_case.ex
@@ -40,6 +40,8 @@ defmodule Nous.Eval.TestCase do
 
   """
 
+  alias __MODULE__
+
   @type eval_type ::
           :exact_match
           | :fuzzy_match
@@ -49,7 +51,7 @@ defmodule Nous.Eval.TestCase do
           | :llm_judge
           | :custom
 
-  @type t :: %__MODULE__{
+  @type t :: %TestCase{
           id: String.t(),
           name: String.t() | nil,
           description: String.t() | nil,
@@ -142,7 +144,7 @@ defmodule Nous.Eval.TestCase do
     id = Keyword.fetch!(opts, :id)
     input = Keyword.fetch!(opts, :input)
 
-    %__MODULE__{
+    %TestCase{
       id: to_string(id),
       name: Keyword.get(opts, :name),
       description: Keyword.get(opts, :description),
@@ -166,7 +168,7 @@ defmodule Nous.Eval.TestCase do
   def from_map(map) when is_map(map) do
     with {:ok, id} <- fetch_required(map, [:id, "id"]),
          {:ok, input} <- fetch_required(map, [:input, "input"]) do
-      test_case = %__MODULE__{
+      test_case = %TestCase{
         id: to_string(id),
         name: get_any(map, [:name, "name"]),
         description: get_any(map, [:description, "description"]),
@@ -212,7 +214,7 @@ defmodule Nous.Eval.TestCase do
   Validate a test case.
   """
   @spec validate(t()) :: :ok | {:error, term()}
-  def validate(%__MODULE__{} = tc) do
+  def validate(%TestCase{} = tc) do
     cond do
       is_nil(tc.id) or tc.id == "" ->
         {:error, "Test case ID is required"}
@@ -243,7 +245,7 @@ defmodule Nous.Eval.TestCase do
   Get display name for the test case.
   """
   @spec display_name(t()) :: String.t()
-  def display_name(%__MODULE__{name: name, id: id}) do
+  def display_name(%TestCase{name: name, id: id}) do
     name || id
   end
 

--- a/lib/nous/hook.ex
+++ b/lib/nous/hook.ex
@@ -54,6 +54,8 @@ defmodule Nous.Hook do
       }
   """
 
+  alias __MODULE__
+
   @type event ::
           :pre_tool_use
           | :post_tool_use
@@ -68,7 +70,7 @@ defmodule Nous.Hook do
 
   @type matcher :: String.t() | Regex.t() | (map() -> boolean()) | nil
 
-  @type t :: %__MODULE__{
+  @type t :: %Hook{
           event: event(),
           matcher: matcher(),
           type: hook_type(),
@@ -120,17 +122,17 @@ defmodule Nous.Hook do
   For other events, `nil` matchers always match.
   """
   @spec matches?(t(), map()) :: boolean()
-  def matches?(%__MODULE__{matcher: nil}, _payload), do: true
+  def matches?(%Hook{matcher: nil}, _payload), do: true
 
-  def matches?(%__MODULE__{matcher: name}, %{tool_name: tool_name}) when is_binary(name) do
+  def matches?(%Hook{matcher: name}, %{tool_name: tool_name}) when is_binary(name) do
     name == tool_name
   end
 
-  def matches?(%__MODULE__{matcher: %Regex{} = re}, %{tool_name: tool_name}) do
+  def matches?(%Hook{matcher: %Regex{} = re}, %{tool_name: tool_name}) do
     Regex.match?(re, tool_name)
   end
 
-  def matches?(%__MODULE__{matcher: fun}, payload) when is_function(fun, 1) do
+  def matches?(%Hook{matcher: fun}, payload) when is_function(fun, 1) do
     fun.(payload)
   end
 
@@ -141,7 +143,7 @@ defmodule Nous.Hook do
   """
   @spec new(event(), keyword()) :: t()
   def new(event, opts \\ []) do
-    %__MODULE__{
+    %Hook{
       event: event,
       type: Keyword.get(opts, :type, :function),
       handler: Keyword.fetch!(opts, :handler),

--- a/lib/nous/hook/registry.ex
+++ b/lib/nous/hook/registry.ex
@@ -19,9 +19,10 @@ defmodule Nous.Hook.Registry do
       hooks = Nous.Hook.Registry.hooks_for(registry, :pre_tool_use, %{tool_name: "delete_file"})
   """
 
+  alias __MODULE__
   alias Nous.Hook
 
-  @type t :: %__MODULE__{
+  @type t :: %Registry{
           hooks: %{Hook.event() => [Hook.t()]}
         }
 
@@ -31,7 +32,7 @@ defmodule Nous.Hook.Registry do
   Create an empty registry.
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %Registry{}
 
   @doc """
   Create a registry from a list of hooks.
@@ -47,7 +48,7 @@ defmodule Nous.Hook.Registry do
   Hooks are stored sorted by priority (lower = earlier execution).
   """
   @spec register(t(), Hook.t()) :: t()
-  def register(%__MODULE__{} = registry, %Hook{} = hook) do
+  def register(%Registry{} = registry, %Hook{} = hook) do
     hooks_for_event = Map.get(registry.hooks, hook.event, [])
 
     updated =
@@ -61,7 +62,7 @@ defmodule Nous.Hook.Registry do
   Register multiple hooks at once.
   """
   @spec register_all(t(), [Hook.t()]) :: t()
-  def register_all(%__MODULE__{} = registry, hooks) when is_list(hooks) do
+  def register_all(%Registry{} = registry, hooks) when is_list(hooks) do
     Enum.reduce(hooks, registry, &register(&2, &1))
   end
 
@@ -69,7 +70,7 @@ defmodule Nous.Hook.Registry do
   Get all hooks for a given event type.
   """
   @spec hooks_for(t(), Hook.event()) :: [Hook.t()]
-  def hooks_for(%__MODULE__{} = registry, event) do
+  def hooks_for(%Registry{} = registry, event) do
     Map.get(registry.hooks, event, [])
   end
 
@@ -80,7 +81,7 @@ defmodule Nous.Hook.Registry do
   For other events, returns all hooks for that event.
   """
   @spec hooks_for(t(), Hook.event(), map()) :: [Hook.t()]
-  def hooks_for(%__MODULE__{} = registry, event, payload) do
+  def hooks_for(%Registry{} = registry, event, payload) do
     registry
     |> hooks_for(event)
     |> Enum.filter(&Hook.matches?(&1, payload))
@@ -90,7 +91,7 @@ defmodule Nous.Hook.Registry do
   Check if the registry has any hooks for a given event.
   """
   @spec has_hooks?(t(), Hook.event()) :: boolean()
-  def has_hooks?(%__MODULE__{} = registry, event) do
+  def has_hooks?(%Registry{} = registry, event) do
     case Map.get(registry.hooks, event) do
       nil -> false
       [] -> false
@@ -102,7 +103,7 @@ defmodule Nous.Hook.Registry do
   Return the total number of registered hooks.
   """
   @spec count(t()) :: non_neg_integer()
-  def count(%__MODULE__{} = registry) do
+  def count(%Registry{} = registry) do
     registry.hooks
     |> Map.values()
     |> Enum.map(&length/1)

--- a/lib/nous/knowledge_base/document.ex
+++ b/lib/nous/knowledge_base/document.ex
@@ -6,10 +6,12 @@ defmodule Nous.KnowledgeBase.Document do
   gets processed by the LLM into structured `Entry` wiki articles.
   """
 
+  alias __MODULE__
+
   @type doc_type :: :markdown | :text | :url | :pdf | :html
   @type status :: :pending | :processing | :compiled | :failed
 
-  @type t :: %__MODULE__{
+  @type t :: %Document{
           id: String.t(),
           title: String.t(),
           content: String.t(),
@@ -52,7 +54,7 @@ defmodule Nous.KnowledgeBase.Document do
     content = Map.fetch!(attrs, :content)
     title = Map.fetch!(attrs, :title)
 
-    %__MODULE__{
+    %Document{
       id: id,
       title: title,
       content: content,

--- a/lib/nous/knowledge_base/entry.ex
+++ b/lib/nous/knowledge_base/entry.ex
@@ -7,9 +7,11 @@ defmodule Nous.KnowledgeBase.Entry do
   and metadata for search and graph traversal.
   """
 
+  alias __MODULE__
+
   @type entry_type :: :article | :concept | :summary | :index | :glossary
 
-  @type t :: %__MODULE__{
+  @type t :: %Entry{
           id: String.t(),
           title: String.t(),
           slug: String.t(),
@@ -57,7 +59,7 @@ defmodule Nous.KnowledgeBase.Entry do
     id = Map.get(attrs, :id) || generate_id()
     title = Map.fetch!(attrs, :title)
 
-    %__MODULE__{
+    %Entry{
       id: id,
       title: title,
       slug: Map.get(attrs, :slug) || slugify(title),

--- a/lib/nous/knowledge_base/health_report.ex
+++ b/lib/nous/knowledge_base/health_report.ex
@@ -5,6 +5,8 @@ defmodule Nous.KnowledgeBase.HealthReport do
   Contains statistics, scores, and identified issues for maintenance.
   """
 
+  alias __MODULE__
+
   @type issue_type :: :stale | :inconsistent | :orphan | :gap | :low_confidence | :duplicate
   @type severity :: :low | :medium | :high
 
@@ -16,7 +18,7 @@ defmodule Nous.KnowledgeBase.HealthReport do
           suggested_action: String.t()
         }
 
-  @type t :: %__MODULE__{
+  @type t :: %HealthReport{
           id: String.t(),
           kb_id: String.t() | nil,
           total_entries: non_neg_integer(),
@@ -46,7 +48,7 @@ defmodule Nous.KnowledgeBase.HealthReport do
   Creates a new HealthReport from attributes.
   """
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{
+    %HealthReport{
       id: Map.get(attrs, :id) || generate_id(),
       kb_id: Map.get(attrs, :kb_id),
       total_entries: Map.get(attrs, :total_entries, 0),

--- a/lib/nous/knowledge_base/link.ex
+++ b/lib/nous/knowledge_base/link.ex
@@ -6,9 +6,11 @@ defmodule Nous.KnowledgeBase.Link do
   concept connections, and parent-child hierarchies.
   """
 
+  alias __MODULE__
+
   @type link_type :: :backlink | :cross_reference | :concept | :see_also | :parent_child
 
-  @type t :: %__MODULE__{
+  @type t :: %Link{
           id: String.t(),
           from_entry_id: String.t(),
           to_entry_id: String.t(),
@@ -36,7 +38,7 @@ defmodule Nous.KnowledgeBase.Link do
   Requires `:from_entry_id` and `:to_entry_id`.
   """
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{
+    %Link{
       id: Map.get(attrs, :id) || generate_id(),
       from_entry_id: Map.fetch!(attrs, :from_entry_id),
       to_entry_id: Map.fetch!(attrs, :to_entry_id),

--- a/lib/nous/memory/entry.ex
+++ b/lib/nous/memory/entry.ex
@@ -3,9 +3,11 @@ defmodule Nous.Memory.Entry do
   Memory entry struct with scoping fields for flexible isolation.
   """
 
+  alias __MODULE__
+
   @type memory_type :: :semantic | :episodic | :procedural
 
-  @type t :: %__MODULE__{
+  @type t :: %Entry{
           id: String.t(),
           content: String.t(),
           type: memory_type(),
@@ -45,7 +47,7 @@ defmodule Nous.Memory.Entry do
     now = DateTime.utc_now()
     id = Map.get(attrs, :id) || generate_id()
 
-    %__MODULE__{
+    %Entry{
       id: id,
       content: Map.fetch!(attrs, :content),
       type: Map.get(attrs, :type, :semantic),

--- a/lib/nous/message.ex
+++ b/lib/nous/message.ex
@@ -40,6 +40,7 @@ defmodule Nous.Message do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias __MODULE__
   alias Nous.Message.ContentPart
 
   @roles ~w(system user assistant tool)a
@@ -57,7 +58,7 @@ defmodule Nous.Message do
     timestamps(type: :utc_datetime_usec, inserted_at: :created_at, updated_at: false)
   end
 
-  @type t :: %__MODULE__{
+  @type t :: %Message{
           role: atom(),
           content: String.t() | nil,
           reasoning_content: String.t() | nil,
@@ -84,7 +85,7 @@ defmodule Nous.Message do
   """
   @spec new(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{}
+    %Message{}
     |> changeset(attrs)
     |> case do
       %Ecto.Changeset{valid?: true} = changeset ->
@@ -293,9 +294,9 @@ defmodule Nous.Message do
 
   """
   @spec extract_text(t()) :: String.t()
-  def extract_text(%__MODULE__{content: content}) when is_binary(content), do: content
+  def extract_text(%Message{content: content}) when is_binary(content), do: content
 
-  def extract_text(%__MODULE__{content: content}) when is_list(content) do
+  def extract_text(%Message{content: content}) when is_list(content) do
     ContentPart.extract_text(content)
   end
 
@@ -313,9 +314,9 @@ defmodule Nous.Message do
 
   """
   @spec to_text(t()) :: String.t()
-  def to_text(%__MODULE__{content: content}) when is_binary(content), do: content
+  def to_text(%Message{content: content}) when is_binary(content), do: content
 
-  def to_text(%__MODULE__{content: content}) when is_list(content) do
+  def to_text(%Message{content: content}) when is_list(content) do
     ContentPart.to_text(content)
   end
 
@@ -334,7 +335,7 @@ defmodule Nous.Message do
 
   """
   @spec has_tool_calls?(t()) :: boolean()
-  def has_tool_calls?(%__MODULE__{tool_calls: tool_calls}) do
+  def has_tool_calls?(%Message{tool_calls: tool_calls}) do
     is_list(tool_calls) and length(tool_calls) > 0
   end
 
@@ -354,8 +355,8 @@ defmodule Nous.Message do
 
   """
   @spec is_tool_related?(t()) :: boolean()
-  def is_tool_related?(%__MODULE__{role: :tool}), do: true
-  def is_tool_related?(%__MODULE__{} = message), do: has_tool_calls?(message)
+  def is_tool_related?(%Message{role: :tool}), do: true
+  def is_tool_related?(%Message{} = message), do: has_tool_calls?(message)
 
   @doc """
   Check if message is from user.
@@ -370,7 +371,7 @@ defmodule Nous.Message do
 
   """
   @spec from_user?(t()) :: boolean()
-  def from_user?(%__MODULE__{role: :user}), do: true
+  def from_user?(%Message{role: :user}), do: true
   def from_user?(_), do: false
 
   @doc """
@@ -386,7 +387,7 @@ defmodule Nous.Message do
 
   """
   @spec from_assistant?(t()) :: boolean()
-  def from_assistant?(%__MODULE__{role: :assistant}), do: true
+  def from_assistant?(%Message{role: :assistant}), do: true
   def from_assistant?(_), do: false
 
   @doc """
@@ -402,7 +403,7 @@ defmodule Nous.Message do
 
   """
   @spec is_system?(t()) :: boolean()
-  def is_system?(%__MODULE__{role: :system}), do: true
+  def is_system?(%Message{role: :system}), do: true
   def is_system?(_), do: false
 
   @doc """
@@ -443,11 +444,11 @@ defmodule Nous.Message do
 
   """
   @spec get_content_parts(t()) :: [ContentPart.t()]
-  def get_content_parts(%__MODULE__{content: content}) when is_binary(content) do
+  def get_content_parts(%Message{content: content}) when is_binary(content) do
     [ContentPart.text(content)]
   end
 
-  def get_content_parts(%__MODULE__{content: content}) when is_list(content) do
+  def get_content_parts(%Message{content: content}) when is_list(content) do
     content
   end
 
@@ -462,7 +463,7 @@ defmodule Nous.Message do
 
   """
   @spec put_metadata(t(), atom() | String.t(), any()) :: t()
-  def put_metadata(%__MODULE__{} = message, key, value) do
+  def put_metadata(%Message{} = message, key, value) do
     %{message | metadata: Map.put(message.metadata, key, value)}
   end
 
@@ -477,7 +478,7 @@ defmodule Nous.Message do
 
   """
   @spec get_metadata(t(), atom() | String.t(), any()) :: any()
-  def get_metadata(%__MODULE__{metadata: metadata}, key, default \\ nil) do
+  def get_metadata(%Message{metadata: metadata}, key, default \\ nil) do
     Map.get(metadata, key, default)
   end
 

--- a/lib/nous/message/content_part.ex
+++ b/lib/nous/message/content_part.ex
@@ -34,6 +34,8 @@ defmodule Nous.Message.ContentPart do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias __MODULE__
+
   @content_types ~w(text image_url image file file_url thinking)a
 
   @primary_key false
@@ -43,7 +45,7 @@ defmodule Nous.Message.ContentPart do
     field(:options, :map, default: %{})
   end
 
-  @type t :: %__MODULE__{
+  @type t :: %ContentPart{
           type: atom(),
           content: String.t(),
           options: map()
@@ -65,7 +67,7 @@ defmodule Nous.Message.ContentPart do
   """
   @spec new(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{}
+    %ContentPart{}
     |> changeset(attrs)
     |> case do
       %Ecto.Changeset{valid?: true} = changeset ->
@@ -242,7 +244,7 @@ defmodule Nous.Message.ContentPart do
 
   """
   @spec merge(t(), t()) :: t() | {:error, :incompatible_types}
-  def merge(%__MODULE__{type: type} = part1, %__MODULE__{type: type} = part2) do
+  def merge(%ContentPart{type: type} = part1, %ContentPart{type: type} = part2) do
     merged_options =
       Map.merge(part1.options, part2.options, fn _key, v1, v2 ->
         case {v1, v2} do
@@ -251,14 +253,14 @@ defmodule Nous.Message.ContentPart do
         end
       end)
 
-    %__MODULE__{
+    %ContentPart{
       type: type,
       content: part1.content <> part2.content,
       options: merged_options
     }
   end
 
-  def merge(%__MODULE__{type: type1}, %__MODULE__{type: type2}) when type1 != type2 do
+  def merge(%ContentPart{type: type1}, %ContentPart{type: type2}) when type1 != type2 do
     {:error, :incompatible_types}
   end
 
@@ -273,15 +275,15 @@ defmodule Nous.Message.ContentPart do
   """
   @spec consolidate([t()]) :: String.t() | [t()]
   def consolidate([]), do: ""
-  def consolidate([%__MODULE__{type: :text, content: content}]), do: content
-  def consolidate([%__MODULE__{type: :thinking, content: content}]), do: content
+  def consolidate([%ContentPart{type: :text, content: content}]), do: content
+  def consolidate([%ContentPart{type: :thinking, content: content}]), do: content
 
   def consolidate(parts) when is_list(parts) do
     cond do
-      Enum.all?(parts, &match?(%__MODULE__{type: :text}, &1)) ->
+      Enum.all?(parts, &match?(%ContentPart{type: :text}, &1)) ->
         Enum.map_join(parts, "", & &1.content)
 
-      Enum.all?(parts, &match?(%__MODULE__{type: :thinking}, &1)) ->
+      Enum.all?(parts, &match?(%ContentPart{type: :thinking}, &1)) ->
         Enum.map_join(parts, "", & &1.content)
 
       true ->
@@ -552,10 +554,10 @@ defmodule Nous.Message.ContentPart do
     end
   end
 
-  defp part_to_text(%__MODULE__{type: :text, content: content}), do: content
-  defp part_to_text(%__MODULE__{type: :image_url, content: url}), do: "[Image: #{url}]"
-  defp part_to_text(%__MODULE__{type: :image, content: _}), do: "[Image]"
-  defp part_to_text(%__MODULE__{type: :file, content: path}), do: "[File: #{path}]"
-  defp part_to_text(%__MODULE__{type: :file_url, content: url}), do: "[File: #{url}]"
-  defp part_to_text(%__MODULE__{type: :thinking, content: content}), do: "[Thinking: #{content}]"
+  defp part_to_text(%ContentPart{type: :text, content: content}), do: content
+  defp part_to_text(%ContentPart{type: :image_url, content: url}), do: "[Image: #{url}]"
+  defp part_to_text(%ContentPart{type: :image, content: _}), do: "[Image]"
+  defp part_to_text(%ContentPart{type: :file, content: path}), do: "[File: #{path}]"
+  defp part_to_text(%ContentPart{type: :file_url, content: url}), do: "[File: #{url}]"
+  defp part_to_text(%ContentPart{type: :thinking, content: content}), do: "[Thinking: #{content}]"
 end

--- a/lib/nous/model.ex
+++ b/lib/nous/model.ex
@@ -14,6 +14,8 @@ defmodule Nous.Model do
 
   """
 
+  alias __MODULE__
+
   @type provider ::
           :openai
           | :anthropic
@@ -30,7 +32,7 @@ defmodule Nous.Model do
           | :mistral
           | :custom
 
-  @type t :: %__MODULE__{
+  @type t :: %Model{
           provider: provider(),
           model: String.t(),
           base_url: String.t() | nil,
@@ -237,7 +239,7 @@ defmodule Nous.Model do
   """
   @spec new(provider(), String.t(), keyword()) :: t()
   def new(provider, model, opts \\ []) do
-    %__MODULE__{
+    %Model{
       provider: provider,
       model: model,
       base_url: Keyword.get(opts, :base_url, default_base_url(provider)),

--- a/lib/nous/prompt_template.ex
+++ b/lib/nous/prompt_template.ex
@@ -65,9 +65,10 @@ defmodule Nous.PromptTemplate do
 
   """
 
+  alias __MODULE__
   alias Nous.Message
 
-  @type t :: %__MODULE__{
+  @type t :: %PromptTemplate{
           text: String.t(),
           role: :system | :user | :assistant,
           inputs: map()
@@ -97,7 +98,7 @@ defmodule Nous.PromptTemplate do
   def from_template(text, opts \\ []) when is_binary(text) do
     case validate_template_safety(text) do
       :ok ->
-        %__MODULE__{
+        %PromptTemplate{
           text: text,
           role: Keyword.get(opts, :role, :user),
           inputs: Keyword.get(opts, :inputs, %{})
@@ -188,7 +189,7 @@ defmodule Nous.PromptTemplate do
 
   """
   @spec format(t(), map()) :: String.t()
-  def format(%__MODULE__{text: text, inputs: default_inputs}, bindings \\ %{}) do
+  def format(%PromptTemplate{text: text, inputs: default_inputs}, bindings \\ %{}) do
     merged = Map.merge(default_inputs, bindings)
     do_format(text, merged)
   end
@@ -218,7 +219,7 @@ defmodule Nous.PromptTemplate do
 
   """
   @spec to_message(t(), map()) :: Message.t()
-  def to_message(%__MODULE__{role: role} = template, bindings \\ %{}) do
+  def to_message(%PromptTemplate{role: role} = template, bindings \\ %{}) do
     content = format(template, bindings)
 
     case role do
@@ -247,7 +248,7 @@ defmodule Nous.PromptTemplate do
   @spec to_messages([t() | Message.t()], map()) :: [Message.t()]
   def to_messages(items, bindings \\ %{}) when is_list(items) do
     Enum.map(items, fn
-      %__MODULE__{} = template -> to_message(template, bindings)
+      %PromptTemplate{} = template -> to_message(template, bindings)
       %Message{} = message -> message
     end)
   end
@@ -286,7 +287,7 @@ defmodule Nous.PromptTemplate do
 
   """
   @spec variables(t()) :: [atom()]
-  def variables(%__MODULE__{text: text}) do
+  def variables(%PromptTemplate{text: text}) do
     extract_variables(text)
   end
 
@@ -328,7 +329,7 @@ defmodule Nous.PromptTemplate do
 
   """
   @spec validate_bindings(t(), map()) :: {:ok, map()} | {:error, [atom()]}
-  def validate_bindings(%__MODULE__{} = template, bindings) do
+  def validate_bindings(%PromptTemplate{} = template, bindings) do
     required = variables(template)
     available = Map.merge(template.inputs, bindings)
     provided = MapSet.new(Map.keys(available))
@@ -378,7 +379,7 @@ defmodule Nous.PromptTemplate do
       |> Enum.map(& &1.text)
       |> Enum.join(separator)
 
-    %__MODULE__{
+    %PromptTemplate{
       text: combined_text,
       role: role,
       inputs: merged_inputs

--- a/lib/nous/research/finding.ex
+++ b/lib/nous/research/finding.ex
@@ -3,7 +3,9 @@ defmodule Nous.Research.Finding do
   Represents a research finding from a search/analysis step.
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Finding{
           claim: String.t(),
           source_url: String.t() | nil,
           source_title: String.t() | nil,
@@ -22,7 +24,7 @@ defmodule Nous.Research.Finding do
   ]
 
   def new(attrs) do
-    %__MODULE__{
+    %Finding{
       claim: Map.fetch!(attrs, :claim),
       source_url: Map.get(attrs, :source_url),
       source_title: Map.get(attrs, :source_title),

--- a/lib/nous/run_context.ex
+++ b/lib/nous/run_context.ex
@@ -24,9 +24,10 @@ defmodule Nous.RunContext do
 
   """
 
+  alias __MODULE__
   alias Nous.Usage
 
-  @type t(deps) :: %__MODULE__{
+  @type t(deps) :: %RunContext{
           deps: deps,
           retry: non_neg_integer(),
           usage: Usage.t()
@@ -54,7 +55,7 @@ defmodule Nous.RunContext do
   """
   @spec new(deps :: any(), opts :: keyword()) :: t(any())
   def new(deps, opts \\ []) do
-    %__MODULE__{
+    %RunContext{
       deps: deps,
       retry: Keyword.get(opts, :retry, 0),
       usage: Keyword.get(opts, :usage, Usage.new())

--- a/lib/nous/skill.ex
+++ b/lib/nous/skill.ex
@@ -72,6 +72,8 @@ defmodule Nous.Skill do
       )
   """
 
+  alias __MODULE__
+
   @type activation ::
           :manual
           | :auto
@@ -83,7 +85,7 @@ defmodule Nous.Skill do
 
   @type status :: :discovered | :loaded | :active | :inactive
 
-  @type t :: %__MODULE__{
+  @type t :: %Skill{
           name: String.t(),
           description: String.t(),
           tags: [atom()],
@@ -196,7 +198,7 @@ defmodule Nous.Skill do
   def from_module(module) when is_atom(module) do
     Code.ensure_loaded!(module)
 
-    %__MODULE__{
+    %Skill{
       name: module.name(),
       description: module.description(),
       tags: if(function_exported?(module, :tags, 0), do: module.tags(), else: []),

--- a/lib/nous/skill/registry.ex
+++ b/lib/nous/skill/registry.ex
@@ -15,12 +15,13 @@ defmodule Nous.Skill.Registry do
       active = Nous.Skill.Registry.active_skills(registry)
   """
 
+  alias __MODULE__
   alias Nous.Skill
   alias Nous.Skill.Loader
 
   require Logger
 
-  @type t :: %__MODULE__{
+  @type t :: %Registry{
           skills: %{optional(String.t()) => Skill.t()},
           groups: %{optional(atom()) => [String.t()]},
           tags: %{optional(atom()) => [String.t()]},
@@ -38,13 +39,13 @@ defmodule Nous.Skill.Registry do
   Create an empty registry.
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %Registry{}
 
   @doc """
   Register a skill in the registry, indexing by name, group, tags, and scope.
   """
   @spec register(t(), Skill.t()) :: t()
-  def register(%__MODULE__{} = registry, %Skill{} = skill) do
+  def register(%Registry{} = registry, %Skill{} = skill) do
     %{
       registry
       | skills: Map.put(registry.skills, skill.name, skill),
@@ -58,7 +59,7 @@ defmodule Nous.Skill.Registry do
   Register multiple skills at once.
   """
   @spec register_all(t(), [Skill.t()]) :: t()
-  def register_all(%__MODULE__{} = registry, skills) do
+  def register_all(%Registry{} = registry, skills) do
     Enum.reduce(skills, registry, &register(&2, &1))
   end
 
@@ -75,7 +76,7 @@ defmodule Nous.Skill.Registry do
 
   """
   @spec register_directory(t(), String.t()) :: t()
-  def register_directory(%__MODULE__{} = registry, path) when is_binary(path) do
+  def register_directory(%Registry{} = registry, path) when is_binary(path) do
     skills = Loader.load_directory(path)
 
     Logger.debug("Loaded #{length(skills)} skill(s) from directory: #{path}")
@@ -93,7 +94,7 @@ defmodule Nous.Skill.Registry do
 
   """
   @spec register_directories(t(), [String.t()]) :: t()
-  def register_directories(%__MODULE__{} = registry, paths) when is_list(paths) do
+  def register_directories(%Registry{} = registry, paths) when is_list(paths) do
     Enum.reduce(paths, registry, &register_directory(&2, &1))
   end
 
@@ -133,7 +134,7 @@ defmodule Nous.Skill.Registry do
   """
   @spec activate(t(), String.t(), Nous.Agent.t(), Nous.Agent.Context.t()) ::
           {String.t() | nil, [Nous.Tool.t()], t()}
-  def activate(%__MODULE__{} = registry, name, agent, ctx) do
+  def activate(%Registry{} = registry, name, agent, ctx) do
     case Map.get(registry.skills, name) do
       nil ->
         Logger.warning("Skill not found: #{name}")
@@ -164,7 +165,7 @@ defmodule Nous.Skill.Registry do
   Deactivate a skill by name.
   """
   @spec deactivate(t(), String.t()) :: t()
-  def deactivate(%__MODULE__{} = registry, name) do
+  def deactivate(%Registry{} = registry, name) do
     case Map.get(registry.skills, name) do
       nil ->
         registry
@@ -191,7 +192,7 @@ defmodule Nous.Skill.Registry do
   """
   @spec activate_group(t(), atom(), Nous.Agent.t(), Nous.Agent.Context.t()) ::
           {[{String.t(), [Nous.Tool.t()]}], t()}
-  def activate_group(%__MODULE__{} = registry, group, agent, ctx) do
+  def activate_group(%Registry{} = registry, group, agent, ctx) do
     names = Map.get(registry.groups, group, [])
 
     {results, updated_registry} =
@@ -207,7 +208,7 @@ defmodule Nous.Skill.Registry do
   Deactivate all skills in a group.
   """
   @spec deactivate_group(t(), atom()) :: t()
-  def deactivate_group(%__MODULE__{} = registry, group) do
+  def deactivate_group(%Registry{} = registry, group) do
     names = Map.get(registry.groups, group, [])
     Enum.reduce(names, registry, &deactivate(&2, &1))
   end
@@ -216,7 +217,7 @@ defmodule Nous.Skill.Registry do
   Get all skills in a group.
   """
   @spec by_group(t(), atom()) :: [Skill.t()]
-  def by_group(%__MODULE__{} = registry, group) do
+  def by_group(%Registry{} = registry, group) do
     resolve_names(registry, Map.get(registry.groups, group, []))
   end
 
@@ -224,7 +225,7 @@ defmodule Nous.Skill.Registry do
   Get all skills with a tag.
   """
   @spec by_tag(t(), atom()) :: [Skill.t()]
-  def by_tag(%__MODULE__{} = registry, tag) do
+  def by_tag(%Registry{} = registry, tag) do
     resolve_names(registry, Map.get(registry.tags, tag, []))
   end
 
@@ -232,7 +233,7 @@ defmodule Nous.Skill.Registry do
   Get all currently active skills.
   """
   @spec active_skills(t()) :: [Skill.t()]
-  def active_skills(%__MODULE__{} = registry) do
+  def active_skills(%Registry{} = registry) do
     registry
     |> resolve_names(registry.active)
     |> Enum.sort_by(& &1.priority)
@@ -245,7 +246,7 @@ defmodule Nous.Skill.Registry do
   description keyword matching.
   """
   @spec match(t(), String.t()) :: [Skill.t()]
-  def match(%__MODULE__{} = registry, input) do
+  def match(%Registry{} = registry, input) do
     input_lower = String.downcase(input)
 
     registry.skills
@@ -270,7 +271,7 @@ defmodule Nous.Skill.Registry do
   List all registered skill names.
   """
   @spec list(t()) :: [String.t()]
-  def list(%__MODULE__{} = registry) do
+  def list(%Registry{} = registry) do
     Map.keys(registry.skills)
   end
 
@@ -278,7 +279,7 @@ defmodule Nous.Skill.Registry do
   Get a skill by name.
   """
   @spec get(t(), String.t()) :: Skill.t() | nil
-  def get(%__MODULE__{} = registry, name) do
+  def get(%Registry{} = registry, name) do
     Map.get(registry.skills, name)
   end
 
@@ -286,7 +287,7 @@ defmodule Nous.Skill.Registry do
   Check if a skill is currently active.
   """
   @spec active?(t(), String.t()) :: boolean()
-  def active?(%__MODULE__{} = registry, name) do
+  def active?(%Registry{} = registry, name) do
     MapSet.member?(registry.active, name)
   end
 

--- a/lib/nous/teams/role.ex
+++ b/lib/nous/teams/role.ex
@@ -23,7 +23,9 @@ defmodule Nous.Teams.Role do
       filtered = Role.apply_tool_filter(role, all_tools)
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Role{
           name: atom(),
           system_prompt: String.t() | nil,
           allowed_tools: [String.t()] | nil,
@@ -72,17 +74,17 @@ defmodule Nous.Teams.Role do
       1
   """
   @spec apply_tool_filter(t(), [Nous.Tool.t()]) :: [Nous.Tool.t()]
-  def apply_tool_filter(%__MODULE__{allowed_tools: allowed} = _role, tools)
+  def apply_tool_filter(%Role{allowed_tools: allowed} = _role, tools)
       when is_list(allowed) do
     Enum.filter(tools, &(&1.name in allowed))
   end
 
-  def apply_tool_filter(%__MODULE__{denied_tools: denied} = _role, tools)
+  def apply_tool_filter(%Role{denied_tools: denied} = _role, tools)
       when is_list(denied) do
     Enum.reject(tools, &(&1.name in denied))
   end
 
-  def apply_tool_filter(%__MODULE__{}, tools), do: tools
+  def apply_tool_filter(%Role{}, tools), do: tools
 
   # Built-in roles
 
@@ -99,7 +101,7 @@ defmodule Nous.Teams.Role do
   """
   @spec researcher() :: t()
   def researcher do
-    %__MODULE__{
+    %Role{
       name: :researcher,
       system_prompt: """
       You are a research specialist on this team. Your job is to:
@@ -135,7 +137,7 @@ defmodule Nous.Teams.Role do
   """
   @spec coder() :: t()
   def coder do
-    %__MODULE__{
+    %Role{
       name: :coder,
       system_prompt: """
       You are a coding specialist on this team. Your job is to:
@@ -162,7 +164,7 @@ defmodule Nous.Teams.Role do
   """
   @spec lead() :: t()
   def lead do
-    %__MODULE__{
+    %Role{
       name: :lead,
       system_prompt: """
       You are the team lead. Your job is to:

--- a/lib/nous/tool.ex
+++ b/lib/nous/tool.ex
@@ -28,9 +28,11 @@ defmodule Nous.Tool do
 
   """
 
+  alias __MODULE__
+
   @type category :: :read | :write | :execute | :communicate | :search | nil
 
-  @type t :: %__MODULE__{
+  @type t :: %Tool{
           name: String.t(),
           description: String.t(),
           parameters: map(),
@@ -110,7 +112,7 @@ defmodule Nous.Tool do
       extract_function_docs(fun) ||
         {Keyword.get(opts, :description, ""), default_schema()}
 
-    %__MODULE__{
+    %Tool{
       name: Keyword.get(opts, :name, function_name),
       description: Keyword.get(opts, :description, description),
       parameters: Keyword.get(opts, :parameters, param_schema),
@@ -198,7 +200,7 @@ defmodule Nous.Tool do
 
     metadata = Behaviour.get_metadata(module)
 
-    %__MODULE__{
+    %Tool{
       name: Keyword.get(opts, :name, metadata.name),
       description: Keyword.get(opts, :description, metadata.description),
       parameters: Keyword.get(opts, :parameters, metadata.parameters),
@@ -235,7 +237,7 @@ defmodule Nous.Tool do
 
   """
   @spec to_openai_schema(t()) :: map()
-  def to_openai_schema(%__MODULE__{} = tool) do
+  def to_openai_schema(%Tool{} = tool) do
     %{
       "type" => "function",
       "function" => %{

--- a/lib/nous/tool/context_update.ex
+++ b/lib/nous/tool/context_update.ex
@@ -54,13 +54,15 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
 
+  alias __MODULE__
+
   @type operation ::
           {:set, atom(), any()}
           | {:merge, atom(), map()}
           | {:append, atom(), any()}
           | {:delete, atom()}
 
-  @type t :: %__MODULE__{
+  @type t :: %ContextUpdate{
           operations: [operation()]
         }
 
@@ -76,7 +78,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %ContextUpdate{}
 
   @doc """
   Set a key to a value in the context deps.
@@ -90,7 +92,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec set(t(), atom(), any()) :: t()
-  def set(%__MODULE__{} = update, key, value) when is_atom(key) do
+  def set(%ContextUpdate{} = update, key, value) when is_atom(key) do
     %{update | operations: update.operations ++ [{:set, key, value}]}
   end
 
@@ -106,7 +108,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec merge(t(), atom(), map()) :: t()
-  def merge(%__MODULE__{} = update, key, map) when is_atom(key) and is_map(map) do
+  def merge(%ContextUpdate{} = update, key, map) when is_atom(key) and is_map(map) do
     %{update | operations: update.operations ++ [{:merge, key, map}]}
   end
 
@@ -122,7 +124,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec append(t(), atom(), any()) :: t()
-  def append(%__MODULE__{} = update, key, item) when is_atom(key) do
+  def append(%ContextUpdate{} = update, key, item) when is_atom(key) do
     %{update | operations: update.operations ++ [{:append, key, item}]}
   end
 
@@ -136,7 +138,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec delete(t(), atom()) :: t()
-  def delete(%__MODULE__{} = update, key) when is_atom(key) do
+  def delete(%ContextUpdate{} = update, key) when is_atom(key) do
     %{update | operations: update.operations ++ [{:delete, key}]}
   end
 
@@ -155,7 +157,7 @@ defmodule Nous.Tool.ContextUpdate do
 
   """
   @spec apply(t(), Nous.Agent.Context.t()) :: Nous.Agent.Context.t()
-  def apply(%__MODULE__{operations: ops}, %Nous.Agent.Context{} = ctx) do
+  def apply(%ContextUpdate{operations: ops}, %Nous.Agent.Context{} = ctx) do
     new_deps = reduce_operations(ops, ctx.deps || %{})
 
     keys =
@@ -182,7 +184,7 @@ defmodule Nous.Tool.ContextUpdate do
   For backwards compatibility with tools using RunContext.
   """
   @spec apply_to_run_context(t(), Nous.RunContext.t()) :: Nous.RunContext.t()
-  def apply_to_run_context(%__MODULE__{operations: ops}, %Nous.RunContext{} = ctx) do
+  def apply_to_run_context(%ContextUpdate{operations: ops}, %Nous.RunContext{} = ctx) do
     new_deps = reduce_operations(ops, ctx.deps || %{})
     %{ctx | deps: new_deps}
   end
@@ -191,14 +193,14 @@ defmodule Nous.Tool.ContextUpdate do
   Check if this ContextUpdate has any operations.
   """
   @spec empty?(t()) :: boolean()
-  def empty?(%__MODULE__{operations: []}), do: true
-  def empty?(%__MODULE__{}), do: false
+  def empty?(%ContextUpdate{operations: []}), do: true
+  def empty?(%ContextUpdate{}), do: false
 
   @doc """
   Get the list of operations in this update.
   """
   @spec operations(t()) :: [operation()]
-  def operations(%__MODULE__{operations: ops}), do: ops
+  def operations(%ContextUpdate{operations: ops}), do: ops
 
   # Private
 

--- a/lib/nous/usage.ex
+++ b/lib/nous/usage.ex
@@ -14,7 +14,9 @@ defmodule Nous.Usage do
 
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Usage{
           requests: non_neg_integer(),
           tool_calls: non_neg_integer(),
           input_tokens: non_neg_integer(),
@@ -43,7 +45,7 @@ defmodule Nous.Usage do
 
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: %Usage{}
 
   @doc """
   Add two usage trackers together.
@@ -59,8 +61,8 @@ defmodule Nous.Usage do
 
   """
   @spec add(t(), t()) :: t()
-  def add(%__MODULE__{} = u1, %__MODULE__{} = u2) do
-    %__MODULE__{
+  def add(%Usage{} = u1, %Usage{} = u2) do
+    %Usage{
       requests: u1.requests + u2.requests,
       tool_calls: u1.tool_calls + u2.tool_calls,
       input_tokens: u1.input_tokens + u2.input_tokens,
@@ -82,7 +84,7 @@ defmodule Nous.Usage do
 
   """
   @spec inc_requests(t()) :: t()
-  def inc_requests(%__MODULE__{} = usage) do
+  def inc_requests(%Usage{} = usage) do
     %{usage | requests: usage.requests + 1}
   end
 
@@ -96,7 +98,7 @@ defmodule Nous.Usage do
 
   """
   @spec inc_tool_calls(t(), non_neg_integer()) :: t()
-  def inc_tool_calls(%__MODULE__{} = usage, count \\ 1) do
+  def inc_tool_calls(%Usage{} = usage, count \\ 1) do
     %{usage | tool_calls: usage.tool_calls + count}
   end
 
@@ -116,7 +118,7 @@ defmodule Nous.Usage do
 
   """
   @spec add_tokens(t(), keyword()) :: t()
-  def add_tokens(%__MODULE__{} = usage, opts) do
+  def add_tokens(%Usage{} = usage, opts) do
     input = Keyword.get(opts, :input, 0)
     output = Keyword.get(opts, :output, 0)
 
@@ -146,7 +148,7 @@ defmodule Nous.Usage do
   """
   @spec from_openai(map()) :: t()
   def from_openai(openai_usage) when is_map(openai_usage) do
-    %__MODULE__{
+    %Usage{
       requests: 1,
       input_tokens: Map.get(openai_usage, :prompt_tokens, 0),
       output_tokens: Map.get(openai_usage, :completion_tokens, 0),

--- a/lib/nous/workflow/checkpoint.ex
+++ b/lib/nous/workflow/checkpoint.ex
@@ -19,7 +19,9 @@ defmodule Nous.Workflow.Checkpoint do
   | `created_at` | When checkpoint was created |
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Checkpoint{
           workflow_id: String.t(),
           run_id: String.t(),
           node_id: String.t() | nil,
@@ -44,7 +46,7 @@ defmodule Nous.Workflow.Checkpoint do
   """
   @spec new(map()) :: t()
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{
+    %Checkpoint{
       workflow_id: Map.fetch!(attrs, :workflow_id),
       run_id: Map.get(attrs, :run_id) || generate_id(),
       node_id: Map.get(attrs, :node_id),

--- a/lib/nous/workflow/edge.ex
+++ b/lib/nous/workflow/edge.ex
@@ -30,9 +30,11 @@ defmodule Nous.Workflow.Edge do
       })
   """
 
+  alias __MODULE__
+
   @type edge_type :: :sequential | :conditional | :default
 
-  @type t :: %__MODULE__{
+  @type t :: %Edge{
           id: String.t(),
           from_id: String.t(),
           to_id: String.t(),
@@ -68,7 +70,7 @@ defmodule Nous.Workflow.Edge do
   """
   @spec new(map()) :: t()
   def new(attrs) when is_map(attrs) do
-    %__MODULE__{
+    %Edge{
       id: Map.get(attrs, :id) || generate_id(),
       from_id: attrs |> Map.fetch!(:from_id) |> to_string(),
       to_id: attrs |> Map.fetch!(:to_id) |> to_string(),

--- a/lib/nous/workflow/graph.ex
+++ b/lib/nous/workflow/graph.ex
@@ -23,11 +23,12 @@ defmodule Nous.Workflow.Graph do
         |> Nous.Workflow.Graph.chain([:fetch, :process, :store])
   """
 
+  alias __MODULE__
   alias Nous.Workflow.{Node, Edge}
 
   @type node_id :: String.t()
 
-  @type t :: %__MODULE__{
+  @type t :: %Graph{
           id: String.t(),
           name: String.t(),
           nodes: %{node_id() => Node.t()},
@@ -66,7 +67,7 @@ defmodule Nous.Workflow.Graph do
   """
   @spec new(String.t(), keyword()) :: t()
   def new(id, opts \\ []) when is_binary(id) do
-    %__MODULE__{
+    %Graph{
       id: id,
       name: Keyword.get(opts, :name, id),
       allows_cycles: Keyword.get(opts, :allows_cycles, false)
@@ -93,7 +94,7 @@ defmodule Nous.Workflow.Graph do
 
   """
   @spec add_node(t(), atom() | String.t(), Node.node_type(), map(), keyword()) :: t()
-  def add_node(%__MODULE__{} = graph, node_id, type, config \\ %{}, opts \\ []) do
+  def add_node(%Graph{} = graph, node_id, type, config \\ %{}, opts \\ []) do
     id = to_string(node_id)
 
     if Map.has_key?(graph.nodes, id) do
@@ -142,7 +143,7 @@ defmodule Nous.Workflow.Graph do
 
   """
   @spec connect(t(), atom() | String.t(), atom() | String.t(), keyword()) :: t()
-  def connect(%__MODULE__{} = graph, from, to, opts \\ []) do
+  def connect(%Graph{} = graph, from, to, opts \\ []) do
     from_id = to_string(from)
     to_id = to_string(to)
 
@@ -185,7 +186,7 @@ defmodule Nous.Workflow.Graph do
 
   """
   @spec chain(t(), [atom() | String.t()]) :: t()
-  def chain(%__MODULE__{} = graph, node_ids) when is_list(node_ids) do
+  def chain(%Graph{} = graph, node_ids) when is_list(node_ids) do
     node_ids
     |> Enum.chunk_every(2, 1, :discard)
     |> Enum.reduce(graph, fn [from, to], acc -> connect(acc, from, to) end)
@@ -195,7 +196,7 @@ defmodule Nous.Workflow.Graph do
   Set the entry node explicitly (overrides the auto-detected first node).
   """
   @spec set_entry(t(), atom() | String.t()) :: t()
-  def set_entry(%__MODULE__{} = graph, node_id) do
+  def set_entry(%Graph{} = graph, node_id) do
     id = to_string(node_id)
     validate_node_exists!(graph, id, "set_entry")
     %{graph | entry_node: id}
@@ -205,7 +206,7 @@ defmodule Nous.Workflow.Graph do
   Returns the successor node IDs for a given node (via out_edges).
   """
   @spec successors(t(), node_id()) :: [node_id()]
-  def successors(%__MODULE__{} = graph, node_id) do
+  def successors(%Graph{} = graph, node_id) do
     graph.out_edges
     |> Map.get(node_id, [])
     |> Enum.map(& &1.to_id)
@@ -215,7 +216,7 @@ defmodule Nous.Workflow.Graph do
   Returns the predecessor node IDs for a given node (via in_edges).
   """
   @spec predecessors(t(), node_id()) :: [node_id()]
-  def predecessors(%__MODULE__{} = graph, node_id) do
+  def predecessors(%Graph{} = graph, node_id) do
     graph.in_edges
     |> Map.get(node_id, [])
     |> Enum.map(& &1.from_id)
@@ -225,19 +226,19 @@ defmodule Nous.Workflow.Graph do
   Returns the number of nodes in the graph.
   """
   @spec node_count(t()) :: non_neg_integer()
-  def node_count(%__MODULE__{nodes: nodes}), do: map_size(nodes)
+  def node_count(%Graph{nodes: nodes}), do: map_size(nodes)
 
   @doc """
   Returns all node IDs in the graph.
   """
   @spec node_ids(t()) :: [node_id()]
-  def node_ids(%__MODULE__{nodes: nodes}), do: Map.keys(nodes)
+  def node_ids(%Graph{nodes: nodes}), do: Map.keys(nodes)
 
   @doc """
   Returns terminal nodes (nodes with no outgoing edges).
   """
   @spec terminal_nodes(t()) :: [node_id()]
-  def terminal_nodes(%__MODULE__{} = graph) do
+  def terminal_nodes(%Graph{} = graph) do
     Enum.filter(Map.keys(graph.nodes), fn id ->
       graph.out_edges |> Map.get(id, []) |> Enum.empty?()
     end)
@@ -258,7 +259,7 @@ defmodule Nous.Workflow.Graph do
           map(),
           keyword()
         ) :: t()
-  def insert_after(%__MODULE__{} = graph, after_id, new_id, type, config \\ %{}, opts \\ []) do
+  def insert_after(%Graph{} = graph, after_id, new_id, type, config \\ %{}, opts \\ []) do
     after_str = to_string(after_id)
     validate_node_exists!(graph, after_str, "insert_after")
 
@@ -301,7 +302,7 @@ defmodule Nous.Workflow.Graph do
   Remove a node and reconnect its predecessors to its successors.
   """
   @spec remove_node(t(), atom() | String.t()) :: t()
-  def remove_node(%__MODULE__{} = graph, node_id) do
+  def remove_node(%Graph{} = graph, node_id) do
     id = to_string(node_id)
     validate_node_exists!(graph, id, "remove_node")
 

--- a/lib/nous/workflow/node.ex
+++ b/lib/nous/workflow/node.ex
@@ -29,6 +29,8 @@ defmodule Nous.Workflow.Node do
       })
   """
 
+  alias __MODULE__
+
   @type node_type ::
           :agent_step
           | :tool_step
@@ -45,7 +47,7 @@ defmodule Nous.Workflow.Node do
           | :skip
           | {:fallback, node_id :: String.t()}
 
-  @type t :: %__MODULE__{
+  @type t :: %Node{
           id: String.t(),
           type: node_type(),
           label: String.t(),
@@ -90,7 +92,7 @@ defmodule Nous.Workflow.Node do
             "invalid node type: #{inspect(type)}, must be one of #{inspect(@valid_types)}"
     end
 
-    %__MODULE__{
+    %Node{
       id: attrs |> Map.fetch!(:id) |> to_string(),
       type: type,
       label: Map.fetch!(attrs, :label),

--- a/lib/nous/workflow/scratch.ex
+++ b/lib/nous/workflow/scratch.ex
@@ -23,7 +23,9 @@ defmodule Nous.Workflow.Scratch do
   The scratch reference is available in `state.metadata.scratch`.
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %Scratch{
           table: :ets.tid() | nil,
           id: String.t()
         }
@@ -35,7 +37,7 @@ defmodule Nous.Workflow.Scratch do
   """
   @spec new() :: t()
   def new do
-    %__MODULE__{
+    %Scratch{
       id: :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
     }
   end
@@ -44,7 +46,7 @@ defmodule Nous.Workflow.Scratch do
   Store a value in the scratch space.
   """
   @spec put(t(), term(), term()) :: t()
-  def put(%__MODULE__{} = scratch, key, value) do
+  def put(%Scratch{} = scratch, key, value) do
     scratch = ensure_table(scratch)
     :ets.insert(scratch.table, {key, value})
     scratch
@@ -56,9 +58,9 @@ defmodule Nous.Workflow.Scratch do
   @spec get(t(), term(), term()) :: term()
   def get(scratch, key, default \\ nil)
 
-  def get(%__MODULE__{table: nil}, _key, default), do: default
+  def get(%Scratch{table: nil}, _key, default), do: default
 
-  def get(%__MODULE__{} = scratch, key, default) do
+  def get(%Scratch{} = scratch, key, default) do
     case :ets.lookup(scratch.table, key) do
       [{^key, value}] -> value
       [] -> default
@@ -69,9 +71,9 @@ defmodule Nous.Workflow.Scratch do
   Delete a key from the scratch space.
   """
   @spec delete(t(), term()) :: :ok
-  def delete(%__MODULE__{table: nil}, _key), do: :ok
+  def delete(%Scratch{table: nil}, _key), do: :ok
 
-  def delete(%__MODULE__{} = scratch, key) do
+  def delete(%Scratch{} = scratch, key) do
     :ets.delete(scratch.table, key)
     :ok
   end
@@ -80,14 +82,14 @@ defmodule Nous.Workflow.Scratch do
   Clean up the scratch ETS table. Called automatically on workflow completion.
   """
   @spec cleanup(t()) :: :ok
-  def cleanup(%__MODULE__{table: nil}), do: :ok
+  def cleanup(%Scratch{table: nil}), do: :ok
 
-  def cleanup(%__MODULE__{table: table}) do
+  def cleanup(%Scratch{table: table}) do
     :ets.delete(table)
     :ok
   end
 
-  defp ensure_table(%__MODULE__{table: nil} = scratch) do
+  defp ensure_table(%Scratch{table: nil} = scratch) do
     table = :ets.new(:"nous_scratch_#{scratch.id}", [:set, :public])
     %{scratch | table: table}
   end

--- a/lib/nous/workflow/state.ex
+++ b/lib/nous/workflow/state.ex
@@ -24,7 +24,9 @@ defmodule Nous.Workflow.State do
       #=> "research topic"
   """
 
-  @type t :: %__MODULE__{
+  alias __MODULE__
+
+  @type t :: %State{
           data: map(),
           node_results: %{String.t() => term()},
           metadata: map(),
@@ -56,7 +58,7 @@ defmodule Nous.Workflow.State do
   def new(data \\ %{}) when is_map(data) do
     now = DateTime.utc_now()
 
-    %__MODULE__{
+    %State{
       data: data,
       started_at: now,
       updated_at: now
@@ -67,7 +69,7 @@ defmodule Nous.Workflow.State do
   Record a node's result in the state.
   """
   @spec put_result(t(), String.t(), term()) :: t()
-  def put_result(%__MODULE__{} = state, node_id, result) do
+  def put_result(%State{} = state, node_id, result) do
     %{
       state
       | node_results: Map.put(state.node_results, node_id, result),
@@ -79,7 +81,7 @@ defmodule Nous.Workflow.State do
   Record an error for a node.
   """
   @spec put_error(t(), String.t(), term()) :: t()
-  def put_error(%__MODULE__{} = state, node_id, error) do
+  def put_error(%State{} = state, node_id, error) do
     %{state | errors: [{node_id, error} | state.errors], updated_at: DateTime.utc_now()}
   end
 
@@ -87,7 +89,7 @@ defmodule Nous.Workflow.State do
   Update the user data map.
   """
   @spec update_data(t(), (map() -> map())) :: t()
-  def update_data(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+  def update_data(%State{} = state, fun) when is_function(fun, 1) do
     %{state | data: fun.(state.data), updated_at: DateTime.utc_now()}
   end
 end

--- a/lib/nous/workflow/trace.ex
+++ b/lib/nous/workflow/trace.ex
@@ -16,6 +16,8 @@ defmodule Nous.Workflow.Trace do
       end
   """
 
+  alias __MODULE__
+
   @type entry :: %{
           node_id: String.t(),
           node_type: atom(),
@@ -26,7 +28,7 @@ defmodule Nous.Workflow.Trace do
           error: term() | nil
         }
 
-  @type t :: %__MODULE__{
+  @type t :: %Trace{
           run_id: String.t(),
           entries: [entry()],
           started_at: DateTime.t()
@@ -41,7 +43,7 @@ defmodule Nous.Workflow.Trace do
   """
   @spec new() :: t()
   def new do
-    %__MODULE__{
+    %Trace{
       run_id: generate_id(),
       entries: [],
       started_at: DateTime.utc_now()
@@ -59,7 +61,7 @@ defmodule Nous.Workflow.Trace do
           :completed | :failed | :skipped | :suspended,
           term()
         ) :: t()
-  def record(%__MODULE__{} = trace, node_id, node_type, duration_ns, status, error \\ nil) do
+  def record(%Trace{} = trace, node_id, node_type, duration_ns, status, error \\ nil) do
     now = DateTime.utc_now()
     duration_ms = System.convert_time_unit(duration_ns, :native, :millisecond)
 
@@ -80,7 +82,7 @@ defmodule Nous.Workflow.Trace do
   Returns the total execution time in milliseconds.
   """
   @spec total_duration_ms(t()) :: non_neg_integer()
-  def total_duration_ms(%__MODULE__{entries: entries}) do
+  def total_duration_ms(%Trace{entries: entries}) do
     Enum.reduce(entries, 0, fn entry, acc -> acc + entry.duration_ms end)
   end
 
@@ -88,7 +90,7 @@ defmodule Nous.Workflow.Trace do
   Returns the number of nodes executed.
   """
   @spec node_count(t()) :: non_neg_integer()
-  def node_count(%__MODULE__{entries: entries}), do: length(entries)
+  def node_count(%Trace{entries: entries}), do: length(entries)
 
   defp generate_id do
     :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)


### PR DESCRIPTION
> **Stacked on #<techdebt-dedup PR number>** — merge that first; this diff is the
  > single commit a97e8c8.

  ## What

  Adopts the `alias __MODULE__` idiom for struct references across the library:
  `%__MODULE__{...}` builds, pattern matches, update syntax, and `@type t` definitions
  become the module's short name (`%Message{}`, `%Context{}`, …). 37 files, ~253 refs,
  matching the existing exemplar in `memory/store/hybrid.ex`.

  Several moduledocs already wrote examples with the short name (`Registry.new()`,
  `Agent.new(...)`) — the alias makes those docs literally accurate.

  ## Scope

  - **Converted:** struct references only
  - **Untouched:** process-identity uses (`GenServer.start_link(__MODULE__, ...)`,
    `:ets.new(__MODULE__, ...)`, `@behaviour`, callback-module arguments)
  - **Excluded:** `errors/base.ex` (refs inside `quote do` — macro hygiene),
    `errors.ex` (9 submodules × 1 ref — alias noise), four 1-ref files

  ## Notes for review

  - Multi-module files got one alias per struct module: `eval/result.ex`
    (`Result` + `SuiteResult`) and `eval/metrics.ex` (`Metrics` + `Metrics.Summary`)
  - Stdlib-shadowing candidates (`Registry`, `Agent`, `Node`) were audited per file —
    no stdlib calls to those names exist in the converted files
  - `skill.ex`'s two refs verified to sit outside its `__using__` quote block

  ## Verification

  Zero behavior change — `alias` is compile-time lexical.

  - `mix test`: 1992 passed (7 doctests), 102 excluded — exact baseline match
  - `mix compile --warnings-as-errors`, `mix format --check-formatted`,
    `mix credo --strict` (0 issues), `mix docs` warning-free
  - Residual `grep -rn "%__MODULE__{" lib` shows only the 15 documented exclusion refs
