### PR TITLE
perf: opt-in parallel tool calls, message fast path, KB downcase cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in parallel tool-call execution** — `parallel_tool_calls: true` on
+  `Nous.Agent.new/2` (default `false`). When a model response contains multiple
+  tool calls, approved executions fan out under `Nous.TaskSupervisor` while
+  everything order-sensitive stays sequential in call order: `pre_tool_use`
+  hooks and approval checks run before the fan-out, and `post_tool_use` hooks,
+  `on_tool_response` callbacks, behaviour `:after_tool`, and
+  `Context.merge_deps` apply after it, in original call order. Result messages
+  keep call order (providers require it). Per-tool timeouts remain
+  `ToolExecutor`'s job (no second outer timeout); a crashed task surfaces as a
+  per-call tool error instead of sinking the turn. Off by default because tools
+  may rely on sequential external side effects within one turn — note that
+  tools already cannot observe each other's context updates within a turn (the
+  run context is snapshotted before the tool loop).
+
 ### Changed
 
 - **Agent-runtime hot-path hardening (behavior-preserving)** (#62). Eliminates

--- a/bench/message_bench.exs
+++ b/bench/message_bench.exs
@@ -1,0 +1,42 @@
+# Message construction fast path (perf-analysis Phase 2).
+#
+# The role helpers (system/user/assistant/tool) construct %Message{} directly
+# via build/1; new!/1 keeps the full Ecto changeset path for external attrs.
+# Helpers used to delegate to new!/1, so "helper vs new!/1" is the
+# before/after comparison — re-run after touching Message construction to
+# guard the win.
+#
+#   Run: mix run bench/message_bench.exs   (benchee is a :dev dependency)
+
+alias Nous.Message
+
+user_content = "What is the weather in Paris today? " <> String.duplicate("context ", 15)
+
+tool_calls = [
+  %{"id" => "call_1", "name" => "search", "arguments" => %{"q" => "elixir", "k" => 5}}
+]
+
+tool_result = "result: " <> String.duplicate("x", 120)
+
+jobs = %{
+  "user helper (direct build)" => fn ->
+    Message.user(user_content)
+  end,
+  "user via new!/1 (changeset)" => fn ->
+    Message.new!(%{role: :user, content: user_content})
+  end,
+  "assistant+tool_calls helper (direct build)" => fn ->
+    Message.assistant("Searching", tool_calls: tool_calls)
+  end,
+  "assistant+tool_calls via new!/1 (changeset)" => fn ->
+    Message.new!(%{role: :assistant, content: "Searching", tool_calls: tool_calls})
+  end,
+  "tool helper (direct build)" => fn ->
+    Message.tool("call_1", tool_result, name: "search")
+  end,
+  "tool via new!/1 (changeset)" => fn ->
+    Message.new!(%{role: :tool, content: tool_result, tool_call_id: "call_1", name: "search"})
+  end
+}
+
+Benchee.run(jobs, warmup: 1, time: 3, memory_time: 1, print: [fast_warning: false])

--- a/bench/persistence_write_bench.exs
+++ b/bench/persistence_write_bench.exs
@@ -1,0 +1,77 @@
+# Write-owner contention measurement (perf-analysis Phase 4, finding #4).
+#
+# Both Nous.Persistence.ETS and Nous.Workflow.Checkpoint.ETS route writes
+# through a singleton TableOwner GenServer (reads go straight to ETS). This
+# measures the single-owner write ceiling under concurrency to decide whether
+# partitioning the owners (a la Nous.AgentRegistry) is warranted.
+#
+# Each job performs one BATCH of 10_000 writes split across C concurrent
+# writer tasks, so writes/sec = ips * 10_000. Compare C=1 vs C=8 vs C=64:
+# if batch time stays ~flat as C grows, the owner serializes but is not a
+# practical bottleneck unless real workloads approach that ceiling
+# (checkpoint/context saves are per agent response / workflow step — orders
+# of magnitude below it).
+#
+#   Run: mix run bench/persistence_write_bench.exs   (benchee is a :dev dep)
+
+alias Nous.Persistence.ETS, as: Persistence
+alias Nous.Workflow.Checkpoint.ETS, as: Checkpoint
+
+writes = 10_000
+
+# ~2KB payload approximating a serialized context
+payload = %{
+  "messages" =>
+    for i <- 1..10 do
+      %{"role" => "user", "content" => "message #{i}: " <> String.duplicate("x", 150)}
+    end,
+  "deps" => %{"counter" => 42},
+  "iteration" => 7
+}
+
+persistence_batch = fn concurrency ->
+  per_task = div(writes, concurrency)
+
+  1..concurrency
+  |> Enum.map(fn worker ->
+    Task.async(fn ->
+      for i <- 1..per_task do
+        :ok = Persistence.save("bench_session_#{worker}", Map.put(payload, "seq", i))
+      end
+    end)
+  end)
+  |> Task.await_many(:infinity)
+end
+
+checkpoint_batch = fn concurrency ->
+  per_task = div(writes, concurrency)
+
+  1..concurrency
+  |> Enum.map(fn worker ->
+    Task.async(fn ->
+      for i <- 1..per_task do
+        :ok =
+          Checkpoint.save(%{
+            run_id: "bench_run_#{worker}",
+            workflow_id: "bench_wf",
+            data: Map.put(payload, "seq", i)
+          })
+      end
+    end)
+  end)
+  |> Task.await_many(:infinity)
+end
+
+Benchee.run(
+  %{
+    "persistence 10k writes, C=1" => fn -> persistence_batch.(1) end,
+    "persistence 10k writes, C=8" => fn -> persistence_batch.(8) end,
+    "persistence 10k writes, C=64" => fn -> persistence_batch.(64) end,
+    "checkpoint 10k writes, C=1" => fn -> checkpoint_batch.(1) end,
+    "checkpoint 10k writes, C=8" => fn -> checkpoint_batch.(8) end,
+    "checkpoint 10k writes, C=64" => fn -> checkpoint_batch.(64) end
+  },
+  warmup: 1,
+  time: 3,
+  print: [fast_warning: false]
+)

--- a/lib/nous/agent.ex
+++ b/lib/nous/agent.ex
@@ -48,7 +48,8 @@ defmodule Nous.Agent do
           end_strategy: :early | :exhaustive,
           enable_todos: boolean(),
           behaviour_module: module() | nil,
-          permissions: Nous.Permissions.Policy.t() | nil
+          permissions: Nous.Permissions.Policy.t() | nil,
+          parallel_tool_calls: boolean()
         }
 
   @enforce_keys [:model]
@@ -70,7 +71,8 @@ defmodule Nous.Agent do
     skills: [],
     end_strategy: :early,
     enable_todos: false,
-    permissions: nil
+    permissions: nil,
+    parallel_tool_calls: false
   ]
 
   @doc """
@@ -102,6 +104,15 @@ defmodule Nous.Agent do
     * `:permissions` - Optional `Nous.Permissions.Policy` enforced at runtime:
       blocked tools are removed from the model's tool list and approval-required
       tools must pass the approval handler (see `Nous.Permissions`)
+    * `:parallel_tool_calls` - Execute multiple tool calls from one model
+      response concurrently (default: `false`). Hooks, approval checks, and
+      post-processing (callbacks, `merge_deps`) stay sequential in call order;
+      only the tool executions themselves fan out, and result messages keep
+      the original call order. Tools already cannot observe each other's
+      context updates within a turn (the run context is snapshotted before the
+      tool loop), but external side effects (HTTP calls, DB writes) will
+      interleave — leave this off if your tools depend on sequential
+      side-effect ordering within a single response
 
   ## Examples
 
@@ -151,7 +162,8 @@ defmodule Nous.Agent do
         merge_skill_dirs(Keyword.get(opts, :skills, []), Keyword.get(opts, :skill_dirs, [])),
       end_strategy: Keyword.get(opts, :end_strategy, :early),
       behaviour_module: Keyword.get(opts, :behaviour_module),
-      permissions: Keyword.get(opts, :permissions)
+      permissions: Keyword.get(opts, :permissions),
+      parallel_tool_calls: Keyword.get(opts, :parallel_tool_calls, false)
     }
   end
 

--- a/lib/nous/agent_runner.ex
+++ b/lib/nous/agent_runner.ex
@@ -795,59 +795,13 @@ defmodule Nous.AgentRunner do
 
         # Execute all real tool calls and collect results
         {tool_results, ctx} =
-          Enum.reduce(real_calls, {[], ctx}, fn call, {results, acc_ctx} ->
-            call_name = get_tool_field(call, :name)
-            call_id = get_tool_field(call, :id)
-            call_arguments = get_tool_field(call, :arguments)
-
-            # Execute callback before tool
-            Callbacks.execute(acc_ctx, :on_tool_call, %{
-              id: call_id,
-              name: call_name,
-              arguments: call_arguments
-            })
-
-            cleaned_name = clean_tool_name(call_name)
-
-            # Short-circuit on tool_call whose arguments JSON failed to parse.
-            # The provider marshalling tagged it with "_invalid_arguments" so
-            # we surface a clean tool-error result and let the LLM retry —
-            # rather than invoking the tool with bogus/empty args.
-            invalid_args =
-              Map.get(call, "_invalid_arguments") || Map.get(call, :_invalid_arguments)
-
-            if is_binary(invalid_args) do
-              Logger.warning(
-                "Tool '#{cleaned_name}' called with malformed arguments JSON: #{invalid_args}"
-              )
-
-              result_msg =
-                Message.tool(
-                  call_id,
-                  "Error: tool arguments were not valid JSON. Please retry with a JSON object.",
-                  name: cleaned_name
-                )
-
-              {[result_msg | results], acc_ctx}
-            else
-              run_tool_with_hooks(
-                call,
-                call_id,
-                call_name,
-                cleaned_name,
-                call_arguments,
-                tools,
-                run_ctx,
-                behaviour,
-                agent,
-                acc_ctx,
-                results
-              )
-            end
-          end)
+          if agent.parallel_tool_calls and length(real_calls) > 1 do
+            run_tool_calls_parallel(real_calls, tools, run_ctx, behaviour, agent, ctx)
+          else
+            run_tool_calls_sequential(real_calls, tools, run_ctx, behaviour, agent, ctx)
+          end
 
         # Add tool result messages
-        tool_results = Enum.reverse(tool_results)
         ctx = Context.add_messages(ctx, tool_results)
 
         # Record tool calls
@@ -856,6 +810,218 @@ defmodule Nous.AgentRunner do
         end)
       end
     end
+  end
+
+  # Sequential tool-call execution (the default): each call runs its full
+  # pre/execute/post pipeline before the next call starts, so call N+1's hooks
+  # and approval checks observe call N's context effects.
+  defp run_tool_calls_sequential(real_calls, tools, run_ctx, behaviour, agent, ctx) do
+    {results, ctx} =
+      Enum.reduce(real_calls, {[], ctx}, fn call, {results, acc_ctx} ->
+        call_name = get_tool_field(call, :name)
+        call_id = get_tool_field(call, :id)
+        call_arguments = get_tool_field(call, :arguments)
+
+        # Execute callback before tool
+        Callbacks.execute(acc_ctx, :on_tool_call, %{
+          id: call_id,
+          name: call_name,
+          arguments: call_arguments
+        })
+
+        cleaned_name = clean_tool_name(call_name)
+
+        # Short-circuit on tool_call whose arguments JSON failed to parse.
+        # The provider marshalling tagged it with "_invalid_arguments" so
+        # we surface a clean tool-error result and let the LLM retry —
+        # rather than invoking the tool with bogus/empty args.
+        invalid_args = invalid_arguments(call)
+
+        if is_binary(invalid_args) do
+          result_msg = invalid_arguments_result(call_id, cleaned_name, invalid_args)
+          {[result_msg | results], acc_ctx}
+        else
+          run_tool_with_hooks(
+            call,
+            call_id,
+            call_name,
+            cleaned_name,
+            call_arguments,
+            tools,
+            run_ctx,
+            behaviour,
+            agent,
+            acc_ctx,
+            results
+          )
+        end
+      end)
+
+    {Enum.reverse(results), ctx}
+  end
+
+  # Parallel tool-call execution (agent.parallel_tool_calls). Three stages keep
+  # hook/approval/post-processing semantics sequential while only the approved
+  # executions fan out:
+  #   (a) pre-stage, in call order: on_tool_call callback, invalid-args
+  #       short-circuit, pre_tool_use hook, approval check
+  #   (b) approved calls execute concurrently under Nous.TaskSupervisor;
+  #       async_stream preserves input order. timeout: :infinity because
+  #       ToolExecutor already enforces per-tool timeouts internally — an
+  #       outer timeout would double-kill.
+  #   (c) post-stage, in original call order: post_tool_use hook,
+  #       on_tool_response callback, behaviour :after_tool, merge_deps
+  # Tools cannot observe each other's context updates within a turn in either
+  # mode (run_ctx is snapshotted before the loop); what changes vs sequential
+  # is only the interleaving of external side effects, and that pre-stage
+  # hooks see the pre-turn ctx rather than earlier calls' post-stage effects.
+  defp run_tool_calls_parallel(real_calls, tools, run_ctx, behaviour, agent, ctx) do
+    decisions = Enum.map(real_calls, &pre_stage_decision(&1, tools, agent, ctx))
+
+    approved = for {:execute, call} <- decisions, do: call
+
+    # Key executions by call id rather than relying on positional alignment
+    # between `approved` and the async_stream output — robust to reordering and
+    # to any future change in how the approved list is built. Provider tool_call
+    # ids are unique within one response (they must be, to match tool results),
+    # so a map keeps every result.
+    executed_by_id =
+      Nous.TaskSupervisor
+      |> Task.Supervisor.async_stream_nolink(
+        approved,
+        fn call -> {get_tool_field(call, :id), execute_single_tool(tools, call, run_ctx)} end,
+        timeout: :infinity,
+        # Carry the input (call) on crash exits so failures keep their
+        # attribution and surface as per-call tool errors.
+        zip_input_on_exit: true
+      )
+      |> Map.new(fn
+        {:ok, {call_id, {result_msg, context_updates}}} ->
+          {call_id, {result_msg, context_updates}}
+
+        {:exit, {call, reason}} ->
+          {get_tool_field(call, :id), crashed_tool_result(call, reason)}
+      end)
+
+    {results, ctx} =
+      Enum.reduce(decisions, {[], ctx}, fn
+        {:done, result_msg}, {results, acc_ctx} ->
+          {[result_msg | results], acc_ctx}
+
+        {:execute, call}, {results, acc_ctx} ->
+          {result_msg, context_updates} = Map.fetch!(executed_by_id, get_tool_field(call, :id))
+
+          {result_msg, acc_ctx} =
+            record_tool_result(call, result_msg, context_updates, behaviour, agent, acc_ctx)
+
+          {[result_msg | results], acc_ctx}
+      end)
+
+    {Enum.reverse(results), ctx}
+  end
+
+  # Pre-execution stage for one call in parallel mode, mirroring the
+  # run_tool_with_hooks branches up to (but not including) the execute step.
+  # Returns {:done, result_msg} for short-circuits (invalid args, hook denial,
+  # approval rejection) or {:execute, call} with final (possibly hook/approval
+  # edited) arguments.
+  defp pre_stage_decision(call, tools, agent, ctx) do
+    call_name = get_tool_field(call, :name)
+    call_id = get_tool_field(call, :id)
+    call_arguments = get_tool_field(call, :arguments)
+    cleaned_name = clean_tool_name(call_name)
+
+    Callbacks.execute(ctx, :on_tool_call, %{
+      id: call_id,
+      name: call_name,
+      arguments: call_arguments
+    })
+
+    invalid_args = invalid_arguments(call)
+
+    if is_binary(invalid_args) do
+      {:done, invalid_arguments_result(call_id, cleaned_name, invalid_args)}
+    else
+      hook_payload = %{
+        tool_name: cleaned_name,
+        tool_id: call_id,
+        arguments: call_arguments
+      }
+
+      case Hook.Runner.run(ctx.hook_registry, :pre_tool_use, hook_payload) do
+        :deny ->
+          Logger.info("Tool '#{cleaned_name}' denied by hook")
+          {:done, Message.tool(call_id, "Tool call was denied by hook.", name: cleaned_name)}
+
+        {:deny, reason} ->
+          Logger.info("Tool '#{cleaned_name}' denied by hook: #{reason}")
+
+          {:done,
+           Message.tool(call_id, "Tool call was denied by hook: #{reason}", name: cleaned_name)}
+
+        {:modify, %{arguments: new_args}} ->
+          modified_call = put_tool_field(call, :arguments, new_args)
+          approval_decision(modified_call, call_id, cleaned_name, tools, agent, ctx)
+
+        _ ->
+          approval_decision(call, call_id, cleaned_name, tools, agent, ctx)
+      end
+    end
+  end
+
+  defp approval_decision(call, call_id, cleaned_name, tools, agent, ctx) do
+    tool =
+      tools
+      |> Enum.find(fn t -> t.name == cleaned_name end)
+      |> enforce_policy_approval(agent.permissions)
+
+    case check_tool_approval(tool, call, ctx) do
+      :reject ->
+        Logger.info("Tool '#{cleaned_name}' rejected by approval handler")
+
+        {:done,
+         Message.tool(call_id, "Tool call was rejected by approval handler.", name: cleaned_name)}
+
+      {:edit, new_args} ->
+        Logger.debug("Tool '#{cleaned_name}' arguments edited by approval handler")
+        {:execute, put_tool_field(call, :arguments, new_args)}
+
+      :approve ->
+        {:execute, call}
+    end
+  end
+
+  # A task killed/crashed outside ToolExecutor's own error handling (which
+  # already converts in-tool crashes to {:error, _}) becomes a per-call tool
+  # error so one dead task never sinks the whole turn.
+  defp crashed_tool_result(call, reason) do
+    call_id = get_tool_field(call, :id)
+    cleaned_name = clean_tool_name(get_tool_field(call, :name))
+
+    Logger.error("Tool '#{cleaned_name}' task exited: #{inspect(reason)}")
+
+    result_msg =
+      Message.tool(
+        call_id,
+        "Tool execution failed: #{cleaned_name} - task exited: #{inspect(reason)}",
+        name: cleaned_name
+      )
+
+    {result_msg, %{}}
+  end
+
+  defp invalid_arguments(call) do
+    Map.get(call, "_invalid_arguments") || Map.get(call, :_invalid_arguments)
+  end
+
+  defp invalid_arguments_result(call_id, cleaned_name, invalid_args) do
+    Logger.warning("Tool '#{cleaned_name}' called with malformed arguments JSON: #{invalid_args}")
+
+    Message.tool(
+      call_id,
+      "Error: tool arguments were not valid JSON. Please retry with a JSON object.",
+      name: cleaned_name
+    )
   end
 
   # Run hooks + execute the tool call, returning the {results, acc_ctx} pair
@@ -994,11 +1160,19 @@ defmodule Nous.AgentRunner do
 
   # Execute a tool call and record its result, returning the result message and updated context
   defp execute_and_record_tool(tools, call, run_ctx, behaviour, agent, acc_ctx) do
+    {result_msg, context_updates} = execute_single_tool(tools, call, run_ctx)
+    record_tool_result(call, result_msg, context_updates, behaviour, agent, acc_ctx)
+  end
+
+  # Post-execution stage for one tool call: post_tool_use hook (may modify the
+  # result), on_tool_response callback, behaviour :after_tool, merge_deps.
+  # Shared by the sequential path (via execute_and_record_tool) and the
+  # parallel path, which applies it in original call order after the fan-out.
+  defp record_tool_result(call, result_msg, context_updates, behaviour, agent, acc_ctx) do
     call_name = get_tool_field(call, :name)
     call_id = get_tool_field(call, :id)
     call_arguments = get_tool_field(call, :arguments)
     cleaned_name = clean_tool_name(call_name)
-    {result_msg, context_updates} = execute_single_tool(tools, call, run_ctx)
 
     # Run post_tool_use hooks (can modify result)
     result_msg =

--- a/lib/nous/knowledge_base/entry.ex
+++ b/lib/nous/knowledge_base/entry.ex
@@ -16,6 +16,8 @@ defmodule Nous.KnowledgeBase.Entry do
           title: String.t(),
           slug: String.t(),
           content: String.t(),
+          title_down: String.t() | nil,
+          content_down: String.t() | nil,
           summary: String.t() | nil,
           entry_type: entry_type(),
           concepts: [String.t()],
@@ -35,6 +37,8 @@ defmodule Nous.KnowledgeBase.Entry do
     :title,
     :slug,
     :content,
+    :title_down,
+    :content_down,
     :summary,
     :embedding,
     :kb_id,
@@ -58,12 +62,15 @@ defmodule Nous.KnowledgeBase.Entry do
     now = DateTime.utc_now()
     id = Map.get(attrs, :id) || generate_id()
     title = Map.fetch!(attrs, :title)
+    content = Map.fetch!(attrs, :content)
 
     %Entry{
       id: id,
       title: title,
       slug: Map.get(attrs, :slug) || slugify(title),
-      content: Map.fetch!(attrs, :content),
+      content: content,
+      title_down: String.downcase(title),
+      content_down: String.downcase(content),
       summary: Map.get(attrs, :summary),
       entry_type: Map.get(attrs, :entry_type, :article),
       concepts: Map.get(attrs, :concepts, []),
@@ -76,6 +83,20 @@ defmodule Nous.KnowledgeBase.Entry do
       created_at: Map.get(attrs, :created_at, now),
       updated_at: Map.get(attrs, :updated_at, now),
       last_verified_at: Map.get(attrs, :last_verified_at)
+    }
+  end
+
+  @doc """
+  Recomputes the cached downcased search fields from `title`/`content`.
+
+  Call after any mutation of `title` or `content` (e.g. store `update_entry`)
+  so search never scores against a stale cache.
+  """
+  def with_downcase_cache(%Entry{} = entry) do
+    %{
+      entry
+      | title_down: String.downcase(entry.title),
+        content_down: String.downcase(entry.content)
     }
   end
 

--- a/lib/nous/knowledge_base/store/ets.ex
+++ b/lib/nous/knowledge_base/store/ets.ex
@@ -154,6 +154,14 @@ defmodule Nous.KnowledgeBase.Store.ETS do
       {:ok, entry} ->
         now = DateTime.utc_now()
         updated = struct(entry, Map.put(updates, :updated_at, now))
+
+        updated =
+          if is_map_key(updates, :title) or is_map_key(updates, :content) do
+            Entry.with_downcase_cache(updated)
+          else
+            updated
+          end
+
         :ets.insert(state.entries, {id, updated})
 
         if updated.slug != entry.slug do
@@ -214,9 +222,12 @@ defmodule Nous.KnowledgeBase.Store.ETS do
       state.entries
       |> scoped_records(kb_id)
       |> Enum.map(fn entry ->
-        # Score against both title and content for better matching
-        title_score = String.jaro_distance(query_down, String.downcase(entry.title))
-        content_score = String.jaro_distance(query_down, String.downcase(entry.content))
+        # Score against both title and content for better matching. The || arms
+        # cover entries persisted before the *_down cache fields existed.
+        title_down = entry.title_down || String.downcase(entry.title)
+        content_down = entry.content_down || String.downcase(entry.content)
+        title_score = String.jaro_distance(query_down, title_down)
+        content_score = String.jaro_distance(query_down, content_down)
         # Weight title matches higher
         score = max(title_score * 1.2, content_score) |> min(1.0)
         {entry, score}

--- a/lib/nous/message.ex
+++ b/lib/nous/message.ex
@@ -132,7 +132,7 @@ defmodule Nous.Message do
       %{role: :system, content: content}
       |> Map.merge(Map.new(opts))
 
-    new!(attrs)
+    build(attrs)
   end
 
   @doc """
@@ -157,7 +157,7 @@ defmodule Nous.Message do
       %{role: :user, content: content}
       |> Map.merge(Map.new(opts))
 
-    new!(attrs)
+    build(attrs)
   end
 
   def user(content_parts, opts) when is_list(content_parts) do
@@ -170,7 +170,7 @@ defmodule Nous.Message do
       metadata: Map.merge(Map.new(opts), %{content_parts: content_parts})
     }
 
-    new!(attrs)
+    build(attrs)
   end
 
   @doc """
@@ -193,7 +193,7 @@ defmodule Nous.Message do
       %{role: :assistant, content: content}
       |> Map.merge(Map.new(opts))
 
-    new!(attrs)
+    build(attrs)
   end
 
   @doc """
@@ -219,7 +219,7 @@ defmodule Nous.Message do
       %{role: :tool, content: content, tool_call_id: tool_call_id}
       |> Map.merge(Map.new(opts))
 
-    new!(attrs)
+    build(attrs)
   end
 
   # Encode an arbitrary tool return value as a JSON string for the LLM.
@@ -336,7 +336,7 @@ defmodule Nous.Message do
   """
   @spec has_tool_calls?(t()) :: boolean()
   def has_tool_calls?(%Message{tool_calls: tool_calls}) do
-    is_list(tool_calls) and length(tool_calls) > 0
+    is_list(tool_calls) and tool_calls != []
   end
 
   @doc """
@@ -542,6 +542,15 @@ defmodule Nous.Message do
   end
 
   # Private functions
+
+  # Direct-construction fast path for the role helpers (system/user/assistant/
+  # tool): they assemble known-valid shapes from internal code, so the cast +
+  # validate pipeline is skipped. Like cast/4, struct/2 ignores unknown keys,
+  # and created_at is stamped unconditionally (changeset/2 put_change does the
+  # same). External/untrusted attrs must keep going through new/1 or new!/1.
+  defp build(attrs) when is_map(attrs) do
+    %{struct(Message, attrs) | created_at: DateTime.utc_now()}
+  end
 
   defp changeset(message, attrs) do
     message

--- a/test/nous/agent_runner_parallel_tools_test.exs
+++ b/test/nous/agent_runner_parallel_tools_test.exs
@@ -1,0 +1,240 @@
+defmodule Nous.AgentRunnerParallelToolsTest do
+  # async: false — swaps the global :model_dispatcher app env.
+  use ExUnit.Case, async: false
+
+  alias Nous.{Agent, AgentRunner, Hook, Usage}
+
+  @moduletag :capture_log
+
+  # Dispatcher: first request returns the tool_calls staged in :persistent_term,
+  # second request returns a plain text response so the loop terminates.
+  defmodule Dispatcher do
+    @moduledoc false
+
+    def request(_model, _messages, _settings) do
+      calls = :persistent_term.get({__MODULE__, :calls}, 0)
+      :persistent_term.put({__MODULE__, :calls}, calls + 1)
+
+      response =
+        if calls == 0 do
+          Nous.Message.assistant("", tool_calls: :persistent_term.get({__MODULE__, :tool_calls}))
+        else
+          Nous.Message.assistant("all done")
+        end
+
+      usage = %Usage{input_tokens: 10, output_tokens: 5, total_tokens: 15, requests: 1}
+      {:ok, %{response | metadata: %{usage: usage}}}
+    end
+
+    def request_stream(_model, _messages, _settings), do: {:ok, []}
+    def count_tokens(_messages), do: 50
+  end
+
+  defmodule ParallelTools do
+    @moduledoc false
+
+    def slow_alpha(_ctx, _args) do
+      Process.sleep(400)
+      "alpha done"
+    end
+
+    def slow_beta(_ctx, _args) do
+      Process.sleep(400)
+      "beta done"
+    end
+
+    def echo(_ctx, args), do: "echo:" <> Map.get(args, "msg", "")
+
+    def boom(_ctx, _args), do: raise("boom")
+
+    def marker_slow(_ctx, _args) do
+      Process.sleep(250)
+      %{result: "slow", __update_context__: %{marker: "slow"}}
+    end
+
+    def marker_fast(_ctx, _args) do
+      %{result: "fast", __update_context__: %{marker: "fast"}}
+    end
+  end
+
+  setup do
+    Application.put_env(:nous, :model_dispatcher, Dispatcher)
+
+    on_exit(fn ->
+      Application.delete_env(:nous, :model_dispatcher)
+
+      for key <- [:calls, :tool_calls] do
+        try do
+          :persistent_term.erase({Dispatcher, key})
+        rescue
+          _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp stage_tool_calls(calls) do
+    :persistent_term.put({Dispatcher, :calls}, 0)
+    :persistent_term.put({Dispatcher, :tool_calls}, calls)
+  end
+
+  defp call(id, name, args \\ %{}) do
+    %{"id" => id, "name" => name, "arguments" => args}
+  end
+
+  defp tool_messages(result) do
+    Enum.filter(result.all_messages, &(&1.role == :tool))
+  end
+
+  describe "parallel_tool_calls: true" do
+    test "tool result messages keep the original call order" do
+      # slow first, fast second — completion order is the reverse of call order
+      stage_tool_calls([call("call_1", "slow_alpha"), call("call_2", "echo", %{"msg" => "hi"})])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.slow_alpha/2, &ParallelTools.echo/2],
+          parallel_tool_calls: true
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "go")
+
+      assert [%{tool_call_id: "call_1", content: "alpha done"}, %{tool_call_id: "call_2"} = echo] =
+               tool_messages(result)
+
+      assert echo.content =~ "echo:hi"
+    end
+
+    test "wall clock is ~max of tool durations, not the sum" do
+      stage_tool_calls([call("call_1", "slow_alpha"), call("call_2", "slow_beta")])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.slow_alpha/2, &ParallelTools.slow_beta/2],
+          parallel_tool_calls: true
+        )
+
+      started = System.monotonic_time(:millisecond)
+      {:ok, result} = AgentRunner.run(agent, "go")
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      assert [%{content: "alpha done"}, %{content: "beta done"}] = tool_messages(result)
+      # Two 400ms tools run concurrently: wall clock is ~max (400ms), not sum
+      # (800ms). Two-sided so a regression in EITHER direction fails — the lower
+      # bound catches "sleeps bypassed / tools not actually run", the upper
+      # bound catches "fell back to sequential". Generous margins for CI.
+      assert elapsed >= 400, "expected the 400ms tools to actually run, got #{elapsed}ms"
+      assert elapsed < 700, "expected ~400ms (max), got #{elapsed}ms (sum would be >= 800ms)"
+    end
+
+    test "merge_deps applies in call order, not completion order" do
+      # Both tools write deps.marker; the second call (fast) completes first,
+      # but the post-stage runs in call order, so its value must win.
+      stage_tool_calls([call("call_1", "marker_slow"), call("call_2", "marker_fast")])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.marker_slow/2, &ParallelTools.marker_fast/2],
+          parallel_tool_calls: true
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "go")
+
+      assert result.deps.marker == "fast"
+    end
+
+    test "pre/post hooks fire per call; denied and approved calls mix" do
+      test_pid = self()
+
+      hooks = [
+        Hook.new(:pre_tool_use,
+          handler: fn _event, payload ->
+            if payload.tool_name == "boom", do: {:deny, "not allowed"}, else: :allow
+          end
+        ),
+        Hook.new(:post_tool_use,
+          handler: fn _event, payload ->
+            send(test_pid, {:post_tool, payload.tool_name})
+            :allow
+          end
+        )
+      ]
+
+      stage_tool_calls([call("call_1", "boom"), call("call_2", "echo", %{"msg" => "ok"})])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.boom/2, &ParallelTools.echo/2],
+          parallel_tool_calls: true,
+          hooks: hooks
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "go")
+
+      assert [denied, allowed] = tool_messages(result)
+      assert denied.tool_call_id == "call_1"
+      assert denied.content =~ "denied by hook: not allowed"
+      assert allowed.content =~ "echo:ok"
+
+      # post_tool_use runs only for executed calls (same as sequential mode)
+      assert_received {:post_tool, "echo"}
+      refute_received {:post_tool, "boom"}
+    end
+
+    test "one tool raising does not sink the turn" do
+      stage_tool_calls([call("call_1", "boom"), call("call_2", "echo", %{"msg" => "alive"})])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.boom/2, &ParallelTools.echo/2],
+          parallel_tool_calls: true
+        )
+
+      {:ok, result} = AgentRunner.run(agent, "go")
+
+      assert [failed, ok] = tool_messages(result)
+      assert failed.tool_call_id == "call_1"
+      assert failed.content =~ "Tool execution failed"
+      assert ok.content =~ "echo:alive"
+    end
+  end
+
+  describe "parallel_tool_calls: false (default)" do
+    test "multiple tool calls run sequentially with identical result shape" do
+      stage_tool_calls([call("call_1", "slow_alpha"), call("call_2", "echo", %{"msg" => "hi"})])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.slow_alpha/2, &ParallelTools.echo/2]
+        )
+
+      refute agent.parallel_tool_calls
+
+      {:ok, result} = AgentRunner.run(agent, "go")
+
+      assert [%{tool_call_id: "call_1", content: "alpha done"}, %{tool_call_id: "call_2"}] =
+               tool_messages(result)
+    end
+
+    test "two slow tools take the sum of their durations" do
+      stage_tool_calls([call("call_1", "slow_alpha"), call("call_2", "slow_beta")])
+
+      agent =
+        Agent.new("openai:test-model",
+          tools: [&ParallelTools.slow_alpha/2, &ParallelTools.slow_beta/2]
+        )
+
+      started = System.monotonic_time(:millisecond)
+      {:ok, _result} = AgentRunner.run(agent, "go")
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      # Two 400ms tools run one after the other: sum (>= 800ms). Upper bound
+      # catches a pathological regression (e.g. a tool running more than once)
+      # short of ExUnit's 60s timeout.
+      assert elapsed >= 800
+      assert elapsed < 2000, "expected ~800ms (sum), got #{elapsed}ms"
+    end
+  end
+end

--- a/test/nous/messages_test.exs
+++ b/test/nous/messages_test.exs
@@ -339,4 +339,113 @@ defmodule Nous.MessagesTest do
       assert tool_call["name"] == "get_data"
     end
   end
+
+  describe "role helper equivalence with the changeset path" do
+    # The role helpers construct %Message{} directly (build/1 fast path, no
+    # cast/validate); these tests pin their output to what Message.new!/1
+    # (changeset path) produces for the same attrs, so the two paths cannot
+    # drift apart field-for-field.
+
+    test "system/2 matches new!/1" do
+      assert_equivalent(
+        Message.system("Be helpful"),
+        Message.new!(%{role: :system, content: "Be helpful"})
+      )
+
+      assert_equivalent(
+        Message.system("Be helpful", metadata: %{source: :config}),
+        Message.new!(%{role: :system, content: "Be helpful", metadata: %{source: :config}})
+      )
+    end
+
+    test "user/2 with binary content matches new!/1" do
+      assert_equivalent(
+        Message.user("Hello!"),
+        Message.new!(%{role: :user, content: "Hello!"})
+      )
+
+      assert_equivalent(
+        Message.user("Hello!", metadata: %{trace_id: "t1"}),
+        Message.new!(%{role: :user, content: "Hello!", metadata: %{trace_id: "t1"}})
+      )
+    end
+
+    test "user/2 with content parts matches new!/1" do
+      alias Nous.Message.ContentPart
+
+      parts = [
+        ContentPart.text("What's in this image?"),
+        ContentPart.image_url("https://example.com/image.png")
+      ]
+
+      assert_equivalent(
+        Message.user(parts),
+        Message.new!(%{
+          role: :user,
+          content: ContentPart.to_text(parts),
+          metadata: %{content_parts: parts}
+        })
+      )
+    end
+
+    test "assistant/2 matches new!/1, including nil content and tool_calls" do
+      assert_equivalent(
+        Message.assistant("Hi there"),
+        Message.new!(%{role: :assistant, content: "Hi there"})
+      )
+
+      # nil content is allowed for assistant (streaming populates it later)
+      assert_equivalent(
+        Message.assistant(nil),
+        Message.new!(%{role: :assistant, content: nil})
+      )
+
+      tool_calls = [%{"id" => "call_1", "name" => "search", "arguments" => %{"q" => "elixir"}}]
+
+      assert_equivalent(
+        Message.assistant("Searching", tool_calls: tool_calls),
+        Message.new!(%{role: :assistant, content: "Searching", tool_calls: tool_calls})
+      )
+    end
+
+    test "tool/3 matches new!/1, including name and encoded map results" do
+      assert_equivalent(
+        Message.tool("call_123", "raw result"),
+        Message.new!(%{role: :tool, content: "raw result", tool_call_id: "call_123"})
+      )
+
+      assert_equivalent(
+        Message.tool("call_123", "raw result", name: "search"),
+        Message.new!(%{
+          role: :tool,
+          content: "raw result",
+          tool_call_id: "call_123",
+          name: "search"
+        })
+      )
+
+      assert_equivalent(
+        Message.tool("call_123", %{status: "success"}),
+        Message.new!(%{
+          role: :tool,
+          content: ~s({"status":"success"}),
+          tool_call_id: "call_123"
+        })
+      )
+    end
+
+    test "unknown opts keys are dropped by both paths" do
+      assert_equivalent(
+        Message.system("x", frobnicate: 1),
+        Message.new!(%{role: :system, content: "x", frobnicate: 1})
+      )
+    end
+  end
+
+  # Compare all fields except created_at (both paths stamp their own utc_now).
+  defp assert_equivalent(%Message{} = fast, %Message{} = via_changeset) do
+    assert %DateTime{} = fast.created_at
+    assert %DateTime{} = via_changeset.created_at
+    assert %{fast | created_at: nil} == %{via_changeset | created_at: nil}
+  end
 end


### PR DESCRIPTION
Description

Remaining performance gaps surfaced by the `/phx:perf` analysis (hot-path + OTP
tracks), ordered by impact/effort. All changes preserve observable behavior;
the one semantic addition (parallel tool calls) is opt-in and default-off.

## Phase 1 — quick wins
- **KB downcase cache**: `KnowledgeBase.Entry` gains `title_down`/`content_down`
  fields, set in `new/1` and recomputed by `Store.ETS.update_entry/3` when
  title/content change. `search_entries/3` scores against them with a nil-safe
  fallback (`entry.title_down || String.downcase(...)`), so entries persisted
  before this change still work. Stops re-downcasing every entry on every query.
- **Idiom**: `Message.has_tool_calls?/1` uses `tool_calls != []` instead of
  `length(tool_calls) > 0`.

## Phase 2 — Message internal fast path
- Private `build/1` constructs `%Message{}` directly (`struct/2`, no changeset).
  The role helpers (`system`/`user`/`assistant`/`tool`) route through it;
  `new/1` and `new!/1` keep the full changeset path for external/untrusted
  attrs. Matches the project convention (changesets for external data, direct
  construction for internal).
- Benchee (`bench/message_bench.exs`): **3.75–4.72× faster, 3.1–4.6× less
  memory**. Field-for-field equivalence with the changeset path is pinned by 6
  new tests.

## Phase 3 — opt-in parallel multi-tool-call execution
- New agent option `parallel_tool_calls` (default `false`). When multiple tool
  calls arrive in one model response, approved executions fan out under
  `Nous.TaskSupervisor` while everything order-sensitive stays sequential:
  `pre_tool_use` hooks and approval checks run before the fan-out;
  `post_tool_use`, `on_tool_response`, behaviour `:after_tool`, and
  `Context.merge_deps` run after it, in original call order.
- The sequential path is extracted verbatim (option off = zero behavior change).
  The parallel path keys executions by call id (robust to reordering) and uses
  `timeout: :infinity` because `ToolExecutor` already enforces per-tool timeouts
  — an outer timeout would double-kill. A crashed task surfaces as a per-call
  tool error instead of sinking the turn. Result messages keep call order
  (providers require it).
- Off by default because tools may rely on sequential external side effects
  within one turn. (Tools already can't observe each other's context updates
  within a turn — the run context is snapshotted before the tool loop.)
- 7 new tests: call-order preservation, wall-clock ≈ max-not-sum, merge_deps
  ordering, hook deny+approve mix, one tool raising doesn't sink the turn,
  sequential default unchanged.

## Phase 4 — write-owner contention (measured, not changed)
- `bench/persistence_write_bench.exs` measures the singleton table owners under
  concurrency. Ceiling ~400–570k writes/sec and throughput *improves* under
  concurrency (no degradation at 64 writers) — orders of magnitude above real
  write rates. Closed as not a bottleneck; no partitioning added.

## Verification
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict` clean.
- Full suite: **2005 passed**.
- Reviewed by parallel elixir/testing/requirements agents (PASS WITH WARNINGS);
  both actionable warnings — two-sided timing assertions and keyed-by-id
  post-stage — fixed before commit.