### PR TITLE
fix: audit follow-ups — atom leaks, secret redaction, O(n²) KB stats

### DIFF
--- a/lib/nous/knowledge_base/workflows.ex
+++ b/lib/nous/knowledge_base/workflows.ex
@@ -227,36 +227,50 @@ defmodule Nous.KnowledgeBase.Workflows do
     {:ok, entries} = store_mod.list_entries(store_state, opts)
     {:ok, docs} = store_mod.list_documents(store_state, opts)
 
-    link_count =
-      Enum.reduce(entries, 0, fn entry, acc ->
-        case store_mod.outlinks(store_state, entry.id) do
-          {:ok, links} -> acc + length(links)
-          _ -> acc
-        end
-      end)
+    link_counts = link_counts_by_source(store_mod, store_state, entries)
 
     stats = %{
       total_entries: length(entries),
-      total_links: link_count,
+      total_links: link_counts |> Map.values() |> Enum.sum(),
       total_documents: length(docs)
     }
 
     entry_summaries =
       Enum.map(entries, fn entry ->
-        {:ok, outlinks} = store_mod.outlinks(store_state, entry.id)
-
         %{
           slug: entry.slug,
           title: entry.title,
           entry_type: entry.entry_type,
           confidence: entry.confidence,
-          link_count: length(outlinks)
+          link_count: Map.get(link_counts, entry.id, 0)
         }
       end)
 
     state
     |> put_in([Access.key(:data), :stats], stats)
     |> put_in([Access.key(:data), :entry_summaries], entry_summaries)
+  end
+
+  # Use the optional bulk Store callback if implemented (single scan instead
+  # of a full links-table scan per entry); fall back to per-entry outlinks/2
+  # so older custom backends keep working without code changes. Scoped to the
+  # listed entries — the bulk callback counts links store-wide.
+  defp link_counts_by_source(store_mod, store_state, entries) do
+    entry_ids = Enum.map(entries, & &1.id)
+
+    if function_exported?(store_mod, :link_counts_by_source, 1) do
+      case store_mod.link_counts_by_source(store_state) do
+        {:ok, counts} -> Map.take(counts, entry_ids)
+        _ -> %{}
+      end
+    else
+      Map.new(entry_ids, fn id ->
+        case store_mod.outlinks(store_state, id) do
+          {:ok, links} -> {id, length(links)}
+          _ -> {id, 0}
+        end
+      end)
+    end
   end
 
   defp build_health_report(state) do

--- a/lib/nous/model.ex
+++ b/lib/nous/model.ex
@@ -43,6 +43,9 @@ defmodule Nous.Model do
           stream_normalizer: module() | nil
         }
 
+  # Keep the API key out of inspect output — crash reports, Logger metadata,
+  # and IEx would otherwise leak it.
+  @derive {Inspect, except: [:api_key]}
   @enforce_keys [:provider, :model]
   defstruct [
     :provider,

--- a/lib/nous/providers/http.ex
+++ b/lib/nous/providers/http.ex
@@ -102,7 +102,7 @@ defmodule Nous.Providers.HTTP do
      %ArgumentError{
        message:
          "Invalid arguments: url must be string, body must be map, headers must be list. " <>
-           "Got: url=#{inspect(url)}, body=#{inspect(body)}, headers=#{inspect(headers)}"
+           "Got: url=#{inspect(url)}, body=#{inspect(body)}, headers=#{redact_headers(headers)}"
      }}
   end
 
@@ -138,6 +138,19 @@ defmodule Nous.Providers.HTTP do
   rescue
     ArgumentError -> fallback.()
   end
+
+  # Header values carry secrets (authorization, x-api-key) — show only the
+  # keys when interpolating headers into error messages.
+  defp redact_headers(headers) when is_list(headers) or is_map(headers) do
+    headers
+    |> Enum.map(fn
+      {key, _value} -> {key, "[REDACTED]"}
+      other -> other
+    end)
+    |> inspect()
+  end
+
+  defp redact_headers(headers), do: inspect(headers)
 
   @doc """
   Make a streaming POST request.
@@ -182,7 +195,7 @@ defmodule Nous.Providers.HTTP do
      %ArgumentError{
        message:
          "Invalid arguments: url must be string, body must be map, headers must be list. " <>
-           "Got: url=#{inspect(url)}, body=#{inspect(body)}, headers=#{inspect(headers)}"
+           "Got: url=#{inspect(url)}, body=#{inspect(body)}, headers=#{redact_headers(headers)}"
      }}
   end
 

--- a/lib/nous/teams/shared_state.ex
+++ b/lib/nous/teams/shared_state.ex
@@ -133,7 +133,9 @@ defmodule Nous.Teams.SharedState do
     # The old single-row-list design copied the entire growing list term on
     # every :ets.insert (O(n) per write, O(n^2) accumulation). Per-row writes
     # are O(1) and claim conflict checks become a file-scoped :ets.select.
-    table = :ets.new(:"team_state_#{team_id}", [:set, :private])
+    # Constant atom: without :named_table the name is cosmetic, and a
+    # per-team :"team_state_#{team_id}" atom would leak (atoms are never GC'd).
+    table = :ets.new(:team_state, [:set, :private])
 
     {:ok, %{team_id: team_id, table: table, claim_ttl: claim_ttl, expiry_timers: %{}, seq: 0}}
   end

--- a/lib/nous/workflow/scratch.ex
+++ b/lib/nous/workflow/scratch.ex
@@ -90,7 +90,9 @@ defmodule Nous.Workflow.Scratch do
   end
 
   defp ensure_table(%Scratch{table: nil} = scratch) do
-    table = :ets.new(:"nous_scratch_#{scratch.id}", [:set, :public])
+    # Constant atom: without :named_table the name is cosmetic, and a
+    # per-run :"nous_scratch_#{id}" atom would leak (atoms are never GC'd).
+    table = :ets.new(:nous_scratch, [:set, :public])
     %{scratch | table: table}
   end
 

--- a/test/nous/workflow/phase5_test.exs
+++ b/test/nous/workflow/phase5_test.exs
@@ -267,7 +267,7 @@ defmodule Nous.Workflow.Phase5Test do
     test "scratch ETS table is cleaned up even when a node raises" do
       # Before fix: if execute_loop raised mid-workflow, the
       # `unless suspended?, do: maybe_cleanup_scratch(...)` line never ran,
-      # so the :"nous_scratch_<id>" table leaked. Long-running supervisors
+      # so the :nous_scratch table leaked. Long-running supervisors
       # that retry on failure would eventually OOM via ets_too_many_tables.
       alias Nous.Workflow
       alias Nous.Workflow.Graph
@@ -277,19 +277,12 @@ defmodule Nous.Workflow.Phase5Test do
         |> Graph.add_node(:boom, :transform, tf(fn _ -> raise "boom" end))
         |> Graph.set_entry(:boom)
 
-      # Count :nous_scratch_* ETS tables before and after a workflow that
-      # raises with `scratch: true`. They must match.
+      # Count :nous_scratch ETS tables before and after a workflow that
+      # raises with `scratch: true`. They must match. (Scratch tables are
+      # unnamed, so several can share the :nous_scratch info-name.)
       scratch_table_count = fn ->
         :ets.all()
-        |> Enum.count(fn t ->
-          case :ets.info(t, :name) do
-            name when is_atom(name) ->
-              name |> Atom.to_string() |> String.starts_with?("nous_scratch_")
-
-            _ ->
-              false
-          end
-        end)
+        |> Enum.count(fn t -> :ets.info(t, :name) == :nous_scratch end)
       end
 
       before_count = scratch_table_count.()


### PR DESCRIPTION
## Summary

Immediate fixes from the 2026-07-17 project health audit (5-track parallel audit: architecture, performance, security, tests, dependencies). Three small, self-contained fixes; one audit finding was investigated and dismissed as a false positive.

### 1. Atom leak: dynamic ETS table names (perf, high)

`Workflow.Scratch` and `Teams.SharedState` built a fresh atom per run/team for their ETS table names (`:"nous_scratch_#{id}"`, `:"team_state_#{team_id}"`). Atoms are never GC'd, so long-running nodes drifted toward atom-table exhaustion. Neither table uses `:named_table` — the name is purely cosmetic — so both now use constant atoms (`:nous_scratch`, `:team_state`) with zero collision risk. The leak-regression test in `phase5_test.exs` that matched tables by name prefix was updated to match the constant name.

### 2. Secret exposure via inspect/error messages (security, medium)

- `%Nous.Model{}` now derives `Inspect` with `:api_key` excluded, so crash reports, `Logger` metadata, and IEx output can no longer leak the key (the field stays readable directly).
- The argument-error messages in `Nous.Providers.HTTP.post/4` and `stream/4` interpolated `inspect(headers)`, which included `authorization` values. Header values are now redacted while keys are kept for debuggability.

### 3. O(entries × links) KB statistics (perf, high)

`gather_kb_statistics` in `KnowledgeBase.Workflows` called `outlinks/2` once per entry in two passes — each call a full links-table scan. It now uses the bulk `link_counts_by_source/1` store callback when exported (scoped to the listed entries via `Map.take`, since the bulk callback counts store-wide), keeping the per-entry loop as a fallback for custom backends that don't implement the optional callback.

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix test` — 1,992/1,992 pass (102 excluded, unchanged from baseline)
- End-to-end smoke run: KB stats output identical to the legacy per-entry path on a populated store; 100 scratch create/cleanup cycles with **zero** atom-table growth; concurrent scratches and two team SharedStates fully isolated; `"SECRET123"` absent from `inspect(model)` and both HTTP error messages while header keys remain visible
